### PR TITLE
Fix DGX Spark default Parakeet RNNT model deployment

### DIFF
--- a/docker/docker-compose.parakeet-asr.yaml
+++ b/docker/docker-compose.parakeet-asr.yaml
@@ -4,7 +4,7 @@ x-parakeet-asr-env: &parakeet-asr-env
   NGC_API_KEY: ${NVIDIA_API_KEY}
   NIM_HTTP_API_PORT: "9001"
   NIM_GRPC_API_PORT: "50052"
-  NIM_TAGS_SELECTOR: mode=str,vad=silero
+  NIM_TAGS_SELECTOR: mode=str,vad=silero,type=default
 
 x-parakeet-asr: &parakeet-asr-base
   user: "0:0"


### PR DESCRIPTION
DGX Spark deployment for Parakeet RNNT model was using wrong NIM profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default ASR deployment settings to select the intended model variant more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->