### PR TITLE
Fix Omni trailing structured response flush

### DIFF
--- a/src/examples/omni_assistant/nvidia_omni_multimodal_service.py
+++ b/src/examples/omni_assistant/nvidia_omni_multimodal_service.py
@@ -670,7 +670,12 @@ class NvidiaOmniMultimodalService(LLMService):
             await self._on_turn_result(result)
             if result.transcript and not transcript_emitted:
                 await self._emit_user_transcript(result.transcript)
-            if not response_started and result.response:
+            if trailing_text:
+                response_started = await self._emit_assistant_text(
+                    trailing_text,
+                    response_started=response_started,
+                )
+            elif not response_started and result.response:
                 response_started = await self._emit_assistant_text(
                     result.response,
                     response_started=response_started,

--- a/tests/test_omni_turn_preemption.py
+++ b/tests/test_omni_turn_preemption.py
@@ -6,7 +6,10 @@
 import asyncio
 import unittest
 from collections.abc import Callable
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from pipecat.frames.frames import LLMFullResponseEndFrame, LLMFullResponseStartFrame, LLMTextFrame
 
 from examples.omni_assistant.nvidia_omni_multimodal_service import NvidiaOmniMultimodalService
 
@@ -140,6 +143,77 @@ class OmniTurnPreemptionTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(first_task.cancelled())
         self.assertFalse(self.turns[0].cancelled)
         self.assertEqual(len(self.turns), 1)
+
+    async def test_structured_stream_flushes_unpunctuated_trailing_response(self) -> None:
+        frames = []
+        self.service._settings.emit_transcriptions = True
+        self.service.push_frame = AsyncMock(side_effect=lambda frame, *_args: frames.append(frame))
+        self.service.start_processing_metrics = AsyncMock()
+        self.service.start_ttfb_metrics = AsyncMock()
+        self.service.stop_processing_metrics = AsyncMock()
+        self.service.stop_ttfb_metrics = AsyncMock()
+
+        async def stream():
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content='{"transcript":"Where is the Eiffel Tower?","response":"Paris"}')
+                    )
+                ],
+                usage=None,
+            )
+
+        self.service._client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=AsyncMock(return_value=stream())))
+        )
+
+        await self.service._run_streaming_omni_turn({}, has_audio=True, metrics_start_time=None)
+
+        assistant_frames = [
+            frame
+            for frame in frames
+            if isinstance(frame, (LLMFullResponseStartFrame, LLMTextFrame, LLMFullResponseEndFrame))
+        ]
+        self.assertIsInstance(assistant_frames[0], LLMFullResponseStartFrame)
+        self.assertIsInstance(assistant_frames[1], LLMTextFrame)
+        self.assertEqual(assistant_frames[1].text, "Paris ")
+        self.assertIsInstance(assistant_frames[2], LLMFullResponseEndFrame)
+
+    async def test_structured_stream_falls_back_to_parsed_response_when_no_text_is_emitted(self) -> None:
+        self.service._settings.emit_transcriptions = True
+        self.service.push_frame = AsyncMock()
+        self.service.start_processing_metrics = AsyncMock()
+        self.service.start_ttfb_metrics = AsyncMock()
+        self.service.stop_processing_metrics = AsyncMock()
+        self.service.stop_ttfb_metrics = AsyncMock()
+        self.service._emit_assistant_text = AsyncMock(return_value=True)
+
+        async def stream():
+            yield SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content='{"response":"Paris"}'))],
+                usage=None,
+            )
+
+        class _NoTextStreamer:
+            done = False
+
+            def __init__(self, _field_name: str) -> None:
+                pass
+
+            def feed(self, _text: str) -> str:
+                return ""
+
+        self.service._client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=AsyncMock(return_value=stream())))
+        )
+
+        with patch(
+            "examples.omni_assistant.nvidia_omni_multimodal_service._JsonStringFieldStreamer",
+            _NoTextStreamer,
+        ):
+            await self.service._run_streaming_omni_turn({}, has_audio=True, metrics_start_time=None)
+
+        self.service._emit_assistant_text.assert_awaited_once_with("Paris", response_started=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fix Omni trailing structured response flush

### Description
  Fixes structured Omni streaming responses so short unpunctuated answers are still emitted to TTS.

### Changes:
-  Flush trailing buffered assistant text in the structured-audio streaming path before falling back to the parsed full response. 
-  Preserve the existing fallback behavior for cases where no streamed response text was emitted.

### Testing
-  uv run --project . --group dev pytest tests/test_omni_turn_preemption.py
-  uv run --project . --group dev ruff format --check .
-  uv run --project . --group dev ruff check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured audio streaming so final assistant output now emits `trailing_text` when present, avoiding cases where it could be dropped.
  * Refined fallback behavior to emit the parsed `response` only when assistant text has not yet started.
* **Tests**
  * Added coverage to verify the exact streaming frame sequence when trailing content is unpunctuated.
  * Added coverage to confirm fallback emission when no plain text deltas are produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->