### PR TITLE
Simplify multilingual example to a fixed-language plain-text pipeline

### DIFF
--- a/client/src/components/VoiceSettings.tsx
+++ b/client/src/components/VoiceSettings.tsx
@@ -7,7 +7,7 @@ import { usePipecatClient, useRTVIClientEvent } from "@pipecat-ai/client-react";
 import { useVoiceCatalog } from "../api";
 import { useConnectionState } from "../hooks/useConnectionState";
 import { useApp } from "../context/useApp";
-import { SESSION_LANGUAGE_AUTO } from "../context/AppContext";
+import { DEFAULT_SESSION_LANGUAGE } from "../context/AppContext";
 import { PanelSection } from "./PanelSection";
 
 type LanguageSwitchedMessage = {
@@ -73,8 +73,9 @@ export function VoiceSettings() {
     if (!sessionLanguagesEnabled) return;
     if (!ttsConfig) return;
     const languages = ttsConfig?.languages ?? [];
-    if (selectedSessionLanguage && !languages.includes(selectedSessionLanguage)) {
-      setSelectedSessionLanguage(SESSION_LANGUAGE_AUTO);
+    if (languages.length === 0) return;
+    if (!selectedSessionLanguage || !languages.includes(selectedSessionLanguage)) {
+      setSelectedSessionLanguage(languages.includes(DEFAULT_SESSION_LANGUAGE) ? DEFAULT_SESSION_LANGUAGE : languages[0]);
     }
   }, [sessionLanguagesEnabled, selectedSessionLanguage, ttsConfig, setSelectedSessionLanguage]);
 
@@ -159,12 +160,11 @@ export function VoiceSettings() {
           <span className="settings-label">Language</span>
           <select
             className="select-dark"
-            value={selectedSessionLanguage || SESSION_LANGUAGE_AUTO}
+            value={selectedSessionLanguage || DEFAULT_SESSION_LANGUAGE}
             onChange={(e) => setSelectedSessionLanguage(e.target.value)}
             disabled={isConnecting || isLocked}
             title={languageSelectTitle}
           >
-            <option value={SESSION_LANGUAGE_AUTO}>Auto-detect (per turn)</option>
             {availableLanguages.map((lang) => (
               <option key={lang} value={lang}>{lang}</option>
             ))}

--- a/client/src/context/AppContext.tsx
+++ b/client/src/context/AppContext.tsx
@@ -24,8 +24,8 @@ const PROMPT_SELECTION = "nvidia-voice-agent-prompt-selection";
 const TRANSPORT_STORAGE = "nvidia-voice-agent-transport";
 const SELECTED_EXAMPLE_STORAGE = "nvidia-voice-agent-selected-example";
 
-/** Empty string = auto-detect language on each turn. */
-export const SESSION_LANGUAGE_AUTO = "";
+/** Fallback session language when an example declares none. */
+export const DEFAULT_SESSION_LANGUAGE = "en-US";
 
 type ManagedService = {
   id: string;
@@ -185,7 +185,7 @@ export interface AppState {
   selectedVoiceId: string;
   setSelectedVoiceId: (id: string) => void;
 
-  /** Empty string = auto-detect per turn when session language selection is enabled. */
+  /** The language the whole session is locked to when session language selection is enabled. */
   selectedSessionLanguage: string;
   setSelectedSessionLanguage: (code: string) => void;
 
@@ -309,15 +309,15 @@ export function AppProvider({ children }: Readonly<{ children: ReactNode }>) {
 
   const [selectedVoiceId, setSelectedVoiceId] = useState("");
 
-  const [selectedSessionLanguage, setSelectedSessionLanguage] = useState(SESSION_LANGUAGE_AUTO);
+  const [selectedSessionLanguage, setSelectedSessionLanguage] = useState(DEFAULT_SESSION_LANGUAGE);
   const defaultSessionLanguageExampleKey = useRef("");
-  const selectedExampleDefaultSessionLanguage = selectedExample?.default_session_language ?? SESSION_LANGUAGE_AUTO;
+  const selectedExampleDefaultSessionLanguage = selectedExample?.default_session_language ?? DEFAULT_SESSION_LANGUAGE;
 
   useEffect(() => {
     const selectedExampleKey = selectedExample?.key ?? "";
     if (!selectedExampleKey || defaultSessionLanguageExampleKey.current === selectedExampleKey) return;
     defaultSessionLanguageExampleKey.current = selectedExampleKey;
-    setSelectedSessionLanguage(selectedExampleDefaultSessionLanguage || SESSION_LANGUAGE_AUTO);
+    setSelectedSessionLanguage(selectedExampleDefaultSessionLanguage || DEFAULT_SESSION_LANGUAGE);
   }, [selectedExample?.key, selectedExampleDefaultSessionLanguage]);
 
   // --- TTS state ---

--- a/docker/docker-compose.nemotron-asr.yaml
+++ b/docker/docker-compose.nemotron-asr.yaml
@@ -52,6 +52,7 @@ services:
     <<: *nemotron-asr
     profiles:
       - nemotron-asr-streaming-multilingual/workstation
+      - multilingual-assistant/workstation
     environment:
       <<: *nemotron-asr-env
       NIM_TAGS_SELECTOR: type=multi,mode=str
@@ -60,6 +61,7 @@ services:
     <<: *nemotron-asr
     profiles:
       - nemotron-asr-streaming-multilingual/dgx-spark
+      - multilingual-assistant/dgx-spark
     environment:
       <<: *nemotron-asr-env
       NIM_TAGS_SELECTOR: type=multi,mode=str,gpu=dgx_spark,batch_size=32

--- a/docker/docker-compose.parakeet-asr.yaml
+++ b/docker/docker-compose.parakeet-asr.yaml
@@ -53,8 +53,6 @@ services:
       NIM_TAGS_SELECTOR: mode=str,vad=silero,type=default
     profiles:
       - parakeet-rnnt-asr
-      - multilingual-assistant/workstation
-      - multilingual-assistant/dgx-spark
     image: nvcr.io/nim/nvidia/parakeet-1-1b-rnnt-multilingual:1.5.0
 
 volumes:

--- a/docs/how-to/configure-asr.md
+++ b/docs/how-to/configure-asr.md
@@ -30,8 +30,8 @@ For multilingual deployments, choose between the two multilingual ASR models bas
 
 | Model | Recommendation and trade-offs |
 | --- | --- |
-| Nemotron ASR Streaming Multilingual | Prefer this model when latency and throughput are the main constraints. It is faster in this pipeline, but recognition quality is currently weaker for a few languages, and language auto-detection is less reliable. For best results, preselect the session language instead of relying on auto-detection. |
-| Parakeet 1.1B RNNT Multilingual | Prefer this model when multilingual recognition quality matters more than raw latency. Language auto-detection is relatively stronger, and Hindi and Chinese recognition are generally better than Nemotron ASR in this setup. The trade-off is slower latency and throughput. It can also miss the first word of an utterance in some cases and may produce occasional false transcripts when the microphone is muted or no user speech is intended, so validate turn-start and silence handling for production. |
+| Nemotron ASR Streaming Multilingual | Prefer this model when latency and throughput are the main constraints. It is faster in this pipeline, but recognition quality is currently weaker for a few languages. In noisy environments, it can occasionally emit an empty transcript for turns, so the user may need to repeat themselves. A good microphone and reduced background noise help. |
+| Parakeet 1.1B RNNT Multilingual | Prefer this model when multilingual recognition quality matters more than raw latency. Hindi and Chinese recognition are generally better than Nemotron ASR in this setup. The trade-off is slower latency and throughput. It can also miss the first word of an utterance in some cases and may produce occasional false transcripts when the microphone is muted or no user speech is intended, so validate turn-start and silence handling for production. |
 
 ## Hardware requirements and deployment configs
 
@@ -76,7 +76,7 @@ For ASR latency and throughput across GPUs and WER for different models, see the
 
   This blueprint's turn-taking is driven mainly by pipeline-level [Smart Turn / Silero VAD](tune-pipeline-performance.md#smart-turn-detection). ASR endpointing is the lower-level, ASR-side signal. See [ASR customization](https://docs.nvidia.com/nim/speech/latest/asr/customization/customization.html) for exact semantics, defaults, and the `force_eou` runtime flag.
 
-- **Language**: multilingual streaming uses `language_code: auto` for per-turn language detection. Pin a fixed locale (e.g. `es-US`) to force one language. For the full set a model supports, see its per-model supported-language table in the [ASR support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html) (Nemotron ASR Streaming covers 40 locales, Parakeet RNNT Multilingual 25+).
+- **Language**: the multilingual example locks each session to a single locale, selectable per connection in the UI (any locale the ASR and TTS both support, default `de-DE`) and fixed for that session. Different sessions can use different languages. The ASR also accepts `language_code: auto` for per-turn detection, but this blueprint does not use it, since a pinned locale is more reliable. For the full set a model supports, see its per-model supported-language table in the [ASR support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html) (Nemotron ASR Streaming covers 40 locales, Parakeet RNNT Multilingual 25+).
 - **Catalog config**: a cloud entry sets `server` / `model` / `function_id`, while a local entry points at the Compose sidecar `host:port`. Host-run deployments rewrite sidecar endpoints to `localhost` automatically. See [Configure Services → On-prem catalog](configure-services.md#on-prem-catalog).
 
 ```yaml

--- a/docs/how-to/configure-llm.md
+++ b/docs/how-to/configure-llm.md
@@ -28,6 +28,8 @@ Each model is exposed as one or more **catalog keys** in `services.cloud.yaml` /
 
 The `*-reasoning` keys are the **same weights** with thinking enabled (see [Reasoning, parser & tool calling](#reasoning-parser--tool-calling)). The active default per slot is set in [`examples_registry.yaml`](../../examples_registry.yaml) under `defaults`.
 
+> **Multilingual conversation quality.** Nemotron 3 Nano's conversation quality is weaker in some languages (for example Hindi). For multilingual deployments where language fidelity matters, prefer **Nemotron 3 Super** (`nemotron-super`). It stays more reliably in the target language and reads more naturally across languages.
+
 ## Hardware requirements and deployment configs
 
 You can self-host the LLM two ways, and the repo wires the right one per profile:

--- a/examples_registry.yaml
+++ b/examples_registry.yaml
@@ -37,12 +37,11 @@ examples:
     capabilities: [session_languages]
     agent_prompt_keys:
       - fixed_session_language_addon
-      - auto_detect_language_addon
     defaults:
-      default_session_language: es-US
+      default_session_language: de-DE
       prompt: [multilingual_voice_assistant]
       llm: [nemotron-super]
-      asr: [parakeet-rnnt]
+      asr: [nemotron-asr-streaming-multilingual]
       tts: [magpie-tts]
     bot: examples.multilingual.pipeline:bot
 

--- a/src/examples/multilingual/README.md
+++ b/src/examples/multilingual/README.md
@@ -1,8 +1,8 @@
 # Multilingual - cascaded pipeline example
 
-Multilingual cascaded voice pipeline using Pipecat's built-in NVIDIA services (`NvidiaSTTService` -> `NvidiaLLMService` -> `NvidiaTTSService`). The LLM emits structured `Language: / Text: / MetaData:` output and the pipeline automatically switches the active TTS voice on each detected language change. It can listen, reason, and respond across supported languages while staying deterministic about which text reaches TTS and the UI.
+Multilingual cascaded voice pipeline using Pipecat's built-in NVIDIA services (`NvidiaSTTService` -> `NvidiaLLMService` -> `NvidiaTTSService`). The session is locked to a single language for the whole connection (selected in the UI, default `de-DE`): the ASR, the TTS voice, and the LLM all operate in that one language. The LLM replies with plain spoken text, kept on-language by the fixed-session prompt addon and a per-turn reminder.
 
-The pattern uses dedicated ASR, LLM, and TTS services with a structured LLM response contract that drives runtime language and voice switching. It showcases prompt-enforced `Language: / Text: / MetaData:` output, the `MultilingualTextAggregator` that drives early TTS voice updates, and metadata filtering that keeps `Language:` and `MetaData:` out of speech and the transcript.
+The pattern uses dedicated ASR, LLM, and TTS services with a plain-text response, a per-turn language reminder injected at request time only, and a clean chat history that stores just the spoken reply.
 
 ![Architecture Diagram](../../../docs/images/arch.png)
 
@@ -25,7 +25,7 @@ This example runs on the **Cloud** (no local GPU, NVCF endpoints), **Workstation
    printf '%s' "$NVIDIA_API_KEY" | docker login nvcr.io -u '$oauthtoken' --password-stdin
    ```
 
-3. Deploy the profile that matches your hardware. The on-prem recipes start a Parakeet RNNT ASR sidecar:
+3. Deploy the profile that matches your hardware. The on-prem recipes start a Nemotron ASR Streaming Multilingual sidecar:
 
    ```bash
    docker compose --profile multilingual-assistant up -d              # Cloud (no local GPU)
@@ -36,8 +36,8 @@ This example runs on the **Cloud** (no local GPU, NVCF endpoints), **Workstation
    | Recipe profile | App service | Sidecars |
    | --- | --- | --- |
    | `multilingual-assistant` | `multilingual-assistant` | none (cloud NVCF) |
-   | `multilingual-assistant/workstation` | `multilingual-assistant` | `nvidia-llm`, `parakeet-rnnt-asr`, `tts-service` |
-   | `multilingual-assistant/dgx-spark` | `multilingual-assistant` | `nvidia-llm-vllm`, `parakeet-rnnt-asr`, `tts-service` |
+   | `multilingual-assistant/workstation` | `multilingual-assistant` | `nvidia-llm`, `nemotron-asr-streaming-multilingual`, `tts-service` |
+   | `multilingual-assistant/dgx-spark` | `multilingual-assistant` | `nvidia-llm-vllm`, `nemotron-asr-streaming-multilingual`, `tts-service` |
 
 4. Open the UI at `https://localhost:7860/`. Keep TLS enabled for browser UI testing. `PIPELINE_TLS=false` serves plain HTTP for headless performance and API testing. For plain-HTTP browser testing, see [browser access](../../../docs/06-troubleshooting.md#browser-access).
 
@@ -49,51 +49,46 @@ This example runs on the **Cloud** (no local GPU, NVCF endpoints), **Workstation
 
 To run host-native without Docker, set `selection: multilingual-assistant` in [`examples_registry.yaml`](../../../examples_registry.yaml), then run `uv run python3 src/server.py`.
 
-After deploying, validate language switching with the steps in [Testing](#testing).
+After deploying, validate the session language with the steps in [Testing](#testing).
 
 ## Customization
 
-Cloud and on-prem defaults use **Parakeet 1.1B RNNT Multilingual** (`parakeet-rnnt`) via `examples_registry.yaml` and `services.local.yaml`. The `multilingual-assistant/workstation` and `/dgx-spark` recipe profiles start `parakeet-rnnt-asr` locally.
+On-prem recipes default to **Nemotron ASR Streaming Multilingual** (`nemotron-asr-streaming-multilingual`) via `examples_registry.yaml` and `services.local.yaml`. The `multilingual-assistant/workstation` and `/dgx-spark` recipe profiles start that sidecar locally. There is no NVCF endpoint for it, so the cloud recipe falls back to **Parakeet 1.1B RNNT Multilingual** (`parakeet-rnnt`), the only multilingual ASR available on NVCF.
 
-TTS voices and supported language codes are discovered at runtime by prewarming the configured TTS service. The `{lang_codes}` placeholder in the multilingual prompt is replaced automatically with the discovered codes, so no manual language list is needed.
+TTS voices and supported language codes are discovered at runtime by prewarming the configured TTS service, and the UI language selector is populated from the languages shared by the ASR and TTS services. The selected session language is injected into the prompt and pins the ASR and the TTS voice for the whole connection.
 
 | Path | Role |
 | --- | --- |
 | `pipeline.py` | pipecat entry point, multilingual mode always on |
 | `prompts.yaml` | multilingual prompt catalog (`multilingual_voice_assistant`) |
 | `services.cloud.yaml` | cloud service endpoints and defaults |
-| `services.local.yaml` | on-prem service endpoints (workstation / dgx-spark), registry default `parakeet-rnnt` |
+| `services.local.yaml` | on-prem service endpoints (workstation / dgx-spark), registry default `nemotron-asr-streaming-multilingual` |
 
 ### How it works
 
-1. The LLM returns each response in this format:
-
-   ```text
-   Language: <LangCode> Text: <DirectResponse> MetaData: <AdditionalInfo>
-   ```
-
-2. `MultilingualTextAggregator` parses the structured output and fires a language-switch callback the moment the `Language:` code is detected.
-3. The pipeline queues a `TTSUpdateSettingsFrame` to switch the TTS voice before the first sentence of the response is spoken.
-4. Only the `Text:` content is forwarded to TTS and shown in the client transcript. `Language:` and `MetaData:` segments are dropped from both audio and the UI.
+1. The user selects the session language in the UI (default `de-DE`) before connecting.
+2. The ASR and the TTS voice are pinned to that language when the connection starts. They do not change mid-session.
+3. The fixed-session prompt addon instructs the LLM to reply only in that language, and the LLM returns plain spoken text (no JSON, labels, or metadata) that flows straight to TTS, the client transcript, and chat history.
+4. `PerTurnReminderProcessor` re-states the "reply only in <language>" reminder on each user turn at request time only, so the reminder never pollutes stored history.
 
 ### Switching the multilingual ASR model
 
-The **Nemotron ASR Streaming Multilingual** sidecar offers lower streaming latency and is best for a fixed single language (see [Model Selection Notes](#model-selection-notes)). To run it instead of the default Parakeet RNNT:
+**Parakeet 1.1B RNNT Multilingual** offers stronger multilingual recognition quality at higher latency (see [Model Selection Notes](#model-selection-notes)). To run it instead of the default Nemotron ASR Streaming Multilingual on-prem:
 
-1. In [`examples_registry.yaml`](../../../examples_registry.yaml), under `multilingual-assistant`, set `defaults.asr: [nemotron-asr-streaming-multilingual]`.
-2. Redeploy with the recipe profile plus the Nemotron streaming profile, scaling Parakeet off (only one local ASR may bind port `50152`):
+1. In [`examples_registry.yaml`](../../../examples_registry.yaml), under `multilingual-assistant`, set `defaults.asr: [parakeet-rnnt]`.
+2. Redeploy with the recipe profile plus the Parakeet profile, scaling the Nemotron sidecar off (only one local ASR may bind port `50152`):
 
    ```bash
    # Workstation
    docker compose --profile multilingual-assistant/workstation \
-     --profile nemotron-asr-streaming-multilingual/workstation up -d --scale parakeet-rnnt-asr=0
+     --profile parakeet-rnnt-asr up -d --scale nemotron-asr-streaming-multilingual=0
 
    # DGX Spark
    docker compose --profile multilingual-assistant/dgx-spark \
-     --profile nemotron-asr-streaming-multilingual/dgx-spark up -d --scale parakeet-rnnt-asr=0
+     --profile parakeet-rnnt-asr up -d --scale nemotron-asr-streaming-multilingual-dgx-spark=0
    ```
 
-3. Switch back to Parakeet by reversing the registry edit and redeploying the stock on-prem recipe.
+3. Switch back to Nemotron by reversing the registry edit and redeploying the stock on-prem recipe.
 
 ## Tips & best practices
 
@@ -103,30 +98,32 @@ Multilingual behavior depends on the ASR model, the LLM, and the selected TTS vo
 
 | Component | Recommendation and trade-offs |
 | --- | --- |
-| Nemotron ASR Streaming Multilingual | Prefer this model when latency and throughput are the main constraints. It is faster in this pipeline, but recognition quality is currently weaker for a few languages, and language auto-detection is less reliable. For best results, preselect the session language instead of relying on auto-detection. |
-| Parakeet 1.1B RNNT Multilingual | Prefer this model when multilingual recognition quality matters more than raw latency. Language auto-detection is relatively stronger, and Hindi and Chinese recognition are generally better than Nemotron ASR in this setup. The trade-off is slower latency and throughput. It can also miss the first word of an utterance in some cases and may produce occasional false transcripts when the microphone is muted or no user speech is intended, so validate turn-start and silence handling for production. |
-| Nemotron 3 Super LLM | Recommended over Nemotron 3 Nano when response-format reliability is important. The multilingual pipeline depends on the LLM following the `Language: / Text: / MetaData:` contract, and the larger model is generally more reliable at staying within that format. |
-| Nemotron 3 Nano LLM | Useful for lower latency, lower resource usage, and faster local experiments, but it may be less consistent about strict structured output under ambiguous or noisy ASR transcripts. For single language, add prompt instructions in target language only  |
+| Nemotron ASR Streaming Multilingual | Prefer this model when latency and throughput are the main constraints. It is faster in this pipeline, but recognition quality is currently weaker for a few languages. Since the session language is fixed, its pinned-language recognition is a good fit here. In noisy environments, it can occasionally emit an empty transcript for turns, so the user may need to repeat themselves. A good microphone and reduced background noise help. |
+| Parakeet 1.1B RNNT Multilingual | Prefer this model when multilingual recognition quality matters more than raw latency. Hindi and Chinese recognition are generally better than Nemotron ASR in this setup. The trade-off is slower latency and throughput. It can also miss the first word of an utterance in some cases and may produce occasional false transcripts when the microphone is muted or no user speech is intended, so validate turn-start and silence handling for production. |
+| Nemotron 3 Super LLM | **Recommended for multilingual.** Stays more reliably in the fixed session language and delivers better conversation quality across languages, especially where Nemotron 3 Nano is weak (for example Hindi). Generally more concise as well. |
+| Nemotron 3 Nano LLM | Useful for lower latency, lower resource usage, and faster local experiments. Its conversation quality is weaker in some languages (for example Hindi), and with reasoning disabled it can occasionally slip in foreign words on quantized builds, so the fixed-session prompt addon and the per-turn reminder both enforce a single language. Prefer Nemotron 3 Super when multilingual quality matters. |
 
 ### Testing
 
 1. Start the app with the `multilingual-assistant` profile.
-2. Speak in English and verify the bot responds in English.
-3. Speak in another supported language (for example German, French, or Spanish).
+2. In Voice Settings, pick the session language (for example German, French, or Spanish), then connect.
+3. Speak in the selected language and verify the bot responds in that same language.
 4. Verify that:
-   - the spoken response switches to the new language
-   - the transcript shows only the clean spoken text (no `Language:` / `MetaData:` markers)
-   - the UI language indicator reflects the switched language
+   - the bot always responds in the selected session language, regardless of the language you speak
+   - the transcript shows the clean spoken text
+   - changing the language requires disconnecting, selecting a new language, and connecting again
 
 ### Troubleshooting
 
 | Issue | Cause | What to check |
 |-------|-------|---------------|
-| Response stays in English | LLM did not emit the expected structured format | Verify the selected prompt instructs the model to use `Language: / Text: / MetaData:` |
-| TTS uses the wrong voice or language | Detected language is not supported by the active TTS service | Check the configured TTS service exposes that language code |
-| Transcript shows raw structured output | `skip_aggregator_types` not applied | Confirm you are using the `multilingual-assistant` pipeline |
+| Bot responds in the wrong language | LLM ignored the fixed session language | Confirm the fixed-session prompt addon and per-turn reminder name the selected language. Try the larger Nemotron 3 Super LLM |
+| Bot slips in foreign words | Quantized small-model sampling artifacts | Lower the LLM `temperature` in `services.*.yaml`, or use a larger LLM |
+| TTS uses the wrong voice or language | Selected session language is not supported by the active TTS service | Check the configured TTS service exposes that language code, or pick a supported language |
 | No voices discovered at startup | TTS prewarm failed | Check TTS sidecar health (`docker compose ps`) and `NVIDIA_API_KEY` |
-| Port conflict on the ASR sidecar | Parakeet and Nemotron streaming both bind `50152` | Scale `parakeet-rnnt-asr=0` when running a Nemotron streaming profile |
-| Random ASR text while silent | Parakeet RNNT noise sensitivity | Expected with Parakeet. Try the Nemotron Streaming Multilingual opt-in, or reduce room noise using a good mic |
+| Bot does not respond to a turn (no transcript) | Nemotron ASR Multilingual can drop a turn in noisy environments | Speak again, reduce background noise, and use a good microphone. See [Configure ASR](../../../docs/how-to/configure-asr.md#choosing-a-multilingual-asr-model) |
+| Weak or awkward replies in some languages (for example Hindi) | Nemotron 3 Nano has weaker conversation quality in a few languages | Use Nemotron 3 Super for better multilingual quality. See [Configure LLM](../../../docs/how-to/configure-llm.md) |
+| Port conflict on the ASR sidecar | Parakeet and Nemotron streaming both bind `50152` | Run only one local ASR. When opting into Parakeet, scale the Nemotron sidecar off (`--scale nemotron-asr-streaming-multilingual=0`) |
+| Random ASR text while silent | Parakeet RNNT noise sensitivity | Expected with the Parakeet opt-in. The default Nemotron ASR is less prone to this; otherwise reduce room noise and use a good mic |
 
 For ASR, LLM, and TTS model details and general failure modes, see [Configure ASR](../../../docs/how-to/configure-asr.md), [Configure TTS](../../../docs/how-to/configure-tts.md), [Configure LLM](../../../docs/how-to/configure-llm.md), and the [Troubleshooting guide](../../../docs/06-troubleshooting.md).

--- a/src/examples/multilingual/multilingual_processor.py
+++ b/src/examples/multilingual/multilingual_processor.py
@@ -3,219 +3,119 @@
 
 """Multilingual support for the cascaded pipeline.
 
-Parses the LLM's ``Language: <code> Text: <reply> MetaData: <info>`` format in
-a streaming aggregator, switches the TTS voice on the detected language, and
-exposes the lang/meta segments to the assistant context (so chat history
-keeps the structured response) while skipping them on the TTS side.
+The session is locked to a single language for the whole connection: the ASR,
+the TTS voice, and the LLM all operate in that one language. The LLM replies
+with plain spoken text (no JSON, no metadata), so responses flow straight to
+TTS and into a clean chat history.
 
-Designed to be plugged into a Pipecat ``LLMTextProcessor`` together with a
-TTS service configured with ``skip_aggregator_types=SKIP_TTS_AGGREGATIONS``.
+``PerTurnReminderProcessor`` re-states the language contract on every user turn
+at request time only, so the stored context stays clean.
 """
 
-import re
-from collections.abc import AsyncIterator, Awaitable, Callable
+import copy
 
-from loguru import logger
-from pipecat.frames.frames import (
-    AggregatedTextFrame,
-    Frame,
-    LLMTextFrame,
-    TTSUpdateSettingsFrame,
-)
-from pipecat.pipeline.worker import PipelineWorker
+from pipecat.frames.frames import Frame, LLMContextFrame
+from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
-from pipecat.services.nvidia.tts import NvidiaTTSService, NvidiaTTSSettings
-from pipecat.utils.text.base_text_aggregator import (
-    Aggregation,
-    AggregationType,
-    BaseTextAggregator,
-)
-from pipecat.utils.text.simple_text_aggregator import SimpleTextAggregator
 
 import config_store
 from examples.shared.prewarm import build_session_languages, load_voice_map
-from utils import normalize_lang_code
-
-LANG_TYPE = "lang"
-META_TYPE = "meta"
-SKIP_TTS_AGGREGATIONS: list[str] = [LANG_TYPE, META_TYPE]
-
-_LANG_PREFIX = "Language:"
-_TEXT_MARKER = "Text:"
-_META_MARKER = "MetaData:"
-_TEXT_MARKER_RE = re.compile(rf"\s*{re.escape(_TEXT_MARKER)}\s*", re.IGNORECASE)
-_META_MARKER_RE = re.compile(rf"\s*{re.escape(_META_MARKER)}\s*", re.IGNORECASE)
-
-_STATE_HEADER = 0
-_STATE_TEXT = 1
-_STATE_META = 2
-
-_LanguageHandler = Callable[[str], Awaitable[None]]
-_LanguageSwitchNotifier = Callable[[str, str], Awaitable[None]]
 
 
-class MultilingualTextAggregator(BaseTextAggregator):
-    """Streaming aggregator for the ``Language: ... Text: ... MetaData: ...`` format.
+class PerTurnReminderProcessor(FrameProcessor):
+    """Append a language reminder to the last user message at request time only.
 
-    Yields three aggregation types:
-
-    * ``"lang"`` — the full ``Language: <code> Text:`` header.
-    * ``"sentence"`` — each complete sentence of the spoken reply.
-    * ``"meta"`` — the trailing ``MetaData: <info>`` block.
-
-    ``on_language`` fires the moment ``Language: <code>`` is fully buffered,
-    independent of (and before) the ``Text:`` marker.
+    Sits between the user aggregator and the LLM. When an ``LLMContextFrame``
+    passes through, it forwards a *copy* of the context whose last user message
+    carries the reminder, leaving the shared/stored context untouched so chat
+    history (and summaries) never contain the reminder text.
     """
 
-    def __init__(self, *, on_language: _LanguageHandler | None = None):
-        """Build the aggregator with an optional language-switch callback."""
-        super().__init__(aggregation_type=AggregationType.SENTENCE)
-        self._on_language = on_language
-        self._state = _STATE_HEADER
-        self._buf = ""
-        self._sentence_aggregator = SimpleTextAggregator()
-        self._lang_handler_fired = False
-        self._pending_meta = ""
+    def __init__(self, reminder: str):
+        """Build the processor with the reminder text to inject per turn."""
+        super().__init__()
+        self._reminder = (reminder or "").strip()
 
-    @property
-    def text(self) -> Aggregation:
-        """Return the currently buffered text as a sentence aggregation."""
-        return Aggregation(text=self._buf, type=AggregationType.SENTENCE.value)
-
-    async def aggregate(self, text: str) -> AsyncIterator[Aggregation]:
-        """Consume streaming LLM text and yield typed aggregations."""
-        self._buf += text
-        await self._maybe_fire_language_handler()
-
-        while True:
-            if self._state == _STATE_HEADER:
-                text_match = _TEXT_MARKER_RE.search(self._buf)
-                if text_match:
-                    header = self._buf[: text_match.start()].strip()
-                    self._buf = self._buf[text_match.end() :]
-                    self._state = _STATE_TEXT
-                    if header:
-                        yield Aggregation(text=f"{header} Text:", type=LANG_TYPE)
-                    continue
-
-                return
-
-            if self._state == _STATE_TEXT:
-                meta_match = _META_MARKER_RE.search(self._buf)
-                if meta_match:
-                    pending = self._buf[: meta_match.start()]
-                    self._buf = self._buf[meta_match.end() :]
-                    if pending:
-                        async for agg in self._sentence_aggregator.aggregate(pending):
-                            yield agg
-                    trailing = await self._sentence_aggregator.flush()
-                    if trailing and trailing.text.strip():
-                        yield trailing
-                    self._state = _STATE_META
-                    continue
-
-                holdback = _partial_field_marker_suffix_len(self._buf, _META_MARKER)
-                pending, self._buf = (self._buf[:-holdback], self._buf[-holdback:]) if holdback else (self._buf, "")
-                if pending:
-                    async for agg in self._sentence_aggregator.aggregate(pending):
-                        yield agg
-                return
-
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        """Forward frames; inject the reminder into outbound context frames."""
+        await super().process_frame(frame, direction)
+        if self._reminder and isinstance(frame, LLMContextFrame):
+            await self.push_frame(self._reminded_frame(frame), direction)
             return
+        await self.push_frame(frame, direction)
 
-    async def flush(self) -> Aggregation | None:
-        """Yield any pending text once the LLM response ends."""
-        if self._pending_meta:
-            text = self._pending_meta
-            self._pending_meta = ""
-            return Aggregation(text=f"MetaData: {text}", type=META_TYPE)
+    def _reminded_frame(self, frame: LLMContextFrame) -> LLMContextFrame:
+        source = frame.context
+        messages = self._append_reminder(list(source.get_messages()))
+        new_context = LLMContext(messages, tools=source.tools, tool_choice=source.tool_choice)
+        return LLMContextFrame(context=new_context)
 
-        if self._state == _STATE_META:
-            text = self._buf.strip()
-            self._buf = ""
-            return Aggregation(text=f"MetaData: {text}", type=META_TYPE) if text else None
+    def _append_reminder(self, messages: list) -> list:
+        for i in range(len(messages) - 1, -1, -1):
+            msg = messages[i]
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                messages[i] = self._augment(msg)
+                return messages
+        messages.append({"role": "user", "content": self._reminder})
+        return messages
 
-        if self._state == _STATE_TEXT:
-            meta_match = _META_MARKER_RE.search(self._buf)
-            if meta_match:
-                pending = self._buf[: meta_match.start()]
-                self._buf = self._buf[meta_match.end() :]
-                spoken_text = pending.strip()
-                meta_text = self._buf.strip()
-                self._buf = ""
-                self._state = _STATE_META
-                if spoken_text:
-                    self._pending_meta = meta_text
-                    return Aggregation(text=spoken_text, type=AggregationType.SENTENCE.value)
-                return Aggregation(text=f"MetaData: {meta_text}", type=META_TYPE) if meta_text else None
-
-            pending, self._buf = self._buf, ""
-            if pending:
-                async for _ in self._sentence_aggregator.aggregate(pending):
-                    pass
-            tail = await self._sentence_aggregator.flush()
-            return tail if tail and tail.text.strip() else None
-
-        text = self._buf.strip()
-        self._buf = ""
-        if not text:
-            return None
-        logger.warning("Multilingual: LLM response missing 'Text:' marker; dropping raw output")
-        return None
-
-    def set_on_language(self, handler: _LanguageHandler | None) -> None:
-        """Wire (or rewire) the language-switch handler post-construction."""
-        self._on_language = handler
-
-    async def handle_interruption(self):
-        """Drop all buffered state when the user interrupts the bot."""
-        await self.reset()
-
-    async def reset(self):
-        """Clear buffered state and reset the streaming parse to the header."""
-        self._state = _STATE_HEADER
-        self._buf = ""
-        self._lang_handler_fired = False
-        self._pending_meta = ""
-        await self._sentence_aggregator.reset()
-
-    async def _maybe_fire_language_handler(self) -> None:
-        if self._lang_handler_fired or self._on_language is None:
-            return
-        code = _detect_language_code(self._buf)
-        if not code:
-            return
-        self._lang_handler_fired = True
-        try:
-            await self._on_language(code)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(f"Multilingual: language handler failed: {exc}")
+    def _augment(self, msg: dict) -> dict:
+        content = msg.get("content")
+        if isinstance(content, str):
+            return {**msg, "content": f"{content}\n\n{self._reminder}"}
+        if isinstance(content, list):
+            return {**msg, "content": [*content, {"type": "text", "text": self._reminder}]}
+        return {**msg, "content": self._reminder}
 
 
-def _detect_language_code(buf: str) -> str:
-    """Return ``<code>`` once ``Language: <code>`` is fully buffered (code + ws)."""
-    stripped = buf.lstrip()
-    if not stripped.lower().startswith(_LANG_PREFIX.lower()):
+def with_reasoning(extra: dict, enabled: bool) -> dict:
+    """Return a copy of OpenAI extra params with reasoning toggled.
+
+    Sets ``extra_body.chat_template_kwargs.enable_thinking``. Used to enable
+    reasoning for the out-of-band summarizer (better summary faithfulness)
+    while spoken turns stay reasoning-off for low latency.
+    """
+    merged = copy.deepcopy(extra) if extra else {}
+    extra_body = merged.setdefault("extra_body", {})
+    if not isinstance(extra_body, dict):
+        return merged
+    ctk = extra_body.setdefault("chat_template_kwargs", {})
+    if isinstance(ctk, dict):
+        ctk["enable_thinking"] = enabled
+    return merged
+
+
+_LANGUAGE_NAMES: dict[str, str] = {
+    "de": "German (Deutsch)",
+    "en": "English",
+    "es": "Spanish (español)",
+    "fr": "French (français)",
+    "hi": "Hindi (हिन्दी)",
+    "it": "Italian (italiano)",
+    "ja": "Japanese (日本語)",
+    "vi": "Vietnamese (Tiếng Việt)",
+    "zh": "Chinese (中文)",
+}
+
+
+def describe_language(code: str) -> str:
+    """Return a human-readable language name for a BCP-47 code (falls back to the code)."""
+    if not code:
         return ""
-    rest = stripped[len(_LANG_PREFIX) :].lstrip()
-    for i, ch in enumerate(rest):
-        if ch.isspace():
-            return rest[:i].strip()
-    return ""
+    base = code.split("-")[0].strip().lower()
+    return _LANGUAGE_NAMES.get(base, code)
 
 
-def _partial_field_marker_suffix_len(buf: str, marker: str) -> int:
-    """Length of trailing text that may become a field marker on the next chunk."""
-    trailing_whitespace = len(buf) - len(buf.rstrip())
-    if trailing_whitespace:
-        return trailing_whitespace
+_ONE_LANGUAGE_RULE = (
+    "Your ENTIRE response must be in ONE single language only. Never mix two languages "
+    "and never switch language mid-sentence."
+)
 
-    lower_buf = buf.lower()
-    lower_marker = marker.lower()
-    for k in range(min(len(buf), len(marker) - 1), 0, -1):
-        if lower_buf[-k:] == lower_marker[:k]:
-            return k
-    return 0
+
+def build_reminder(fixed_language: str) -> str:
+    """Build the concise per-turn language reminder for the fixed session language."""
+    name = describe_language(fixed_language)
+    return f"Reminder: reply only in {name}, using its standard native script. {_ONE_LANGUAGE_RULE}"
 
 
 def get_lang_codes(
@@ -226,7 +126,7 @@ def get_lang_codes(
     tts_server: str = "",
     tts_voice_id: str = "",
 ) -> str:
-    """Comma-separated language codes for prompt ``{lang_codes}`` injection."""
+    """Comma-separated language codes shared by the ASR and TTS services (informational)."""
     if asr_server or tts_server:
         languages = build_session_languages(
             asr_server,
@@ -237,7 +137,6 @@ def get_lang_codes(
         ).get("languages", [])
         if languages:
             return ", ".join(languages)
-        return ""
 
     tts_config = config_store.get("tts", {})
     languages = tts_config.get("languages", []) if isinstance(tts_config, dict) else []
@@ -247,77 +146,4 @@ def get_lang_codes(
 
 
 FIXED_SESSION_LANGUAGE_ADDON_KEY = "fixed_session_language_addon"
-AUTO_DETECT_LANGUAGE_ADDON_KEY = "auto_detect_language_addon"
 FIXED_SESSION_GREETING_TRIGGER = "[session_start]"
-
-
-def make_language_handler(
-    tts: NvidiaTTSService,
-    task: PipelineWorker,
-    *,
-    on_language_switched: _LanguageSwitchNotifier | None = None,
-    fixed_language: str = "",
-) -> _LanguageHandler:
-    """Build the language handler that queues a TTSUpdateSettingsFrame on language change."""
-    locked = normalize_lang_code(fixed_language) if fixed_language else ""
-    current = ""
-
-    async def handle(code: str) -> None:
-        nonlocal current
-        normalized = normalize_lang_code(locked or code)
-        if not normalized:
-            logger.warning(f"Multilingual: empty language code in LLM response: {code!r}")
-            return
-        if current.lower() == normalized.lower():
-            return
-        voice_map = load_voice_map()
-        voice_id = voice_map.get(normalized.lower())
-        if not voice_id:
-            logger.warning(f"Multilingual: language '{normalized}' not in voice catalog ({sorted(voice_map.keys())})")
-            return
-        current = normalized.lower()
-        try:
-            await task.queue_frame(
-                TTSUpdateSettingsFrame(
-                    delta=NvidiaTTSSettings(voice=voice_id, language=normalized),
-                    service=tts,
-                )
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(f"Multilingual: TTS settings update failed: {exc}")
-            return
-        logger.info(f"Multilingual: TTS → language={normalized}, voice={voice_id}")
-        if on_language_switched:
-            try:
-                await on_language_switched(normalized, voice_id)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(f"Multilingual: RTVI language notification failed: {exc}")
-
-    return handle
-
-
-class RTVISpokenTextEmitter(FrameProcessor):
-    """Mirror spoken-sentence aggregations as ``LLMTextFrame``s for RTVI.
-
-    Sits between ``LLMTextProcessor`` and TTS so RTVI's ``BotLlmText`` event
-    sees clean spoken text from a non-llm source. Mirrored frames carry
-    ``skip_tts=True`` (TTS already speaks via the AggregatedTextFrame path)
-    and ``append_to_context=False`` (the assistant aggregator already captures
-    the AggregatedTextFrame, so we must not double-add).
-    """
-
-    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
-        """Forward each frame; mirror spoken aggregations as ``LLMTextFrame``."""
-        await super().process_frame(frame, direction)
-        await self.push_frame(frame, direction)
-        if not isinstance(frame, AggregatedTextFrame):
-            return
-        if frame.aggregated_by in SKIP_TTS_AGGREGATIONS:
-            return
-        text = (frame.text or "").strip()
-        if not text:
-            return
-        mirror = LLMTextFrame(text=text)
-        mirror.skip_tts = True
-        mirror.append_to_context = False
-        await self.push_frame(mirror, direction)

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -3,9 +3,10 @@
 
 """Multilingual cascaded pipeline: NVIDIA STT -> Nemotron LLM -> Magpie TTS.
 
-Always runs in multilingual mode: the LLM emits ``Language: <code> Text: <reply>
-MetaData: <info>`` and the pipeline switches the TTS voice on every detected
-language change.
+The session is locked to a single language for the whole connection (selected in
+the UI, default ``de-DE``): the ASR, the TTS voice, and the LLM all operate in
+that one language. The LLM replies with plain spoken text, kept on-language by
+the fixed-session prompt addon plus a per-turn reminder.
 """
 
 import asyncio
@@ -24,8 +25,6 @@ from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
     LLMUserAggregatorParams,
 )
-from pipecat.processors.aggregators.llm_text_processor import LLMTextProcessor
-from pipecat.processors.frameworks.rtvi import RTVIObserverParams
 from pipecat.processors.frameworks.rtvi.frames import RTVIServerMessageFrame
 from pipecat.runner.types import RunnerArguments
 from pipecat.services.nvidia.llm import NvidiaLLMService, NvidiaLLMSettings
@@ -39,14 +38,13 @@ from pipecat.workers.runner import WorkerRunner
 
 import config_store
 from examples.multilingual.multilingual_processor import (
-    AUTO_DETECT_LANGUAGE_ADDON_KEY,
     FIXED_SESSION_GREETING_TRIGGER,
     FIXED_SESSION_LANGUAGE_ADDON_KEY,
-    SKIP_TTS_AGGREGATIONS,
-    MultilingualTextAggregator,
-    RTVISpokenTextEmitter,
+    PerTurnReminderProcessor,
+    build_reminder,
+    describe_language,
     get_lang_codes,
-    make_language_handler,
+    with_reasoning,
 )
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
@@ -73,6 +71,7 @@ from utils import (
 
 load_dotenv(override=True)
 CHAT_HISTORY_RECENT_TURNS = parse_env_int("CHAT_HISTORY_RECENT_TURNS", 10)
+DEFAULT_SESSION_LANGUAGE = "de-DE"
 
 
 def _build_multilingual_user_aggregator_params() -> LLMUserAggregatorParams:
@@ -93,29 +92,6 @@ def _build_multilingual_user_aggregator_params() -> LLMUserAggregatorParams:
             stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0)],
         ),
     )
-
-
-async def _build_multilingual_pipeline(
-    tts_server: str,
-    tts_voice: str,
-    asr_server: str,
-    asr_model: str,
-    asr_function_id: str,
-) -> tuple[MultilingualTextAggregator, LLMTextProcessor, RTVISpokenTextEmitter, str]:
-    """Prewarm the voice catalog and build the multilingual processors."""
-    if not config_store.get("tts"):
-        await asyncio.to_thread(prewarm_tts, tts_server, tts_voice)
-    await asyncio.to_thread(prewarm_asr, asr_server, asr_model, asr_function_id)
-    aggregator = MultilingualTextAggregator()
-    text_processor = LLMTextProcessor(text_aggregator=aggregator)
-    lang_codes = get_lang_codes(
-        asr_server=asr_server,
-        asr_model=asr_model,
-        asr_function_id=asr_function_id,
-        tts_server=tts_server,
-        tts_voice_id=tts_voice,
-    )
-    return aggregator, text_processor, RTVISpokenTextEmitter(), lang_codes
 
 
 async def bot(runner_args: RunnerArguments) -> None:
@@ -140,12 +116,15 @@ async def bot(runner_args: RunnerArguments) -> None:
         "server": asr_server,
         "use_ssl": asr_ssl,
     }
-    asr_function_id = body.get("asr_function_id", "") or default_asr.get("function_id", "")
+    raw_asr_function_id = body.get("asr_function_id")
+    asr_function_id = (
+        str(raw_asr_function_id) if raw_asr_function_id is not None else default_asr.get("function_id", "")
+    )
     asr_model = body.get("asr_model", "") or default_asr.get("model", "")
     asr_language_code = body.get("asr_language_code", "") or default_asr.get("language_code", "")
-    if asr_language_code and asr_language_code.strip().lower() == "auto":
-        asr_language_code = ""
-    fixed_session_language = normalize_lang_code(asr_language_code) if asr_language_code else ""
+    if not asr_language_code or asr_language_code.strip().lower() == "auto":
+        asr_language_code = DEFAULT_SESSION_LANGUAGE
+    fixed_session_language = normalize_lang_code(asr_language_code)
     if asr_function_id or asr_model:
         asr_kwargs["model_function_map"] = {
             "function_id": asr_function_id,
@@ -156,41 +135,69 @@ async def bot(runner_args: RunnerArguments) -> None:
     stt = NvidiaSTTService(**asr_kwargs, stop_history=400)
     logger.info(
         f"ASR: server={asr_server}, ssl={asr_ssl}, function_id={asr_function_id or '(default)'}, "
-        f"language={fixed_session_language or 'auto-detect'}"
+        f"language={fixed_session_language}"
+    )
+
+    tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
+    tts_ssl = is_nvcf(tts_server)
+    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "Magpie-Multilingual.EN-US.Aria")
+    if not config_store.get("tts"):
+        await asyncio.to_thread(prewarm_tts, tts_server, tts_voice)
+    await asyncio.to_thread(prewarm_asr, asr_server, asr_model, asr_function_id)
+    lang_codes = get_lang_codes(
+        asr_server=asr_server,
+        asr_model=asr_model,
+        asr_function_id=asr_function_id,
+        tts_server=tts_server,
+        tts_voice_id=tts_voice,
     )
 
     # --- LLM ---
     model_id = body.get("model_id", "") or default_llm.get("model_id", "nvidia/nemotron-3-nano-30b-a3b")
     base_url = body.get("base_url", "") or default_llm.get("base_url", "https://integrate.api.nvidia.com/v1")
     system_prompt = body.get("system_prompt", "") or default_llm.get("system_prompt", "")
-    extra_params = parse_json_dict(
+    base_extra = parse_json_dict(
         body.get("extra_params", "") or default_llm.get("extra_params", ""),
         label="extra_params",
     )
 
+    raw_temperature = body.get("temperature", "")
+    if raw_temperature in ("", None):
+        raw_temperature = default_llm.get("temperature", "")
+    llm_temperature = float(raw_temperature) if raw_temperature not in ("", None) else None
+
     logger.info(
         f"LLM: model={model_id}, base_url={base_url}, "
         f"system_prompt={'<' + system_prompt + '>' if system_prompt else '(none)'}, "
-        f"extra_params={extra_params or '(none)'}"
+        f"temperature={llm_temperature if llm_temperature is not None else '(default)'}, "
+        f"extra_params={base_extra or '(none)'}"
     )
 
     llm_settings = NvidiaLLMSettings(model=model_id)
-    if extra_params:
-        llm_settings.extra = extra_params
+    if base_extra:
+        llm_settings.extra = base_extra
+    if llm_temperature is not None:
+        llm_settings.temperature = llm_temperature
     llm = NvidiaLLMService(
         api_key=os.getenv("NVIDIA_API_KEY"),
         base_url=base_url,
         settings=llm_settings,
     )
 
-    # --- TTS ---
-    tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
-    tts_ssl = is_nvcf(tts_server)
-    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "Magpie-Multilingual.EN-US.Aria")
-    custom_dictionary = load_ipa_dictionary()
-    if not config_store.get("tts"):
-        await asyncio.to_thread(prewarm_tts, tts_server, tts_voice)
+    summary_extra = with_reasoning(base_extra, True)
+    summary_llm_settings = NvidiaLLMSettings(model=model_id)
+    if summary_extra:
+        summary_llm_settings.extra = summary_extra
+    if llm_temperature is not None:
+        summary_llm_settings.temperature = llm_temperature
+    summary_llm = NvidiaLLMService(
+        api_key=os.getenv("NVIDIA_API_KEY"),
+        base_url=base_url,
+        settings=summary_llm_settings,
+    )
 
+    # --- TTS ---
+    custom_dictionary = load_ipa_dictionary()
     tts_settings_kwargs: dict = {"voice": tts_voice}
     if fixed_session_language:
         tts_settings_kwargs["language"] = fixed_session_language
@@ -206,20 +213,6 @@ async def bot(runner_args: RunnerArguments) -> None:
         use_ssl=tts_ssl,
         text_filters=[NemotronSpeechTextFilter()],
         custom_dictionary=custom_dictionary,
-        skip_aggregator_types=list(SKIP_TTS_AGGREGATIONS),
-    )
-
-    (
-        multilingual_aggregator,
-        multilingual_text_processor,
-        multilingual_rtvi_emitter,
-        lang_codes,
-    ) = await _build_multilingual_pipeline(
-        tts_server,
-        tts_voice,
-        asr_server,
-        asr_model,
-        asr_function_id,
     )
 
     logger.info(
@@ -229,24 +222,13 @@ async def bot(runner_args: RunnerArguments) -> None:
     )
 
     # --- Context ---
-    if fixed_session_language:
-        prompt_catalog = load_prompt_catalog(__file__)
-        base_system_content = base_system_content.replace("{lang_codes}", fixed_session_language)
-        base_system_content = render_prompt_addon(
-            base_system_content,
-            prompt_catalog,
-            FIXED_SESSION_LANGUAGE_ADDON_KEY,
-            {"fixed_language": fixed_session_language, "lang_codes": fixed_session_language},
-        )
-    elif lang_codes:
-        prompt_catalog = load_prompt_catalog(__file__)
-        base_system_content = base_system_content.replace("{lang_codes}", lang_codes)
-        base_system_content = render_prompt_addon(
-            base_system_content,
-            prompt_catalog,
-            AUTO_DETECT_LANGUAGE_ADDON_KEY,
-            {"lang_codes": lang_codes},
-        )
+    prompt_catalog = load_prompt_catalog(__file__)
+    base_system_content = render_prompt_addon(
+        base_system_content,
+        prompt_catalog,
+        FIXED_SESSION_LANGUAGE_ADDON_KEY,
+        {"fixed_language_name": describe_language(fixed_session_language)},
+    )
 
     messages = build_context_messages(base_system_content, system_prompt)
     context = LLMContext(messages)
@@ -261,6 +243,8 @@ async def bot(runner_args: RunnerArguments) -> None:
         f"preserve_prompt_messages={preserve_prompt_messages}"
     )
 
+    reminder_processor = PerTurnReminderProcessor(build_reminder(fixed_session_language))
+
     audio_recorder = create_audio_recorder()
 
     pipeline = Pipeline(
@@ -268,9 +252,8 @@ async def bot(runner_args: RunnerArguments) -> None:
             transport.input(),
             stt,
             user_aggregator,
+            reminder_processor,
             llm,
-            multilingual_text_processor,
-            multilingual_rtvi_emitter,
             tts,
             transport.output(),
             *([audio_recorder] if audio_recorder else []),
@@ -286,7 +269,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         async with summary_lock:
             await apply_pinned_prompt_summary(
                 context=context,
-                llm=llm,
+                llm=summary_llm,
                 preserve_prompt_messages=preserve_prompt_messages,
                 recent_turns=CHAT_HISTORY_RECENT_TURNS,
                 summary_system_prompt=system_prompt,
@@ -344,10 +327,6 @@ async def bot(runner_args: RunnerArguments) -> None:
         idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
         observers=[latency_observer],
         enable_tracing=IS_TRACING_ENABLED,
-        rtvi_observer_params=RTVIObserverParams(
-            ignored_sources=[llm],
-            skip_aggregator_types=list(SKIP_TTS_AGGREGATIONS),
-        ),
     )
 
     @user_aggregator.event_handler("on_user_turn_stopped")
@@ -363,36 +342,12 @@ async def bot(runner_args: RunnerArguments) -> None:
             )
         )
 
-    async def _notify_language_switched(language: str, voice_id: str) -> None:
-        await task.queue_frame(
-            RTVIServerMessageFrame(
-                data={
-                    "type": "language-switched",
-                    "language": language,
-                    "voice_id": voice_id,
-                }
-            )
-        )
-
-    multilingual_aggregator.set_on_language(
-        make_language_handler(
-            tts,
-            task,
-            on_language_switched=_notify_language_switched,
-            fixed_language=fixed_session_language,
-        )
-    )
-
     @task.rtvi.event_handler("on_client_ready")
     async def on_client_connected(rtvi):
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if fixed_session_language:
-            context.add_message({"role": "user", "content": FIXED_SESSION_GREETING_TRIGGER})
-        else:
-            # Normal greeting so the LLM auto-detects language on the first LLMRunFrame turn.
-            context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
+        context.add_message({"role": "user", "content": FIXED_SESSION_GREETING_TRIGGER})
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/src/examples/multilingual/prompts.yaml
+++ b/src/examples/multilingual/prompts.yaml
@@ -1,109 +1,14 @@
 multilingual_voice_assistant:
-  description: "Multilingual voice assistant with language detection and key-value output format."
+  description: "Multilingual voice assistant that replies in the fixed session language."
   content: |
-    Your name is Atlas. You are a helpful multilingual voice assistant. Always answer as helpful, friendly, and polite.
-    Do not invent another name, role, business, or domain persona.
-    NEVER use asterisks (*), dashes (-), bullet points, or markdown formatting.
-    NEVER respond with bulleted or numbered lists - use simple sentences only.
-
-    # CRITICAL: MULTILINGUAL OUTPUT FORMAT
-
-    @ **RESPONSE FORMAT (MANDATORY)**
-    Your response MUST follow this key-value pair format STRICTLY:
-    Language: <LangCode> Text: <DirectResponse> MetaData: <AdditionalInfo>
-    DO NOT OUTPUT ANYTHING OUTSIDE THIS FORMAT.
-
-    @ **Field Definitions**
-    Language: The language code for this response (must follow session language rules below)
-    Text: ONLY the direct spoken response to user - nothing else (this will be spoken aloud)
-    MetaData: Any additional context, notes, or information NOT meant to be spoken (optional)
-
-    @ **LangCode Rules**
-    Allowed codes ONLY: {lang_codes}
-    Use exactly one code from the list above
-    Never invent or modify codes
-
-    @ **Text Field Rules (CRITICAL - MUST FOLLOW)**
-    Text MUST contain ONLY the direct response the user should hear
-    1 - 2 sentences maximum
-    Maximum of 200 characters
-    ABSOLUTELY NO ASTERISKS (*), NO DASHES (-), NO SLASHES (/), NO BULLET POINTS, NO MARKDOWN
-    NEVER use * or ** for formatting - this BREAKS the TTS system
-    NO lists of any kind - respond with simple conversational sentences only
-    No special characters, no translations, no explanations, no meta-commentary
-    Text must ALWAYS match the Language code (if Language: en-US, Text must be in English)
-    Write Text in each language's standard native writing system (e.g., Hindi → Devanagari, Russian → Cyrillic, Japanese → kana/kanji, German → Latin). Never use Romanized/Latin transliteration when the language has its own script (e.g., Namaste, Main Atlas hoon for hi-IN is wrong)
-    NEVER include translations, explanations, or meta-commentary in Text
-    NEVER echo/repeat the user's input in Text
-    If user asks for a list, summarize in 1-2 plain sentences instead
-
-    @ **MetaData Field Rules**
-    Use for any information NOT meant to be spoken aloud
-    Examples: detected intent, confidence notes, internal reasoning, rules, translations, note
-    Can be empty or omitted if no metadata needed
-    Always in English for consistency
-
-    @ **Good Examples**
-    1) Language: en-US Text: Hi, I am Atlas. How can I help you today? MetaData: greeting
-    2) Language: de-DE Text: Gerne! Welche Frage soll ich beantworten? MetaData: user requested German
-    3) Language: fr-FR Text: Bonjour! Je peux vous aider avec plaisir. MetaData: user greeted in French
-    4) Language: es-US Text: Hola! Puedo ayudarte con esa pregunta. MetaData: user requested Spanish
-    5) Language: it-IT Text: Posso spiegartelo in modo semplice. MetaData: user asked for a brief explanation
-    6) Language: hi-IN Text: नमस्ते! मैं अटलस हूँ, मैं आपकी कैसे मदद कर सकता हूँ? MetaData: User requested Hindi.
-    7) Language: hi-IN Text: एक छोटा सा चुटकुला: समय क्या है? MetaData: User requested a joke in Hindi.
-
-    @ **Bad Examples (DO NOT DO THIS)**
-    1) Language: de-DE Text: Gerne! Translation: Of course! (NO translations in Text)
-    2) Language: en-US Text: Sure, I can help. Let me explain... (Text too verbose)
-    3) Hello! How are you? (missing format entirely)
-    4) Language: de-DE Text: User wants help. Gerne! (meta-commentary in Text)
-    5) Language: ko-KR Text: 안녕하세요 (WRONG - Korean not in allowed list, must use en-US and English text)
-    6) Language: en-US Text: * Food * Venue * Budget (WRONG - NO asterisks or bullet points ever)
-    7) Language: en-US Text: **Requirements**: 1. Food 2. Venue (WRONG - NO markdown, NO numbered lists)
-    8) Language: hi-IN Text: Namaste! Main Atlas hoon... (WRONG - use the language's native script, not Romanized transliteration)
-
-    Your response MUST follow this format:
-    Language: <LangCode> Text: <DirectResponse> MetaData: <AdditionalInfo>
-    Text field is ONLY for what the user hears. Everything else goes in MetaData.
+    Your name is Atlas, a helpful, friendly, and polite multilingual voice assistant.
+    Do not invent another name, role, or persona.
+    
+    Write in the target language's standard native script (e.g. Hindi in Devanagari, not Romanized "Namaste").
+    Keep replies to 1-2 short sentences meant to be spoken aloud. Never use markdown, asterisks, dashes, slashes, bullet points, numbered lists, or emojis. Do not add translations, explanations, or repeat the user's words.
 
 fixed_session_language_addon:
-  description: Appended when the session language is locked for the whole connection.
+  description: Appended to lock the session to a single language for the whole connection.
   content: |
-    @ **FIXED SESSION LANGUAGE (MANDATORY — OVERRIDES EVERYTHING ABOVE)**
-    This session is LOCKED to {fixed_language} only. This is NOT auto-detect mode.
-    You MUST ALWAYS output Language: {fixed_language} on EVERY response, including the first greeting.
-    You MUST ALWAYS write the Text field in {fixed_language}, using its standard native writing system.
-    The user's spoken or written language does NOT matter. Do NOT mirror, detect, or switch to the user's language.
-    If the user speaks or writes in another language (e.g., English, German, French), still respond ONLY in {fixed_language}.
-    Do NOT use en-US, do NOT use any code other than {fixed_language}, even as a fallback.
-    Ignore every instruction above about multilingual switching, per-turn detection, or responding in the user's language.
-    Ignore the multilingual good examples above that show different Language codes — they do not apply to this session.
-    The only allowed Language code for this entire session is: {fixed_language}.
-    When you receive the message [session_start], greet the user briefly in {fixed_language}.
-
-    @ **Fixed-session good examples**
-    1) User: Tell me a joke (in English) → Language: {fixed_language} Text: [joke written only in {fixed_language}] MetaData: user language ignored
-    2) User: Bonjour (in French) → Language: {fixed_language} Text: [greeting written only in {fixed_language}] MetaData: stayed on locked language
-
-    @ **Fixed-session bad examples (DO NOT DO THIS)**
-    1) User speaks English → Language: en-US Text: Sure, here is a joke... (WRONG — session is locked; must use {fixed_language})
-    2) User speaks German → Language: de-DE Text: Gerne! ... (WRONG — must stay on {fixed_language})
-
-auto_detect_language_addon:
-  description: Appended when the session uses per-turn language auto-detection.
-  content: |
-    @ **AUTO-DETECT SESSION (MANDATORY)**
-    Detect the user's language independently on EVERY turn from their current speech or transcript.
-    IGNORE conversation history and prior assistant turns when choosing Language.
-    ALWAYS respond in the SAME language the user used in that turn.
-    When the user's message is in a supported language, you MUST set Language to that code and write Text in that same language.
-    Do NOT default to en-US when the user clearly spoke a supported language (e.g., Hindi → hi-IN, German → de-DE).
-    Set Language to the matching code from the allowed list and write Text in that language using its standard native writing system.
-    Allowed codes for this session: {lang_codes}
-    If unsure which supported code to use, use en-US.
-    Only use en-US when the user's message is in English or in a language NOT in the allowed list.
-    CRITICAL: If user speaks a language NOT in the allowed list (e.g., Korean, Arabic, Thai, Polish), you MUST use Language: en-US AND respond in English.
-    Do NOT lock the session to one language. Do NOT keep using a prior turn's Language when the user switches language.
-
-    @ **Auto-detect bad examples**
-    1) User spoke Hindi → Language: en-US Text: Ek chhoti si chutkula... (WRONG — must use Language: hi-IN and Hindi Text)
+    @ FIXED SESSION LANGUAGE (overrides everything above)
+    This session is locked to {fixed_language_name}. Always reply only in {fixed_language_name}, using its standard native script, regardless of the language the user speaks or writes. Do not mix in words, grammar, or spellings from any other language (for example, if the language uses Devanagari, do not slip into Marathi or Nepali). When you receive [session_start], greet the user briefly in {fixed_language_name}.

--- a/tests/test_multilingual_processor.py
+++ b/tests/test_multilingual_processor.py
@@ -5,90 +5,61 @@
 
 import unittest
 
-from examples.multilingual.multilingual_processor import LANG_TYPE, META_TYPE, MultilingualTextAggregator
+from examples.multilingual.multilingual_processor import (
+    PerTurnReminderProcessor,
+    build_reminder,
+    describe_language,
+    with_reasoning,
+)
 
 
-async def _collect_aggregations(chunks: list[str]):
-    aggregator = MultilingualTextAggregator()
-    aggregations = []
-    for chunk in chunks:
-        async for aggregation in aggregator.aggregate(chunk):
-            aggregations.append(aggregation)
-    while tail := await aggregator.flush():
-        aggregations.append(tail)
-    return aggregations
+class DescribeLanguageTests(unittest.TestCase):
+    def test_maps_known_subtag_to_name(self) -> None:
+        self.assertEqual(describe_language("de-DE"), "German (Deutsch)")
+
+    def test_falls_back_to_raw_code_for_unknown(self) -> None:
+        self.assertEqual(describe_language("xx-YY"), "xx-YY")
+
+    def test_empty_code_returns_empty(self) -> None:
+        self.assertEqual(describe_language(""), "")
 
 
-def _spoken_texts(aggregations) -> list[str]:
-    return [aggregation.text for aggregation in aggregations if aggregation.type not in {LANG_TYPE, META_TYPE}]
+class BuildReminderTests(unittest.TestCase):
+    def test_names_language_and_forbids_mixing(self) -> None:
+        reminder = build_reminder("hi-IN")
+        self.assertIn("Hindi", reminder)
+        self.assertIn("ONE single language", reminder)
+        self.assertNotIn("JSON", reminder)
 
 
-def _metadata_texts(aggregations) -> list[str]:
-    return [aggregation.text for aggregation in aggregations if aggregation.type == META_TYPE]
+class WithReasoningTests(unittest.TestCase):
+    def test_enables_thinking_without_mutating_input(self) -> None:
+        base = {"extra_body": {"repetition_penalty": 1.05}}
+        merged = with_reasoning(base, True)
+        self.assertTrue(merged["extra_body"]["chat_template_kwargs"]["enable_thinking"])
+        self.assertEqual(merged["extra_body"]["repetition_penalty"], 1.05)
+        self.assertNotIn("chat_template_kwargs", base["extra_body"])
+
+    def test_disables_thinking_on_empty_input(self) -> None:
+        merged = with_reasoning({}, False)
+        self.assertFalse(merged["extra_body"]["chat_template_kwargs"]["enable_thinking"])
 
 
-class MultilingualTextAggregatorTests(unittest.IsolatedAsyncioTestCase):
-    async def test_newline_metadata_is_not_spoken(self) -> None:
-        aggregations = await _collect_aggregations(
-            [
-                "Language: en-US Text: Hello there.",
-                "\nMetaData: internal note. This must not be spoken.",
-            ]
-        )
+class PerTurnReminderProcessorTests(unittest.IsolatedAsyncioTestCase):
+    async def test_appends_reminder_to_last_user_message(self) -> None:
+        processor = PerTurnReminderProcessor("REMINDER")
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ]
+        result = processor._append_reminder([dict(msg) for msg in messages])
+        self.assertEqual(result[-1]["content"], "hello\n\nREMINDER")
+        self.assertEqual(result[0]["content"], "sys")
 
-        self.assertEqual(_spoken_texts(aggregations), ["Hello there."])
-        self.assertTrue(any(aggregation.type == META_TYPE for aggregation in aggregations))
-
-    async def test_split_metadata_marker_is_not_spoken(self) -> None:
-        aggregations = await _collect_aggregations(
-            [
-                "Language: en-US Text: Hello there. Me",
-                "taData: hidden note.",
-            ]
-        )
-
-        self.assertEqual(_spoken_texts(aggregations), ["Hello there."])
-        self.assertTrue(
-            any(
-                aggregation.type == META_TYPE and aggregation.text == "MetaData: hidden note."
-                for aggregation in aggregations
-            )
-        )
-
-    async def test_only_text_field_is_spoken(self) -> None:
-        aggregations = await _collect_aggregations(
-            [
-                "Language: en-US Text: Hello there.MetaData: user intent. Extra reasoning after metadata.",
-            ]
-        )
-
-        self.assertEqual(_spoken_texts(aggregations), ["Hello there."])
-        self.assertEqual(
-            _metadata_texts(aggregations),
-            ["MetaData: user intent. Extra reasoning after metadata."],
-        )
-
-    async def test_missing_text_marker_drops_raw_output(self) -> None:
-        aggregations = await _collect_aggregations(
-            [
-                "Language: en-US Hello there. MetaData: hidden note.",
-            ]
-        )
-
-        self.assertEqual(aggregations, [])
-
-    async def test_flush_preserves_metadata_after_spoken_text(self) -> None:
-        aggregator = MultilingualTextAggregator()
-        async for _ in aggregator.aggregate("Language: en-US Text:"):
-            pass
-        aggregator._buf = "Hello there. MetaData: hidden note."
-
-        first = await aggregator.flush()
-        second = await aggregator.flush()
-
-        self.assertEqual(first.text if first else "", "Hello there.")
-        self.assertEqual(second.text if second else "", "MetaData: hidden note.")
-        self.assertEqual(second.type if second else "", META_TYPE)
+    async def test_appends_user_message_when_none_present(self) -> None:
+        processor = PerTurnReminderProcessor("REMINDER")
+        result = processor._append_reminder([{"role": "system", "content": "sys"}])
+        self.assertEqual(result[-1], {"role": "user", "content": "REMINDER"})
 
 
 if __name__ == "__main__":

--- a/tests/test_prompt_catalog.py
+++ b/tests/test_prompt_catalog.py
@@ -44,7 +44,6 @@ class PromptCatalogTests(unittest.TestCase):
                 "generic_assistant_without_tools",
             },
             PROJECT_ROOT / "src/examples/multilingual/prompts.yaml": {
-                "auto_detect_language_addon",
                 "fixed_session_language_addon",
                 "multilingual_voice_assistant",
             },

--- a/tests/test_service_catalog.py
+++ b/tests/test_service_catalog.py
@@ -152,7 +152,7 @@ llm:
             keys = examples_registry.agent_prompt_keys("multilingual-assistant")
         self.assertEqual(
             keys,
-            frozenset({"fixed_session_language_addon", "auto_detect_language_addon"}),
+            frozenset({"fixed_session_language_addon"}),
         )
 
     def test_multilingual_default_session_language_is_registry_declared(self) -> None:
@@ -160,7 +160,7 @@ llm:
 
         metadata = examples_registry.metadata(example)
 
-        self.assertEqual(metadata["default_session_language"], "es-US")
+        self.assertEqual(metadata["default_session_language"], "de-DE")
 
     def test_registry_defaults_promote_reachable_local_multilingual_asr(self) -> None:
         example = examples_registry._lookup_by_key("multilingual-assistant")
@@ -168,8 +168,8 @@ llm:
         with patch("examples_registry.is_endpoint_reachable", return_value=True):
             defaults = examples_registry.metadata(example)["defaults"]
 
-        self.assertEqual(defaults["asr"][0]["id"], "self-hosted:parakeet-rnnt")
-        self.assertEqual(defaults["asr"][0]["model"], "parakeet-1.1b-rnnt-multilingual-asr")
+        self.assertEqual(defaults["asr"][0]["id"], "self-hosted:nemotron-asr-streaming-multilingual")
+        self.assertEqual(defaults["asr"][0]["model"], "cache-aware-parakeet-rnnt-multi-asr-streaming-sortformer")
 
     def test_jetson_default_uses_reachable_nemotron_speech_asr(self) -> None:
         example = examples_registry._lookup_by_key("generic-assistant")


### PR DESCRIPTION
The session is now locked to a single UI-selected language for the whole connection (default de-DE) instead of per-turn auto-detection. The LLM replies with plain spoken text rather than the structured Language:/Text:/MetaData: (or JSON) contract, so responses flow straight to TTS and into a clean chat history.

- Remove auto-detect mode end to end: drop the auto_detect_language_addon, the empty-language pipeline branch, and the "Auto-detect (per turn)" UI option; default the session language to de-DE.
- Replace the structured LLM output contract with plain text: remove the streaming JSON aggregator, guided-JSON decoding, dynamic per-turn voice switching, and the shared json_stream helper.
- Keep the per-turn language reminder and the VAD-only user-turn-start strategy (interim ASR text must not start a turn).
- Update multilingual prompts, README, and the ASR/LLM docs; document the Nemotron ASR noisy-environment drop and Nemotron 3 Nano weaker-language quality (prefer Nemotron 3 Super).
- Update tests accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multilingual voice sessions now stay pinned to one selected language for the duration of a connection, with a new default language.
  * The app now better handles missing or unavailable session languages by automatically choosing a valid fallback.

* **Bug Fixes**
  * Improved language selection reliability in multilingual voice sessions and removed the previous auto-detect behavior.

* **Documentation**
  * Updated multilingual setup guides with the new fixed-language workflow and refreshed model guidance.

* **Tests**
  * Updated multilingual coverage to match the new session-language behavior and prompt rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->