### PR TITLE
Fix multilingual language catalog fallbacks

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -167,6 +167,7 @@ export interface DeploymentOption {
   label: string;
   slots: string[];
   capabilities?: string[];
+  default_session_language?: string;
   defaults?: DeploymentDefaults;
 }
 

--- a/client/src/components/VoiceSettings.tsx
+++ b/client/src/components/VoiceSettings.tsx
@@ -71,11 +71,12 @@ export function VoiceSettings() {
 
   useEffect(() => {
     if (!sessionLanguagesEnabled) return;
+    if (!ttsConfig) return;
     const languages = ttsConfig?.languages ?? [];
     if (selectedSessionLanguage && !languages.includes(selectedSessionLanguage)) {
       setSelectedSessionLanguage(SESSION_LANGUAGE_AUTO);
     }
-  }, [sessionLanguagesEnabled, selectedSessionLanguage, ttsConfig?.languages, setSelectedSessionLanguage]);
+  }, [sessionLanguagesEnabled, selectedSessionLanguage, ttsConfig, setSelectedSessionLanguage]);
 
   const defaultVoice = useMemo(() => {
     if (!ttsConfig?.voices?.length) return null;

--- a/client/src/context/AppContext.tsx
+++ b/client/src/context/AppContext.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   type ReactNode,
 } from "react";
 import { useDeployment, useDefaultLLMs, useDefaultPrompts, useDefaultASR, useDefaultTTS, useDefaultTools, type DeploymentOption, type LLMService, type Prompt, type SimpleService, type Tool, type TransportOption, type TransportType } from "../api";
@@ -25,7 +26,6 @@ const SELECTED_EXAMPLE_STORAGE = "nvidia-voice-agent-selected-example";
 
 /** Empty string = auto-detect language on each turn. */
 export const SESSION_LANGUAGE_AUTO = "";
-export const SESSION_LANGUAGE_DEFAULT = "es-US";
 
 type ManagedService = {
   id: string;
@@ -309,7 +309,16 @@ export function AppProvider({ children }: Readonly<{ children: ReactNode }>) {
 
   const [selectedVoiceId, setSelectedVoiceId] = useState("");
 
-  const [selectedSessionLanguage, setSelectedSessionLanguage] = useState(SESSION_LANGUAGE_DEFAULT);
+  const [selectedSessionLanguage, setSelectedSessionLanguage] = useState(SESSION_LANGUAGE_AUTO);
+  const defaultSessionLanguageExampleKey = useRef("");
+  const selectedExampleDefaultSessionLanguage = selectedExample?.default_session_language ?? SESSION_LANGUAGE_AUTO;
+
+  useEffect(() => {
+    const selectedExampleKey = selectedExample?.key ?? "";
+    if (!selectedExampleKey || defaultSessionLanguageExampleKey.current === selectedExampleKey) return;
+    defaultSessionLanguageExampleKey.current = selectedExampleKey;
+    setSelectedSessionLanguage(selectedExampleDefaultSessionLanguage || SESSION_LANGUAGE_AUTO);
+  }, [selectedExample?.key, selectedExampleDefaultSessionLanguage]);
 
   // --- TTS state ---
   const { data: defaultTTS = [], isLoading: ttsLoading } = useDefaultTTS(serviceCatalogKey);

--- a/client/src/context/AppContext.tsx
+++ b/client/src/context/AppContext.tsx
@@ -25,6 +25,7 @@ const SELECTED_EXAMPLE_STORAGE = "nvidia-voice-agent-selected-example";
 
 /** Empty string = auto-detect language on each turn. */
 export const SESSION_LANGUAGE_AUTO = "";
+export const SESSION_LANGUAGE_DEFAULT = "es-US";
 
 type ManagedService = {
   id: string;
@@ -308,7 +309,7 @@ export function AppProvider({ children }: Readonly<{ children: ReactNode }>) {
 
   const [selectedVoiceId, setSelectedVoiceId] = useState("");
 
-  const [selectedSessionLanguage, setSelectedSessionLanguage] = useState(SESSION_LANGUAGE_AUTO);
+  const [selectedSessionLanguage, setSelectedSessionLanguage] = useState(SESSION_LANGUAGE_DEFAULT);
 
   // --- TTS state ---
   const { data: defaultTTS = [], isLoading: ttsLoading } = useDefaultTTS(serviceCatalogKey);

--- a/docker/docker-compose.parakeet-asr.yaml
+++ b/docker/docker-compose.parakeet-asr.yaml
@@ -4,7 +4,7 @@ x-parakeet-asr-env: &parakeet-asr-env
   NGC_API_KEY: ${NVIDIA_API_KEY}
   NIM_HTTP_API_PORT: "9001"
   NIM_GRPC_API_PORT: "50052"
-  NIM_TAGS_SELECTOR: mode=str,vad=silero
+  NIM_TAGS_SELECTOR: mode=str,vad=silero,type=default
 
 x-parakeet-asr: &parakeet-asr-base
   user: "0:0"

--- a/docker/docker-compose.parakeet-asr.yaml
+++ b/docker/docker-compose.parakeet-asr.yaml
@@ -4,7 +4,6 @@ x-parakeet-asr-env: &parakeet-asr-env
   NGC_API_KEY: ${NVIDIA_API_KEY}
   NIM_HTTP_API_PORT: "9001"
   NIM_GRPC_API_PORT: "50052"
-  NIM_TAGS_SELECTOR: mode=str,vad=silero,type=default
 
 x-parakeet-asr: &parakeet-asr-base
   user: "0:0"
@@ -40,12 +39,18 @@ x-parakeet-asr: &parakeet-asr-base
 services:
   parakeet-ctc-asr:
     <<: *parakeet-asr-base
+    environment:
+      <<: *parakeet-asr-env
+      NIM_TAGS_SELECTOR: mode=str,vad=silero
     profiles:
       - parakeet-ctc-asr
     image: nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0
 
   parakeet-rnnt-asr:
     <<: *parakeet-asr-base
+    environment:
+      <<: *parakeet-asr-env
+      NIM_TAGS_SELECTOR: mode=str,vad=silero,type=default
     profiles:
       - parakeet-rnnt-asr
       - multilingual-assistant/workstation

--- a/examples_registry.yaml
+++ b/examples_registry.yaml
@@ -35,6 +35,7 @@ examples:
     label: Multilingual Assistant
     slots: [llm, asr, tts]
     capabilities: [session_languages]
+    default_session_language: es-US
     agent_prompt_keys:
       - fixed_session_language_addon
       - auto_detect_language_addon

--- a/examples_registry.yaml
+++ b/examples_registry.yaml
@@ -35,11 +35,11 @@ examples:
     label: Multilingual Assistant
     slots: [llm, asr, tts]
     capabilities: [session_languages]
-    default_session_language: es-US
     agent_prompt_keys:
       - fixed_session_language_addon
       - auto_detect_language_addon
     defaults:
+      default_session_language: es-US
       prompt: [multilingual_voice_assistant]
       llm: [nemotron-super]
       asr: [parakeet-rnnt]

--- a/src/examples/multilingual/multilingual_processor.py
+++ b/src/examples/multilingual/multilingual_processor.py
@@ -237,6 +237,7 @@ def get_lang_codes(
         ).get("languages", [])
         if languages:
             return ", ".join(languages)
+        return ""
 
     tts_config = config_store.get("tts", {})
     languages = tts_config.get("languages", []) if isinstance(tts_config, dict) else []

--- a/src/examples/shared/prewarm.py
+++ b/src/examples/shared/prewarm.py
@@ -89,6 +89,9 @@ def _normalize_catalog_code(code: str) -> str:
     return normalize_lang_code(code).lower()
 
 
+_EMPTY_ASR_LANGUAGE_FALLBACK = "es-US"
+
+
 def intersect_session_languages(asr_config: dict, tts_config: dict) -> list[str]:
     """Languages supported by both ASR and TTS (LLM prompt uses the TTS catalog)."""
     tts_langs = _tts_language_set(tts_config)
@@ -97,9 +100,9 @@ def intersect_session_languages(asr_config: dict, tts_config: dict) -> list[str]
 
     asr_langs = {_normalize_catalog_code(code) for code in (asr_config or {}).get("languages", []) if code}
     if not asr_langs:
-        result = tts_langs
-    else:
-        result = asr_langs & tts_langs
+        asr_langs = {_normalize_catalog_code(_EMPTY_ASR_LANGUAGE_FALLBACK)}
+
+    result = asr_langs & tts_langs
 
     return sorted(
         (normalize_lang_code(code) for code in result),
@@ -176,6 +179,13 @@ def prewarm_tts(server: str, voice_id: str) -> dict:
 _ASR_PREWARM_RPC_TIMEOUT_SECS = float(os.getenv("ASR_PREWARM_RPC_TIMEOUT_SECS", "5"))
 
 
+def _fetch_asr_config(svc: NvidiaSTTService):
+    return svc._asr_service.stub.GetRivaSpeechRecognitionConfig(
+        riva_asr_pb2.RivaSpeechRecognitionConfigRequest(),
+        timeout=_ASR_PREWARM_RPC_TIMEOUT_SECS,
+    )
+
+
 def prewarm_asr(server: str, model: str = "", function_id: str = "") -> dict:
     """Pre-warm an ASR server and cache its supported language codes.
 
@@ -203,12 +213,10 @@ def prewarm_asr(server: str, model: str = "", function_id: str = "") -> dict:
             }
         svc = NvidiaSTTService(**asr_kwargs)
         svc._initialize_client()
-        raw_config = svc._asr_service.stub.GetRivaSpeechRecognitionConfig(
-            riva_asr_pb2.RivaSpeechRecognitionConfigRequest(model_name=model or ""),
-            timeout=_ASR_PREWARM_RPC_TIMEOUT_SECS,
-        )
+        raw_config = _fetch_asr_config(svc)
         asr_config = _parse_asr_config(raw_config)
         asr_config["server"] = server
+        asr_config["config_model"] = ""
         config_store.set(cache_key, asr_config)
         logger.info(f"ASR pre-warmed ({server}) — {len(asr_config['languages']) or 'all'} languages from model config")
         return asr_config

--- a/src/examples_registry.py
+++ b/src/examples_registry.py
@@ -22,9 +22,8 @@ class ExampleEntry(TypedDict):
     label: str
     slots: list[str]
     capabilities: list[str]
-    default_session_language: str
     agent_prompt_keys: list[str]
-    defaults: dict[str, list[str]]
+    defaults: dict[str, list[str] | str]
     bot: str
 
 
@@ -58,7 +57,6 @@ class PromptDefault(TypedDict, total=False):
 
 _SRC_ROOT = Path(__file__).resolve().parent
 _REGISTRY_PATH = _SRC_ROOT.parent / "examples_registry.yaml"
-_DEFAULT_SESSION_LANGUAGE_KEY = "default_session_language"
 
 
 def _load_yaml_registry() -> dict:
@@ -296,7 +294,7 @@ def _resolve_service_defaults(example: EnrichedExample) -> dict[str, list[Servic
     return {
         category: [_resolve_service_default(example, category, service_id) for service_id in service_ids]
         for category, service_ids in example["defaults"].items()
-        if category != "prompt"
+        if category not in ("prompt", "default_session_language") and isinstance(service_ids, list)
     }
 
 
@@ -358,16 +356,12 @@ def _load_examples(data: dict) -> dict[str, ExampleEntry]:
             raise RuntimeError(f"Example {example_id!r} agent_prompt_keys must be a list of strings")
         if not isinstance(defaults, dict):
             raise RuntimeError(f"Example {example_id!r} defaults must be a mapping")
-        default_session_language_value = defaults.get(
-            _DEFAULT_SESSION_LANGUAGE_KEY,
-            entry.get(_DEFAULT_SESSION_LANGUAGE_KEY),
-        )
-        if default_session_language_value is not None and not isinstance(default_session_language_value, str):
-            raise RuntimeError(f"Example {example_id!r} defaults[{_DEFAULT_SESSION_LANGUAGE_KEY!r}] must be a string")
-        default_session_language = str(default_session_language_value or "").strip()
-        normalized_defaults: dict[str, list[str]] = {}
+        normalized_defaults: dict[str, list[str] | str] = {}
         for slot, service_ids in defaults.items():
-            if slot == _DEFAULT_SESSION_LANGUAGE_KEY:
+            if slot == "default_session_language":
+                if not isinstance(service_ids, str):
+                    raise RuntimeError(f"Example {example_id!r} defaults[{slot!r}] must be a string")
+                normalized_defaults[str(slot)] = service_ids.strip()
                 continue
             if not isinstance(service_ids, list) or not all(isinstance(service_id, str) for service_id in service_ids):
                 raise RuntimeError(f"Example {example_id!r} defaults[{slot!r}] must be a list of strings")
@@ -376,7 +370,6 @@ def _load_examples(data: dict) -> dict[str, ExampleEntry]:
             "label": label,
             "slots": list(slots),
             "capabilities": list(capabilities),
-            "default_session_language": default_session_language,
             "agent_prompt_keys": list(agent_prompt_keys),
             "defaults": normalized_defaults,
             "bot": bot_spec,
@@ -501,7 +494,7 @@ def metadata(example: EnrichedExample) -> dict:
         "label": example["label"],
         "slots": example["slots"],
         "capabilities": example["capabilities"],
-        "default_session_language": example.get("default_session_language", ""),
+        "default_session_language": str(example["defaults"].get("default_session_language") or ""),
         "defaults": defaults,
     }
 

--- a/src/examples_registry.py
+++ b/src/examples_registry.py
@@ -22,6 +22,7 @@ class ExampleEntry(TypedDict):
     label: str
     slots: list[str]
     capabilities: list[str]
+    default_session_language: str
     agent_prompt_keys: list[str]
     defaults: dict[str, list[str]]
     bot: str
@@ -344,6 +345,7 @@ def _load_examples(data: dict) -> dict[str, ExampleEntry]:
         bot_spec = str(entry.get("bot") or "").strip()
         slots = entry.get("slots", [])
         capabilities = entry.get("capabilities", [])
+        default_session_language = str(entry.get("default_session_language") or "").strip()
         agent_prompt_keys = entry.get("agent_prompt_keys", [])
         defaults = entry.get("defaults", {})
         if not label or not bot_spec:
@@ -365,6 +367,7 @@ def _load_examples(data: dict) -> dict[str, ExampleEntry]:
             "label": label,
             "slots": list(slots),
             "capabilities": list(capabilities),
+            "default_session_language": default_session_language,
             "agent_prompt_keys": list(agent_prompt_keys),
             "defaults": normalized_defaults,
             "bot": bot_spec,
@@ -489,6 +492,7 @@ def metadata(example: EnrichedExample) -> dict:
         "label": example["label"],
         "slots": example["slots"],
         "capabilities": example["capabilities"],
+        "default_session_language": example.get("default_session_language", ""),
         "defaults": defaults,
     }
 

--- a/src/examples_registry.py
+++ b/src/examples_registry.py
@@ -58,6 +58,7 @@ class PromptDefault(TypedDict, total=False):
 
 _SRC_ROOT = Path(__file__).resolve().parent
 _REGISTRY_PATH = _SRC_ROOT.parent / "examples_registry.yaml"
+_DEFAULT_SESSION_LANGUAGE_KEY = "default_session_language"
 
 
 def _load_yaml_registry() -> dict:
@@ -345,7 +346,6 @@ def _load_examples(data: dict) -> dict[str, ExampleEntry]:
         bot_spec = str(entry.get("bot") or "").strip()
         slots = entry.get("slots", [])
         capabilities = entry.get("capabilities", [])
-        default_session_language = str(entry.get("default_session_language") or "").strip()
         agent_prompt_keys = entry.get("agent_prompt_keys", [])
         defaults = entry.get("defaults", {})
         if not label or not bot_spec:
@@ -358,8 +358,17 @@ def _load_examples(data: dict) -> dict[str, ExampleEntry]:
             raise RuntimeError(f"Example {example_id!r} agent_prompt_keys must be a list of strings")
         if not isinstance(defaults, dict):
             raise RuntimeError(f"Example {example_id!r} defaults must be a mapping")
+        default_session_language_value = defaults.get(
+            _DEFAULT_SESSION_LANGUAGE_KEY,
+            entry.get(_DEFAULT_SESSION_LANGUAGE_KEY),
+        )
+        if default_session_language_value is not None and not isinstance(default_session_language_value, str):
+            raise RuntimeError(f"Example {example_id!r} defaults[{_DEFAULT_SESSION_LANGUAGE_KEY!r}] must be a string")
+        default_session_language = str(default_session_language_value or "").strip()
         normalized_defaults: dict[str, list[str]] = {}
         for slot, service_ids in defaults.items():
+            if slot == _DEFAULT_SESSION_LANGUAGE_KEY:
+                continue
             if not isinstance(service_ids, list) or not all(isinstance(service_id, str) for service_id in service_ids):
                 raise RuntimeError(f"Example {example_id!r} defaults[{slot!r}] must be a list of strings")
             normalized_defaults[str(slot)] = list(service_ids)

--- a/tests/test_service_catalog.py
+++ b/tests/test_service_catalog.py
@@ -155,6 +155,13 @@ llm:
             frozenset({"fixed_session_language_addon", "auto_detect_language_addon"}),
         )
 
+    def test_multilingual_default_session_language_is_registry_declared(self) -> None:
+        example = examples_registry._lookup_by_key("multilingual-assistant")
+
+        metadata = examples_registry.metadata(example)
+
+        self.assertEqual(metadata["default_session_language"], "es-US")
+
     def test_registry_defaults_promote_reachable_local_multilingual_asr(self) -> None:
         example = examples_registry._lookup_by_key("multilingual-assistant")
 

--- a/tests/test_session_languages.py
+++ b/tests/test_session_languages.py
@@ -8,6 +8,13 @@ import types
 import unittest
 from unittest.mock import patch
 
+
+class _FakeRivaSpeechRecognitionConfigRequest:
+    def __init__(self, **kwargs):
+        self.model_name = kwargs.get("model_name", "")
+        self.model_name_was_set = "model_name" in kwargs
+
+
 if "pipecat.services.nvidia.stt" not in sys.modules:
     pipecat = types.ModuleType("pipecat")
     services = types.ModuleType("pipecat.services")
@@ -29,12 +36,7 @@ if "riva.client.proto.riva_asr_pb2" not in sys.modules:
     proto = types.ModuleType("riva.client.proto")
     riva_asr_pb2 = types.ModuleType("riva.client.proto.riva_asr_pb2")
 
-    class RivaSpeechRecognitionConfigRequest:
-        def __init__(self, **kwargs):
-            self.model_name = kwargs.get("model_name", "")
-            self.model_name_was_set = "model_name" in kwargs
-
-    riva_asr_pb2.RivaSpeechRecognitionConfigRequest = RivaSpeechRecognitionConfigRequest
+    riva_asr_pb2.RivaSpeechRecognitionConfigRequest = _FakeRivaSpeechRecognitionConfigRequest
     sys.modules["riva"] = riva
     sys.modules["riva.client"] = client
     sys.modules["riva.client.proto"] = proto
@@ -99,6 +101,10 @@ class SessionLanguageCatalogTests(unittest.TestCase):
         _FakeNvidiaSTTService.last = None
         with (
             patch("examples.shared.prewarm.NvidiaSTTService", _FakeNvidiaSTTService),
+            patch(
+                "examples.shared.prewarm.riva_asr_pb2.RivaSpeechRecognitionConfigRequest",
+                _FakeRivaSpeechRecognitionConfigRequest,
+            ),
             patch("examples.shared.prewarm.config_store.get", return_value=None),
             patch("examples.shared.prewarm.config_store.set"),
         ):

--- a/tests/test_session_languages.py
+++ b/tests/test_session_languages.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# ruff: noqa: D100, D101, D102, D107
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+if "pipecat.services.nvidia.stt" not in sys.modules:
+    pipecat = types.ModuleType("pipecat")
+    services = types.ModuleType("pipecat.services")
+    nvidia = types.ModuleType("pipecat.services.nvidia")
+    stt = types.ModuleType("pipecat.services.nvidia.stt")
+    tts = types.ModuleType("pipecat.services.nvidia.tts")
+    stt.NvidiaSTTService = object
+    tts.NvidiaTTSService = object
+    tts.NvidiaTTSSettings = object
+    sys.modules["pipecat"] = pipecat
+    sys.modules["pipecat.services"] = services
+    sys.modules["pipecat.services.nvidia"] = nvidia
+    sys.modules["pipecat.services.nvidia.stt"] = stt
+    sys.modules["pipecat.services.nvidia.tts"] = tts
+
+if "riva.client.proto.riva_asr_pb2" not in sys.modules:
+    riva = types.ModuleType("riva")
+    client = types.ModuleType("riva.client")
+    proto = types.ModuleType("riva.client.proto")
+    riva_asr_pb2 = types.ModuleType("riva.client.proto.riva_asr_pb2")
+
+    class RivaSpeechRecognitionConfigRequest:
+        def __init__(self, **kwargs):
+            self.model_name = kwargs.get("model_name", "")
+            self.model_name_was_set = "model_name" in kwargs
+
+    riva_asr_pb2.RivaSpeechRecognitionConfigRequest = RivaSpeechRecognitionConfigRequest
+    sys.modules["riva"] = riva
+    sys.modules["riva.client"] = client
+    sys.modules["riva.client.proto"] = proto
+    sys.modules["riva.client.proto.riva_asr_pb2"] = riva_asr_pb2
+
+from examples.shared.prewarm import intersect_session_languages, prewarm_asr
+
+
+class _FakeModelConfig:
+    def __init__(self, language_code: str):
+        self.parameters = {"language_code": language_code}
+
+
+class _FakeRecognitionConfig:
+    def __init__(self, language_code: str):
+        self.model_config = [_FakeModelConfig(language_code)]
+
+
+class _FallbackASRStub:
+    def __init__(self):
+        self.requests: list[tuple[str, bool]] = []
+
+    def GetRivaSpeechRecognitionConfig(self, request, timeout: float):
+        self.requests.append((request.model_name, request.model_name_was_set))
+        return _FakeRecognitionConfig("en-US,fr-FR,multi")
+
+
+class _FakeNvidiaSTTService:
+    last: "_FakeNvidiaSTTService | None" = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._asr_service = types.SimpleNamespace(stub=_FallbackASRStub())
+        _FakeNvidiaSTTService.last = self
+
+    def _initialize_client(self) -> None:
+        pass
+
+
+class SessionLanguageCatalogTests(unittest.TestCase):
+    def test_empty_asr_catalog_falls_back_to_spanish_only(self) -> None:
+        tts_config = {"languages": ["en-US", "es-US", "vi-VN", "zh-CN"], "voices": []}
+
+        self.assertEqual(intersect_session_languages({"languages": []}, tts_config), ["es-US"])
+
+    def test_empty_asr_catalog_does_not_return_tts_languages_when_spanish_is_unavailable(self) -> None:
+        tts_config = {"languages": ["en-US", "vi-VN", "zh-CN"], "voices": []}
+
+        self.assertEqual(intersect_session_languages({"languages": []}, tts_config), [])
+
+    def test_runtime_asr_catalog_drives_intersection(self) -> None:
+        tts_config = {"languages": ["en-US", "fr-FR"], "voices": []}
+
+        languages = intersect_session_languages(
+            {"languages": ["fr-FR"]},
+            tts_config,
+        )
+
+        self.assertEqual(languages, ["fr-FR"])
+
+    def test_asr_prewarm_uses_default_config_request_without_model_name(self) -> None:
+        _FakeNvidiaSTTService.last = None
+        with (
+            patch("examples.shared.prewarm.NvidiaSTTService", _FakeNvidiaSTTService),
+            patch("examples.shared.prewarm.config_store.get", return_value=None),
+            patch("examples.shared.prewarm.config_store.set"),
+        ):
+            config = prewarm_asr(
+                "parakeet-rnnt-asr:50052",
+                "parakeet-1.1b-rnnt-multilingual-asr",
+                "",
+            )
+
+        self.assertEqual(config["languages"], ["en-US", "fr-FR", "multi"])
+        self.assertEqual(config["config_model"], "")
+        self.assertIsNotNone(_FakeNvidiaSTTService.last)
+        self.assertEqual(
+            _FakeNvidiaSTTService.last._asr_service.stub.requests,
+            [("", False)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Fix multilingual language catalog fallback and Spanish default

### Description

  This PR fixes multilingual session-language discovery and default selection.

### Changes:

  - Use RivaSpeechRecognitionConfigRequest() without model_name for ASR language catalog discovery.
  - Compute UI session languages from the ASR/TTS intersection.
  - Prevent TTS-only languages like vi-VN and zh-CN from appearing when ASR does not support them.
  - If ASR discovery returns no languages, fall back to es-US only.
  - Default the UI language selector to es-US instead of Auto-detect.
  - Set Parakeet RNNT ASR NIM selector to mode=str,vad=silero,type=default.
  - Add regression coverage for language intersection and fallback behavior.

### Testing

  - uv run --project . --group dev ruff format --check .
  - uv run --project . --group dev ruff check .
  - uv run pytest tests/test_session_languages.py tests/test_service_catalog.py
  - npm --prefix client run lint
  - npm --prefix client run build

  Also verified the cloud UI on https://localhost:7863/ returns shared ASR/TTS languages:

  de-DE, en-US, es-US, fr-FR, hi-IN, it-IT, ja-JP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `default_session_language` for examples and deployment options; `multilingual-assistant` defaults to `es-US`.
* **Bug Fixes**
  * Voice settings language sync now waits for TTS availability.
  * Session language now refreshes when switching deployment examples.
  * Session-language intersection/prewarming falls back to Spanish-only when the ASR catalog is empty.
  * Language-code resolution returns empty when no session languages are detected for provided ASR/TTS.
  * Refined ASR container environment selection per service mode.
* **Tests**
  * Added unit tests covering intersection logic, ASR prewarm behavior, and registry default validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->