### PR TITLE
fix: avoid duplicate omni subagent transcripts

### DIFF
--- a/src/examples/omni_assistant_subagents/subagents/speaker/agent.py
+++ b/src/examples/omni_assistant_subagents/subagents/speaker/agent.py
@@ -219,4 +219,10 @@ class SpeakerOmniAgent(PipelineWorker):
             uploaded_attachment_available=uploaded_attachment_available,
             audio_response_instruction=audio_response_instruction,
         )
-        super().__init__(Pipeline([omni]), name=name or self.AGENT_NAME, active=True, bridged=())
+        super().__init__(
+            Pipeline([omni]),
+            name=name or self.AGENT_NAME,
+            active=True,
+            bridged=(),
+            enable_rtvi=False,
+        )


### PR DESCRIPTION
## Summary

  Fixes duplicated user transcripts in the omni assistant subagents example.

  The `speaker_omni` worker is a helper pipeline worker and should not emit RTVI events directly. With Pipecat 1.3.0, `PipelineWorker` enables RTVI by default, so both `speaker_omni` and `omni_transport` were emitting user
  transcript events. The UI then received duplicate final transcript events and rendered them as concatenated text.

  ## Change

  - Disable RTVI for `SpeakerOmniAgent` with `enable_rtvi=False`.
  - Keep RTVI enabled on `OmniTransportAgent`, which is the browser-facing worker.

  ## Testing

  ```bash
  uv run --project . --group dev ruff format --check .
  uv run --project . --group dev ruff check .

  Both checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the speaker assistant setup to explicitly disable RTVI during initialization, aligning its runtime behavior with the current configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->