### PR TITLE
Add chatterbox TTS support

### DIFF
--- a/benchmarking_tools/AA-BigBenchAudio-Eval/README.md
+++ b/benchmarking_tools/AA-BigBenchAudio-Eval/README.md
@@ -46,7 +46,7 @@ Listens on `http://localhost:7860`. Set `PIPELINE_TLS=true` or unset it to use H
 uv run python speech-inference.py --input_dir ./datasets/bigbench_audio --preprocess
 ```
 
-**Inference** — `POST /api/session-config` + WebSocket `/api/ws` per sample (same protocol as the Nemotron WebSocket client). Use **`http://` or `https://`** in `--server-url`; port defaults to **7860** if omitted.
+**Inference** — `POST /api/session-config` + WebSocket `/api/ws` per sample (same protocol as the Nemotron WebSocket client). Use **`http://` or `https://`** in `--server-url`. Port defaults to **7860** if omitted.
 
 ```bash
 uv run python speech-inference.py \

--- a/benchmarking_tools/scaling-perf/README.md
+++ b/benchmarking_tools/scaling-perf/README.md
@@ -116,7 +116,7 @@ uv run python3 benchmark.py
 # Concurrent run (4 parallel processes, single concurrency level)
 ./simulate_concurrency.sh --clients 4
 
-# Scaling sweep (one run per concurrency level; cooldown between levels)
+# Scaling sweep (one run per concurrency level, cooldown between levels)
 ./simulate_concurrency.sh --clients "1 2 4 8 16"
 ```
 
@@ -129,7 +129,7 @@ The shell wrapper accepts `-h`/`--help`. Common flags:
 | `--test-duration` | `300` | Seconds of metric collection per level. |
 | `--client-start-delay` | `1` | Stagger between clients connecting (s). With N clients and delay D, the metric window opens at ``now + (N-1)*D`` so every worker is connected before measurement starts. |
 | `--cooldown` | `10` | Pause between sweep levels (s) — lets the server settle between bursts. |
-| `--reverse-barge-in-threshold` | `0.4` | Bot audio arriving within this many seconds of the user finishing speaking is discarded as a *reverse* barge-in (the server racing the end of the user's utterance) instead of being timed as the real response. Used internally; not surfaced in summaries. |
+| `--reverse-barge-in-threshold` | `0.4` | Bot audio arriving within this many seconds of the user finishing speaking is discarded as a *reverse* barge-in (the server racing the end of the user's utterance) instead of being timed as the real response. Used internally. Not surfaced in summaries. |
 | `--no-save-audio` | (audio saved) | Skip writing per-client output WAVs. |
 | `--dataset-dir DIR` | `./dataset` | Override input WAV directory. |
 | `--output-dir DIR` | this folder | Override result destination. |

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -148,6 +148,7 @@ export function useDefaultTTS(pipelineMode = "") {
         id: e.id,
         name: e.name,
         server: String(e.server ?? ""),
+        model: e.model ? String(e.model) : undefined,
         voiceId: e.voice_id ? String(e.voice_id) : undefined,
         functionId: e.function_id ? String(e.function_id) : undefined,
         builtIn: true,
@@ -261,13 +262,26 @@ export function useVoiceCatalog(
   asrServer?: string,
   asrModel?: string,
   asrFunctionId?: string,
+  functionId?: string,
+  model?: string,
 ) {
   return useQuery<TTSConfig>({
-    queryKey: ["tts-config", server || "default", voiceId || "", asrServer || "", asrModel || "", asrFunctionId || ""],
+    queryKey: [
+      "tts-config",
+      server || "default",
+      voiceId || "",
+      functionId || "",
+      model || "",
+      asrServer || "",
+      asrModel || "",
+      asrFunctionId || "",
+    ],
     queryFn: () => {
       const params = new URLSearchParams();
       if (server) params.set("server", server);
       if (voiceId) params.set("voice_id", voiceId);
+      if (functionId) params.set("function_id", functionId);
+      if (model) params.set("model", model);
       if (asrServer) params.set("asr_server", asrServer);
       if (asrModel) params.set("asr_model", asrModel);
       if (asrFunctionId) params.set("asr_function_id", asrFunctionId);

--- a/client/src/components/VoiceSettings.tsx
+++ b/client/src/components/VoiceSettings.tsx
@@ -43,6 +43,8 @@ export function VoiceSettings() {
     sessionLanguagesEnabled ? selectedASR?.server : undefined,
     sessionLanguagesEnabled ? selectedASR?.model : undefined,
     sessionLanguagesEnabled ? selectedASR?.functionId : undefined,
+    selectedTTS?.functionId,
+    selectedTTS?.model,
   );
 
   const [voiceOverride, setVoiceOverride] = useState<VoiceOverrideState>({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ include:
   - path: docker/docker-compose.nemotron-asr.yaml
   - path: docker/docker-compose.parakeet-asr.yaml
   - path: docker/docker-compose.magpie-tts.yaml
+  - path: docker/docker-compose.chatterbox-tts.yaml
   - path: docker/docker-compose.nemotron3-omni.yaml
   - path: docker/docker-compose.speech-jetson.yaml
   - path: docker/docker-compose.coturn.yaml

--- a/docker/docker-compose.chatterbox-tts.yaml
+++ b/docker/docker-compose.chatterbox-tts.yaml
@@ -20,7 +20,7 @@ x-chatterbox-tts-service: &chatterbox-tts-service-base
       resources:
         reservations:
           devices:
-            # ~52.5 GB VRAM; keep off Magpie's GPU 0 when both run on workstation.
+            # ~52.5 GB VRAM; keep off Magpie's GPU 0 when both run.
             - driver: nvidia
               device_ids: ['1']
               capabilities: [gpu]
@@ -39,12 +39,10 @@ x-chatterbox-tts-service-env: &chatterbox-tts-service-env
 services:
   chatterbox-tts-service:
     <<: *chatterbox-tts-service-base
+    # Opt-in: do not attach to */workstation recipes (avoids reserving ~52.5 GB by default).
+    #   docker compose --profile <recipe> --profile chatterbox-tts up -d
     profiles:
-      - generic-assistant/workstation
-      - multilingual-assistant/workstation
-      - omni-assistant/workstation
-      - omni-assistant-subagents/workstation
-      - frontend-backend-agent/workstation
+      - chatterbox-tts
     environment:
       <<: *chatterbox-tts-service-env
       NIM_TAGS_SELECTOR: name=chatterbox-tts-multilingual

--- a/docker/docker-compose.chatterbox-tts.yaml
+++ b/docker/docker-compose.chatterbox-tts.yaml
@@ -1,0 +1,53 @@
+x-chatterbox-tts-service: &chatterbox-tts-service-base
+    # Pin to :latest until NGC publishes a stable numeric tag matching Magpie's cadence.
+    image: nvcr.io/nim/nvidia/chatterbox-tts-multilingual:latest
+    user: "0:0"
+    ports:
+      - "50153:50051"
+      - "9002:9000"
+    volumes:
+      - chatterbox_tts_cache:/opt/nim/.cache
+    shm_size: 16GB
+    ulimits:
+      nofile: 2048
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c 'import json, urllib.request; data=json.load(urllib.request.urlopen(\"http://127.0.0.1:9000/v1/health/ready\", timeout=5)); raise SystemExit(0 if data.get(\"status\") == \"ready\" or data.get(\"ready\") is True else 1)'"]
+      interval: 60s
+      timeout: 10s
+      retries: 10
+      start_period: 3000s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            # ~52.5 GB VRAM; keep off Magpie's GPU 0 when both run on workstation.
+            - driver: nvidia
+              device_ids: ['1']
+              capabilities: [gpu]
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+x-chatterbox-tts-service-env: &chatterbox-tts-service-env
+  NGC_API_KEY: ${NVIDIA_API_KEY}
+  NIM_HTTP_API_PORT: "9000"
+  NIM_GRPC_API_PORT: "50051"
+
+services:
+  chatterbox-tts-service:
+    <<: *chatterbox-tts-service-base
+    profiles:
+      - generic-assistant/workstation
+      - multilingual-assistant/workstation
+      - omni-assistant/workstation
+      - omni-assistant-subagents/workstation
+      - frontend-backend-agent/workstation
+    environment:
+      <<: *chatterbox-tts-service-env
+      NIM_TAGS_SELECTOR: name=chatterbox-tts-multilingual
+
+volumes:
+  chatterbox_tts_cache:

--- a/docker/docker-compose.chatterbox-tts.yaml
+++ b/docker/docker-compose.chatterbox-tts.yaml
@@ -1,51 +1,64 @@
-x-chatterbox-tts-service: &chatterbox-tts-service-base
-    # Pin to :latest until NGC publishes a stable numeric tag matching Magpie's cadence.
-    image: nvcr.io/nim/nvidia/chatterbox-tts-multilingual:latest
-    user: "0:0"
-    ports:
-      - "50153:50051"
-      - "9002:9000"
-    volumes:
-      - chatterbox_tts_cache:/opt/nim/.cache
-    shm_size: 16GB
-    ulimits:
-      nofile: 2048
-    healthcheck:
-      test: ["CMD-SHELL", "python3 -c 'import json, urllib.request; data=json.load(urllib.request.urlopen(\"http://127.0.0.1:9000/v1/health/ready\", timeout=5)); raise SystemExit(0 if data.get(\"status\") == \"ready\" or data.get(\"ready\") is True else 1)'"]
-      interval: 60s
-      timeout: 10s
-      retries: 10
-      start_period: 3000s
-    deploy:
-      resources:
-        reservations:
-          devices:
-            # ~52.5 GB VRAM; keep off Magpie's GPU 0 when both run.
-            - driver: nvidia
-              device_ids: ['1']
-              capabilities: [gpu]
-    restart: unless-stopped
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "5"
+# Chatterbox TTS Multilingual: alternate to Magpie.
+# Pin to :latest until NGC publishes a stable numeric tag matching Magpie's cadence.
+#
+# Opt-in alternate to Magpie (shared ports 50151/9000. Only one TTS can run):
+#   docker compose --profile <recipe>/workstation --profile chatterbox-tts \
+#     up -d --scale tts-service=0
+#   # same with <recipe>/dgx-spark instead of workstation
+# Omitting --profile chatterbox-tts leaves Chatterbox running and holding the
+# ports. Stop it before Magpie can bind again:
+#   docker compose --profile chatterbox-tts stop chatterbox-tts-service
+#   docker compose --profile <recipe>/workstation up -d
+# Then pick chatterbox-multilingual-tts (or Magpie) in the Services tab.
 
-x-chatterbox-tts-service-env: &chatterbox-tts-service-env
+x-chatterbox-tts-env: &chatterbox-tts-env
   NGC_API_KEY: ${NVIDIA_API_KEY}
   NIM_HTTP_API_PORT: "9000"
   NIM_GRPC_API_PORT: "50051"
+  # Single profile (~52.5 GB GPU / ~6.4 GB CPU). No batch_size selector.
+  NIM_TAGS_SELECTOR: name=chatterbox-tts-multilingual
+
+x-chatterbox-tts: &chatterbox-tts-base
+  image: nvcr.io/nim/nvidia/chatterbox-tts-multilingual:latest
+  user: "0:0"
+  environment:
+    <<: *chatterbox-tts-env
+  ports:
+    - "50151:50051"
+    - "9000:9000"
+  volumes:
+    - chatterbox_tts_cache:/opt/nim/.cache
+  shm_size: 16GB
+  ulimits:
+    nofile: 2048
+  healthcheck:
+    test: ["CMD-SHELL", "python3 -c 'import json, urllib.request; data=json.load(urllib.request.urlopen(\"http://127.0.0.1:9000/v1/health/ready\", timeout=5)); raise SystemExit(0 if data.get(\"status\") == \"ready\" or data.get(\"ready\") is True else 1)'"]
+    interval: 60s
+    timeout: 10s
+    retries: 10
+    start_period: 3000s
+  deploy:
+    resources:
+      reservations:
+        devices:
+          # ~52.5 GB VRAM. Edit device_ids if you want a second workstation GPU.
+          - driver: nvidia
+            device_ids: ['0']
+            capabilities: [gpu]
+  restart: unless-stopped
+  logging:
+    driver: "json-file"
+    options:
+      max-size: "50m"
+      max-file: "5"
 
 services:
   chatterbox-tts-service:
-    <<: *chatterbox-tts-service-base
-    # Opt-in: do not attach to */workstation recipes (avoids reserving ~52.5 GB by default).
-    #   docker compose --profile <recipe> --profile chatterbox-tts up -d
+    <<: *chatterbox-tts-base
+    environment:
+      <<: *chatterbox-tts-env
     profiles:
       - chatterbox-tts
-    environment:
-      <<: *chatterbox-tts-service-env
-      NIM_TAGS_SELECTOR: name=chatterbox-tts-multilingual
 
 volumes:
   chatterbox_tts_cache:

--- a/docker/docker-compose.chatterbox-tts.yaml
+++ b/docker/docker-compose.chatterbox-tts.yaml
@@ -1,5 +1,4 @@
 # Chatterbox TTS Multilingual: alternate to Magpie.
-# Pin to :latest until NGC publishes a stable numeric tag matching Magpie's cadence.
 #
 # Opt-in alternate to Magpie (shared ports 50151/9000. Only one TTS can run):
 #   docker compose --profile <recipe>/workstation --profile chatterbox-tts \
@@ -11,54 +10,46 @@
 #   docker compose --profile <recipe>/workstation up -d
 # Then pick chatterbox-multilingual-tts (or Magpie) in the Services tab.
 
-x-chatterbox-tts-env: &chatterbox-tts-env
-  NGC_API_KEY: ${NVIDIA_API_KEY}
-  NIM_HTTP_API_PORT: "9000"
-  NIM_GRPC_API_PORT: "50051"
-  # Single profile (~52.5 GB GPU / ~6.4 GB CPU). No batch_size selector.
-  NIM_TAGS_SELECTOR: name=chatterbox-tts-multilingual
-
-x-chatterbox-tts: &chatterbox-tts-base
-  image: nvcr.io/nim/nvidia/chatterbox-tts-multilingual:latest
-  user: "0:0"
-  environment:
-    <<: *chatterbox-tts-env
-  ports:
-    - "50151:50051"
-    - "9000:9000"
-  volumes:
-    - chatterbox_tts_cache:/opt/nim/.cache
-  shm_size: 16GB
-  ulimits:
-    nofile: 2048
-  healthcheck:
-    test: ["CMD-SHELL", "python3 -c 'import json, urllib.request; data=json.load(urllib.request.urlopen(\"http://127.0.0.1:9000/v1/health/ready\", timeout=5)); raise SystemExit(0 if data.get(\"status\") == \"ready\" or data.get(\"ready\") is True else 1)'"]
-    interval: 60s
-    timeout: 10s
-    retries: 10
-    start_period: 3000s
-  deploy:
-    resources:
-      reservations:
-        devices:
-          # ~52.5 GB VRAM. Edit device_ids if you want a second workstation GPU.
-          - driver: nvidia
-            device_ids: ['0']
-            capabilities: [gpu]
-  restart: unless-stopped
-  logging:
-    driver: "json-file"
-    options:
-      max-size: "50m"
-      max-file: "5"
-
 services:
   chatterbox-tts-service:
-    <<: *chatterbox-tts-base
-    environment:
-      <<: *chatterbox-tts-env
+    image: nvcr.io/nim/nvidia/chatterbox-tts-multilingual:1.0.0
+    user: "0:0"
     profiles:
       - chatterbox-tts
+    environment:
+      NGC_API_KEY: ${NVIDIA_API_KEY}
+      NIM_HTTP_API_PORT: "9000"
+      NIM_GRPC_API_PORT: "50051"
+      # Single profile (~52.5 GB GPU / ~6.4 GB CPU). No batch_size selector.
+      NIM_TAGS_SELECTOR: name=chatterbox-tts-multilingual
+    ports:
+      - "50151:50051"
+      - "9000:9000"
+    volumes:
+      - chatterbox_tts_cache:/opt/nim/.cache
+    shm_size: 16GB
+    ulimits:
+      nofile: 2048
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c 'import json, urllib.request; data=json.load(urllib.request.urlopen(\"http://127.0.0.1:9000/v1/health/ready\", timeout=5)); raise SystemExit(0 if data.get(\"status\") == \"ready\" or data.get(\"ready\") is True else 1)'"]
+      interval: 60s
+      timeout: 10s
+      retries: 10
+      start_period: 3000s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            # ~52.5 GB VRAM. Edit device_ids if you want a second workstation GPU.
+            - driver: nvidia
+              device_ids: ['0']
+              capabilities: [gpu]
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
 volumes:
   chatterbox_tts_cache:

--- a/docs/03-jetson-thor.md
+++ b/docs/03-jetson-thor.md
@@ -102,10 +102,10 @@ This guide covers deploying the Nemotron Voice Agent on Jetson Thor using Docker
 5. Start the full stack via Docker Compose. This brings up the LLM (vLLM), Riva speech, and the Pipecat pipeline together. Choose the profile for your example:
 
     ```bash
-    # Generic Cascaded — Riva ASR + TTS + vLLM LLM
+    # Generic Cascaded: Riva ASR + TTS + vLLM LLM
     docker compose --profile generic-assistant/jetson-thor up -d
 
-    # Nemotron Omni — local Omni vLLM + Riva TTS only (Omni does its own ASR; set service_enabled_asr=false in step 3d)
+    # Nemotron Omni: local Omni vLLM + Riva TTS only (Omni does its own ASR. Set service_enabled_asr=false in step 3d)
     docker compose --profile omni-assistant/jetson-thor up -d
     ```
 

--- a/docs/how-to/configure-asr.md
+++ b/docs/how-to/configure-asr.md
@@ -87,7 +87,7 @@ For ASR latency and throughput across GPUs and WER for different models, see the
   ```python
   stt = NvidiaSTTService(
       **asr_kwargs,
-      stop_history=400,       # ms trailing silence before finalizing (repo default; ≥560 favors accuracy)
+      stop_history=400,       # ms trailing silence before finalizing (repo default. ≥560 favors accuracy)
   )
   ```
 
@@ -100,7 +100,7 @@ For ASR latency and throughput across GPUs and WER for different models, see the
 asr:
   my-custom-asr:
     name: "My Custom ASR"
-    server: "grpc.nvcf.nvidia.com:443"   # cloud; local entries use the sidecar host:port
+    server: "grpc.nvcf.nvidia.com:443"   # cloud. Local entries use the sidecar host:port
     model: "my-asr-model"
     function_id: ""
 ```

--- a/docs/how-to/configure-llm.md
+++ b/docs/how-to/configure-llm.md
@@ -91,12 +91,12 @@ Nemotron LLMs support a chain-of-thought "thinking" mode, controlled per catalog
 
 ```yaml
 llm:
-  # Reasoning OFF — lowest latency (recommended default for spoken pipelines)
+  # Reasoning OFF: lowest latency (recommended default for spoken pipelines)
   nemotron-nano:
     model_id: "nvidia/nemotron-3-nano-30b-a3b"
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}'
 
-  # Reasoning ON — better on complex tasks, higher time-to-first-response
+  # Reasoning ON: better on complex tasks, higher time-to-first-response
   nemotron-nano-reasoning:
     model_id: "nvidia/nemotron-3-nano-30b-a3b"
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true}}}'

--- a/docs/how-to/configure-services.md
+++ b/docs/how-to/configure-services.md
@@ -90,7 +90,5 @@ tts:
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     model: "magpie-tts-multilingual"
     function_id: ""
-    # Optional. Magpie Multilingual uses ``stitched``; omit on other models to
-    # keep Pipecat's ``per_sentence`` default.
     synthesis_mode: stitched
 ```

--- a/docs/how-to/configure-services.md
+++ b/docs/how-to/configure-services.md
@@ -88,6 +88,7 @@ tts:
     name: "My Custom TTS"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
+    model: "magpie-tts-multilingual"
     function_id: ""
     # Optional. Magpie Multilingual uses ``stitched``; omit on other models to
     # keep Pipecat's ``per_sentence`` default.

--- a/docs/how-to/configure-services.md
+++ b/docs/how-to/configure-services.md
@@ -89,6 +89,6 @@ tts:
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     model: "magpie-tts-multilingual"
-    function_id: "<NVCF_FUNCTION_ID>"  # https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy
+    function_id: "<NVCF_FUNCTION_ID>"
     synthesis_mode: stitched
 ```

--- a/docs/how-to/configure-services.md
+++ b/docs/how-to/configure-services.md
@@ -89,4 +89,7 @@ tts:
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     function_id: ""
+    # Optional. Magpie Multilingual uses ``stitched``; omit on other models to
+    # keep Pipecat's ``per_sentence`` default.
+    synthesis_mode: stitched
 ```

--- a/docs/how-to/configure-services.md
+++ b/docs/how-to/configure-services.md
@@ -89,6 +89,6 @@ tts:
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     model: "magpie-tts-multilingual"
-    function_id: ""
+    function_id: "<NVCF_FUNCTION_ID>"  # https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy
     synthesis_mode: stitched
 ```

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -9,9 +9,16 @@ TTS services are declared per example in `services.cloud.yaml` (remote / NVCF) a
 | Model | Self-hosted compose service | Modelcard |
 |-------|-----------------------------|-----------|
 | **Magpie TTS Multilingual**: default, streaming multilingual TTS with per-language voices | [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml) | [model card](https://build.nvidia.com/nvidia/magpie-tts-multilingual/modelcard) |
-| **Chatterbox TTS Multilingual**: optional streaming multilingual TTS (workstation local + cloud) | [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml) | [model card](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) |
+| **Chatterbox TTS Multilingual**: alternate streaming multilingual TTS | [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml) | [model card](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) |
 
-Magpie TTS Multilingual is exposed as the catalog key `magpie-multilingual-tts` in `services.cloud.yaml` / `services.local.yaml`. Chatterbox is `chatterbox-multilingual-tts` (cloud everywhere; local under `workstation` only). Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). The available voices and emotions depend on the deployed NIM. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
+Each model is exposed as a **catalog key** in `services.cloud.yaml` / `services.local.yaml` (same pattern as ASR options such as Nemotron vs Parakeet):
+
+| Model | Catalog key | Default deploy? |
+|-------|-------------|-----------------|
+| Magpie TTS Multilingual | `magpie-multilingual-tts` | Yes — Magpie is the registry default and the TTS sidecar started by `*/workstation` / `*/dgx-spark` recipes |
+| Chatterbox TTS Multilingual | `chatterbox-multilingual-tts` | No — catalog option only; pick it in the Services tab (or change `defaults`) to replace Magpie. Cloud is always available; local NIM starts only with the opt-in Compose profile `chatterbox-tts` (like Parakeet’s `parakeet-ctc-asr` / `parakeet-rnnt-asr`) |
+
+Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). The available voices and emotions depend on the deployed NIM. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 
 > The active default per slot is set in [`examples_registry.yaml`](../../examples_registry.yaml) (`defaults`).
 
@@ -21,13 +28,16 @@ Magpie TTS Multilingual is exposed as the catalog key `magpie-multilingual-tts` 
 
 TTS runs one of three ways, and the repo wires the right one per profile:
 
-- **Cloud (NVCF)**: no local GPU, and the catalog calls `grpc.nvcf.nvidia.com`. The simplest starting point.
-- **Magpie TTS NIM sidecar**: on the `*/workstation` and `*/dgx-spark` profiles (`tts-service` on GPU `0` by default, [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml)).
+- **Cloud (NVCF)**: no local GPU, and the catalog calls `grpc.nvcf.nvidia.com`. Magpie and Chatterbox are both listed; switch in the Services tab.
+- **Magpie TTS NIM sidecar** (default local TTS): started by `*/workstation` and `*/dgx-spark` recipes (`tts-service` on GPU `0` by default, [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml)).
+- **Chatterbox TTS NIM sidecar** (opt-in alternate, not part of default recipes): add `--profile chatterbox-tts` when you want the local NIM (`chatterbox-tts-service` on GPU `1` by default, ~52.5 GB VRAM). Then select `chatterbox-multilingual-tts` in the Services tab (or set it in `defaults`) to use it instead of Magpie. See [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml).
 - **Riva embedded (Jetson Thor)**: on `*/jetson-thor`, on-device Riva serves TTS: `nemotron-speech` (ASR + TTS together) or `nemotron-speech-tts` (TTS only). See [Jetson Thor](../03-jetson-thor.md).
 
 ### VRAM & hardware support
 
-The TTS sidecar uses roughly **~14 GB VRAM** and, on local profiles, runs alongside the LLM and ASR. On a single ~80 GB GPU, TTS (~14 GB) + ASR (~15 GB) + the LLM (~30 GB FP8) fit together. To split them across GPUs, set `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support) for the full layout.
+**Magpie TTS** uses roughly **~14 GB VRAM** and, on local profiles, can share a single ~80 GB GPU with ASR (~15 GB) and the LLM (~30 GB FP8). To split Magpie across GPUs, set `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support) for that Magpie + ASR + LLM layout.
+
+**Chatterbox TTS** needs about **~52.5 GB VRAM** (Compose reserves a dedicated GPU, device `1` by default). It does **not** fit the Magpie single-80-GB shared layout with the LLM and ASR; run it on a separate GPU via the opt-in `chatterbox-tts` profile ([`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml)).
 
 ### Performance & scaling
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -11,12 +11,12 @@ TTS services are declared per example in `services.cloud.yaml` (remote / NVCF) a
 | **Magpie TTS Multilingual**: default, streaming multilingual TTS with per-language voices | [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml) | [model card](https://build.nvidia.com/nvidia/magpie-tts-multilingual/modelcard) |
 | **Chatterbox TTS Multilingual**: alternate streaming multilingual TTS | [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml) | [model card](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) |
 
-Each model is exposed as a **catalog key** in `services.cloud.yaml` / `services.local.yaml` (same pattern as ASR options such as Nemotron vs Parakeet):
+Each model is exposed as a **catalog key** in `services.cloud.yaml` / `services.local.yaml`:
 
-| Model | Catalog key | Default deploy? |
-|-------|-------------|-----------------|
-| Magpie TTS Multilingual | `magpie-multilingual-tts` | Yes — Magpie is the registry default and the TTS sidecar started by `*/workstation` / `*/dgx-spark` recipes |
-| Chatterbox TTS Multilingual | `chatterbox-multilingual-tts` | No — catalog option only; pick it in the Services tab (or change `defaults`) to replace Magpie. Cloud is always available; local NIM starts only with the opt-in Compose profile `chatterbox-tts` (like Parakeet’s `parakeet-ctc-asr` / `parakeet-rnnt-asr`) |
+| Model | Catalog key | Default? |
+|-------|-------------|----------|
+| Magpie TTS Multilingual | `magpie-multilingual-tts` | Yes (registry default. Local recipes start Magpie) |
+| Chatterbox TTS Multilingual | `chatterbox-multilingual-tts` | No. Select in the Services tab (or `defaults.tts`) |
 
 Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). The available voices and emotions depend on the deployed NIM. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 
@@ -28,26 +28,33 @@ Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Ch
 
 TTS runs one of three ways, and the repo wires the right one per profile:
 
-- **Cloud (NVCF)**: no local GPU, and the catalog calls `grpc.nvcf.nvidia.com`. Magpie and Chatterbox are both listed; switch in the Services tab.
-- **Magpie TTS NIM sidecar** (default local TTS): started by `*/workstation` and `*/dgx-spark` recipes (`tts-service` on GPU `0` by default, [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml)).
-- **Chatterbox TTS NIM sidecar** (opt-in alternate, not part of default recipes): add `--profile chatterbox-tts` when you want the local NIM (`chatterbox-tts-service` on GPU `1` by default, ~52.5 GB VRAM). Then select `chatterbox-multilingual-tts` in the Services tab (or set it in `defaults`) to use it instead of Magpie. See [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml).
+- **Cloud (NVCF)**: no local GPU. Magpie and Chatterbox both appear in the Services tab. Pick either one (no Compose change).
+- **Magpie TTS (default local)**: started by `*/workstation` and `*/dgx-spark` recipes as `tts-service` ([`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml)).
+- **Chatterbox TTS (local alternate)**: listed in Compose but does **not** start with the default recipe. Enable the opt-in profile and scale Magpie off (they share ports `50151`/`9000`):
+
+  ```bash
+  docker compose --profile generic-assistant/workstation --profile chatterbox-tts \
+    up -d --scale tts-service=0
+  ```
+
+  Same with `generic-assistant/dgx-spark` (or any other recipe). Omitting `--profile chatterbox-tts` leaves Chatterbox running and holding the ports. Stop it before Magpie can bind again (`docker compose --profile chatterbox-tts stop chatterbox-tts-service`, then recipe `up -d`). Then select the matching catalog key in the Services tab (or `defaults.tts`). See [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml).
 - **Riva embedded (Jetson Thor)**: on `*/jetson-thor`, on-device Riva serves TTS: `nemotron-speech` (ASR + TTS together) or `nemotron-speech-tts` (TTS only). See [Jetson Thor](../03-jetson-thor.md).
 
 ### VRAM & hardware support
 
 **Magpie TTS** uses roughly **~14 GB VRAM** and, on local profiles, can share a single ~80 GB GPU with ASR (~15 GB) and the LLM (~30 GB FP8). To split Magpie across GPUs, set `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support) for that Magpie + ASR + LLM layout.
 
-**Chatterbox TTS** needs about **~52.5 GB VRAM** (Compose reserves a dedicated GPU, device `1` by default). It does **not** fit the Magpie single-80-GB shared layout with the LLM and ASR; run it on a separate GPU via the opt-in `chatterbox-tts` profile ([`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml)).
+**Chatterbox TTS** needs about **~52.5 GB VRAM** (~6.4 GB CPU) with Compose profile `NIM_TAGS_SELECTOR=name=chatterbox-tts-multilingual` (GPU `0` by default, same as Magpie). It does **not** fit the Magpie single-80-GB shared layout with the LLM and ASR on a typical workstation GPU. Locally it uses the same ports as Magpie, so scale Magpie off when starting Chatterbox ([`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml)).
 
 ### Performance & scaling
 
-`batch_size` (set on the Magpie service via `NIM_TAGS_SELECTOR=name=magpie-tts-multilingual,batch_size=8`) is the main throughput knob. Tune it per deployment shape, and benchmark before raising it on shared single-GPU profiles. For first-chunk / inter-chunk latency and throughput (RTFX) across GPUs, see the **[TTS performance benchmarks](https://docs.nvidia.com/nim/speech/latest/reference/performances/tts/performance.html)**. For end-to-end pipeline latency (TTS time-to-first-byte) in this blueprint, see [Evaluation and Performance](../04-evaluation-and-performance.md).
+`batch_size` (set on the Magpie service via `NIM_TAGS_SELECTOR=name=magpie-tts-multilingual,batch_size=8`) is the main Magpie throughput knob. Tune it per deployment shape, and benchmark before raising it on shared single-GPU profiles. Chatterbox exposes a **single** profile (`name=chatterbox-tts-multilingual`) with no `batch_size` selector. For first-chunk / inter-chunk latency and throughput (RTFX) across GPUs, see the **[TTS performance benchmarks](https://docs.nvidia.com/nim/speech/latest/reference/performances/tts/performance.html)**. For end-to-end pipeline latency (TTS time-to-first-byte) in this blueprint, see [Evaluation and Performance](../04-evaluation-and-performance.md).
 
 ## Customization
 
 ### Voices & emotions
 
-The active voice is the `voice_id` in the catalog entry. The client UI also has a voice selector that auto-discovers the connected service's available voices and languages, so you can switch mid-session. Voice IDs follow `Model.Language.VoiceName` (e.g. `Magpie-Multilingual.EN-US.Aria`), and Magpie also supports emotional styles. Available voices/emotions depend on your Magpie version (and can be discovered at runtime over gRPC/HTTP). See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
+The active voice is the `voice_id` in the catalog entry. The client UI also has a voice selector that auto-discovers the connected service's available voices and languages, so you can switch mid-session. Voice IDs follow `Model.Language.VoiceName` (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). Magpie supports multiple voices and emotional styles per locale. Chatterbox ships **one default speaker per locale**. Available voices/emotions depend on the deployed NIM (and can be discovered at runtime over gRPC/HTTP). See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 
 To change the **default**, edit `voice_id` in the example's `services.cloud.yaml` / `services.local.yaml`. For a local Magpie NIM, point the entry at the sidecar (`tts-service:50051`) under the active platform block. See [Configure Services](configure-services.md).
 
@@ -55,11 +62,11 @@ To change the **default**, edit `voice_id` in the example's `services.cloud.yaml
 tts:
   magpie-multilingual-tts:
     name: "Magpie TTS Multilingual"
-    server: "grpc.nvcf.nvidia.com:443"   # cloud; local entries use the sidecar host:port (e.g. tts-service:50051)
+    server: "grpc.nvcf.nvidia.com:443"   # cloud. Local entries use the sidecar host:port (e.g. tts-service:50051)
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     model: "magpie-tts-multilingual"
     function_id: "877104f7-e885-42b9-8de8-f6e4c6303969"
-    synthesis_mode: stitched             # Magpie; omit on other models to keep per_sentence
+    synthesis_mode: stitched
 
   chatterbox-multilingual-tts:
     name: "Chatterbox TTS Multilingual"
@@ -67,10 +74,9 @@ tts:
     voice_id: "Chatterbox-Multilingual.en-US.Male"
     model: "chatterbox-tts-multilingual"
     function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
-    # no synthesis_mode → Pipecat per_sentence
 ```
 
-Catalog `model` + `function_id` are hydrated into the session and passed to Pipecat's `NvidiaTTSService` as `model_function_map` (same pattern as ASR). Magpie remains the registry default; pick Chatterbox in the Services tab to switch.
+Catalog `model` + `function_id` are hydrated into the session and passed to Pipecat's `NvidiaTTSService` as `model_function_map`. Magpie remains the registry default. Pick Chatterbox in the Services tab to switch.
 
 ### Synthesis mode
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -10,7 +10,7 @@ TTS services are declared per example in `services.cloud.yaml` (remote / NVCF) a
 |-------|-----------------------------|-----------|
 | **Magpie TTS Multilingual**: default, streaming multilingual TTS with per-language voices | [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml) | [model card](https://build.nvidia.com/nvidia/magpie-tts-multilingual/modelcard) |
 
-Magpie TTS Multilingual is exposed as the catalog key `magpie-tts` in `services.cloud.yaml` / `services.local.yaml`. Voice IDs follow `Model.Language.VoiceName` (e.g. `Magpie-Multilingual.EN-US.Aria`). The available voices and emotions depend on your Magpie version. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
+Magpie TTS Multilingual is exposed as the catalog key `magpie-multilingual-tts` in `services.cloud.yaml` / `services.local.yaml`. Voice IDs follow `Model.Language.VoiceName` (e.g. `Magpie-Multilingual.EN-US.Aria`). The available voices and emotions depend on your Magpie version. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 
 > The active default per slot is set in [`examples_registry.yaml`](../../examples_registry.yaml) (`defaults`).
 
@@ -42,12 +42,24 @@ To change the **default**, edit `voice_id` in the example's `services.cloud.yaml
 
 ```yaml
 tts:
-  magpie-tts:
+  magpie-multilingual-tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"   # cloud; local entries use the sidecar host:port (e.g. tts-service:50051)
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     function_id: ""
+    synthesis_mode: stitched             # Magpie; omit on other models to keep per_sentence
 ```
+
+### Synthesis mode
+
+Pipecat's `NvidiaTTSService` supports two synthesis modes via the catalog field `synthesis_mode`:
+
+| Value | Behavior |
+|-------|----------|
+| `stitched` | Reuse one Magpie `SynthesizeOnline` stream across sentences in a reply (smoother multi-sentence audio). Use this for Magpie multilingual / zero-shot ≥ v1.7.0. |
+| `per_sentence` | Open a fresh synthesis call per sentence. Safe for models without cross-sentence stitching. |
+
+Set `synthesis_mode` on the catalog entry (hydrated as `tts_synthesis_mode`). Magpie ships with `stitched`. Omit the field on other models to leave Pipecat's default (`per_sentence`).
 
 ### Pronunciation (IPA)
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -9,8 +9,9 @@ TTS services are declared per example in `services.cloud.yaml` (remote / NVCF) a
 | Model | Self-hosted compose service | Modelcard |
 |-------|-----------------------------|-----------|
 | **Magpie TTS Multilingual**: default, streaming multilingual TTS with per-language voices | [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml) | [model card](https://build.nvidia.com/nvidia/magpie-tts-multilingual/modelcard) |
+| **Chatterbox TTS Multilingual**: optional streaming multilingual TTS (workstation local + cloud) | [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml) | [model card](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) |
 
-Magpie TTS Multilingual is exposed as the catalog key `magpie-multilingual-tts` in `services.cloud.yaml` / `services.local.yaml`. Voice IDs follow `Model.Language.VoiceName` (e.g. `Magpie-Multilingual.EN-US.Aria`). The available voices and emotions depend on your Magpie version. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
+Magpie TTS Multilingual is exposed as the catalog key `magpie-multilingual-tts` in `services.cloud.yaml` / `services.local.yaml`. Chatterbox is `chatterbox-multilingual-tts` (cloud everywhere; local under `workstation` only). Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). The available voices and emotions depend on the deployed NIM. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 
 > The active default per slot is set in [`examples_registry.yaml`](../../examples_registry.yaml) (`defaults`).
 
@@ -46,9 +47,20 @@ tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"   # cloud; local entries use the sidecar host:port (e.g. tts-service:50051)
     voice_id: "Magpie-Multilingual.EN-US.Aria"
-    function_id: ""
+    model: "magpie-tts-multilingual"
+    function_id: "877104f7-e885-42b9-8de8-f6e4c6303969"
     synthesis_mode: stitched             # Magpie; omit on other models to keep per_sentence
+
+  chatterbox-multilingual-tts:
+    name: "Chatterbox TTS Multilingual"
+    server: "grpc.nvcf.nvidia.com:443"
+    voice_id: "Chatterbox-Multilingual.en-US.Male"
+    model: "chatterbox-tts-multilingual"
+    function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
+    # no synthesis_mode → Pipecat per_sentence
 ```
+
+Catalog `model` + `function_id` are hydrated into the session and passed to Pipecat's `NvidiaTTSService` as `model_function_map` (same pattern as ASR). Magpie remains the registry default; pick Chatterbox in the Services tab to switch.
 
 ### Synthesis mode
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -6,17 +6,12 @@ TTS services are declared per example in `services.cloud.yaml` (remote / NVCF) a
 
 ## Models
 
-| Model | Self-hosted compose service | Modelcard |
-|-------|-----------------------------|-----------|
-| **Magpie TTS Multilingual**: default, streaming multilingual TTS with per-language voices | [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml) | [model card](https://build.nvidia.com/nvidia/magpie-tts-multilingual/modelcard) |
-| **Chatterbox TTS Multilingual**: alternate streaming multilingual TTS | [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml) | [model card](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) |
+| Model | Catalog key | Self-hosted compose service | Modelcard |
+|-------|-------------|-----------------------------|-----------|
+| **Magpie TTS Multilingual**: default, streaming multilingual TTS with per-language voices | `magpie-multilingual-tts` | [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml) | [model card](https://build.nvidia.com/nvidia/magpie-tts-multilingual/modelcard) |
+| **Chatterbox TTS Multilingual**: alternate streaming multilingual TTS | `chatterbox-multilingual-tts` | [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml) | [model card](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) |
 
-Each model is exposed as a **catalog key** in `services.cloud.yaml` / `services.local.yaml`:
-
-| Model | Catalog key | Default? |
-|-------|-------------|----------|
-| Magpie TTS Multilingual | `magpie-multilingual-tts` | Yes (registry default. Local recipes start Magpie) |
-| Chatterbox TTS Multilingual | `chatterbox-multilingual-tts` | No. Select in the Services tab (or `defaults.tts`) |
+> Magpie is the registry default and the TTS sidecar started by local recipes. Chatterbox is opt-in: select `chatterbox-multilingual-tts` in the Services tab (or `defaults.tts`). For local NIM, also enable the `chatterbox-tts` Compose profile (see [Hardware requirements](#hardware-requirements-and-deployment-configs)).
 
 Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). The available voices and emotions depend on the deployed NIM. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 

--- a/docs/how-to/enable-opentelemetry-tracing.md
+++ b/docs/how-to/enable-opentelemetry-tracing.md
@@ -19,8 +19,8 @@ OpenTelemetry tracing provides observability for the cascaded voice pipelines, a
     ```
 
     If the stack is already running, the same command recreates the app container with the new settings, so no separate restart is needed. The `phoenix` service (defined in `docker/docker-compose.phoenix.yaml` and included by the root compose file) exposes:
-    - **Port 6006** — Phoenix UI
-    - **Port 4317** — OTLP gRPC collector
+    - **Port 6006**: Phoenix UI
+    - **Port 4317**: OTLP gRPC collector
 
 3. Open the Phoenix UI.
 
@@ -39,17 +39,17 @@ OpenTelemetry tracing provides observability for the cascaded voice pipelines, a
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:4317` | OTLP collector endpoint |
 
 **Endpoint format:**
-- **gRPC** (port 4317): `host:port` — e.g. `phoenix:4317` or `localhost:4317`
-- **HTTP** (port 4318 or custom): `http://host:port` — e.g. `http://phoenix:4318`
+- **gRPC** (port 4317): `host:port` (e.g. `phoenix:4317` or `localhost:4317`)
+- **HTTP** (port 4318 or custom): `http://host:port` (e.g. `http://phoenix:4318`)
 
 ## Trace Structure
 
 ```
 Conversation
 ├── turn
-│   ├── stt          (ASR — user speech to text)
-│   ├── llm          (LLM — generate response)
-│   └── tts          (TTS — synthesise audio)
+│   ├── stt          (ASR: user speech to text)
+│   ├── llm          (LLM: generate response)
+│   └── tts          (TTS: synthesise audio)
 └── turn ...
 ```
 
@@ -63,6 +63,6 @@ Conversation
 
 ## Alternative Backends
 
-Any OTLP-compatible backend works — Jaeger, Grafana Tempo, Langfuse, Datadog, etc. Point `OTEL_EXPORTER_OTLP_ENDPOINT` at your collector and the traces will flow there instead of Phoenix.
+Any OTLP-compatible backend works (Jaeger, Grafana Tempo, Langfuse, Datadog, etc.). Point `OTEL_EXPORTER_OTLP_ENDPOINT` at your collector and the traces will flow there instead of Phoenix.
 
 See the [Pipecat OpenTelemetry docs](https://docs.pipecat.ai/server/utilities/opentelemetry) for additional exporter options.

--- a/docs/how-to/enable-opentelemetry-tracing.md
+++ b/docs/how-to/enable-opentelemetry-tracing.md
@@ -44,7 +44,7 @@ OpenTelemetry tracing provides observability for the cascaded voice pipelines, a
 
 ## Trace Structure
 
-```
+```text
 Conversation
 ├── turn
 │   ├── stt          (ASR: user speech to text)

--- a/docs/how-to/tune-pipeline-performance.md
+++ b/docs/how-to/tune-pipeline-performance.md
@@ -79,7 +79,7 @@ When the message count exceeds `CHAT_HISTORY_RECENT_TURNS`:
 `AUDIO_OUT_10MS_CHUNKS` sets how many 10 ms audio frames the server batches per outbound send (the output buffer depth). Defaults are `5` (50 ms).
 
 ```bash
-# In .env — override the transport default
+# In .env: override the transport default
 AUDIO_OUT_10MS_CHUNKS=10
 ```
 
@@ -132,6 +132,6 @@ Both transports are exposed by default and the browser UI picks one. To restrict
 | `websocket` | WebSocket only |
 
 ```bash
-# .env — e.g. expose only WebSocket for a telephony / server-side deployment
+# .env: e.g. expose only WebSocket for a telephony / server-side deployment
 TRANSPORT_SELECTION=websocket
 ```

--- a/examples_registry.yaml
+++ b/examples_registry.yaml
@@ -28,7 +28,7 @@ examples:
       prompt: [generic_assistant]
       llm: [nemotron-nano]
       asr: [nemotron-asr-streaming-english]
-      tts: [magpie-tts]
+      tts: [magpie-multilingual-tts]
     bot: examples.generic.pipeline:bot
 
   multilingual-assistant:
@@ -42,7 +42,7 @@ examples:
       prompt: [multilingual_voice_assistant]
       llm: [nemotron-super]
       asr: [nemotron-asr-streaming-multilingual]
-      tts: [magpie-tts]
+      tts: [magpie-multilingual-tts]
     bot: examples.multilingual.pipeline:bot
 
   omni-assistant:
@@ -51,7 +51,7 @@ examples:
     defaults:
       prompt: [generic_omni_assistant]
       llm: [nemotron-omni-nvfp4]
-      tts: [magpie-tts]
+      tts: [magpie-multilingual-tts]
     bot: examples.omni_assistant.pipeline:bot
 
   omni-assistant-subagents:
@@ -61,7 +61,7 @@ examples:
     defaults:
       prompt: [generic_omni_assistant]
       llm: [nemotron-omni-nvfp4]
-      tts: [magpie-tts]
+      tts: [magpie-multilingual-tts]
     bot: examples.omni_assistant_subagents.pipeline:bot
 
   frontend-backend-agent:
@@ -73,5 +73,5 @@ examples:
       thinker-llm: [nemotron-nano]
       booking-server: [default]
       asr: [nemotron-asr-streaming-english]
-      tts: [magpie-tts]
+      tts: [magpie-multilingual-tts]
     bot: examples.frontend_backend_agent.pipeline:bot

--- a/skills/configure-pipeline/SKILL.md
+++ b/skills/configure-pipeline/SKILL.md
@@ -36,9 +36,9 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
    - `<example-package>/prompts.yaml`: built-in prompt presets and prompt content for the active example.
 
 3. Validate:
-   - Multilingual prompts must use multilingual-capable ASR and TTS from the active catalog (e.g. `parakeet-rnnt`, `nemotron-asr-streaming-multilingual`, `magpie-multilingual-tts`). Verify the keys exist before referencing them.
-   - Local catalog endpoints must use Compose service names (`nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `parakeet-ctc-asr:50052`, `parakeet-rnnt-asr:50052`, `tts-service:50051`, `nvidia-llm:8000`, `nvidia-llm-vllm:8000`, `nvidia-llm-vllm-omni:8002`, `nemotron-speech:50051`, `booking-server:8001`). Host-run backends auto-rewrite to the matching `localhost` ports.
-   - ASR/TTS variants are selected via Compose profile (e.g. `parakeet-ctc-asr`, `parakeet-rnnt-asr`).
+   - Multilingual prompts must use multilingual-capable ASR and TTS from the active catalog (e.g. `parakeet-rnnt`, `nemotron-asr-streaming-multilingual`, `magpie-multilingual-tts`, `chatterbox-multilingual-tts`). Verify the keys exist before referencing them.
+   - Local catalog endpoints must use Compose service names (`nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `parakeet-ctc-asr:50052`, `parakeet-rnnt-asr:50052`, `tts-service:50051`, `chatterbox-tts-service:50051`, `nvidia-llm:8000`, `nvidia-llm-vllm:8000`, `nvidia-llm-vllm-omni:8002`, `nemotron-speech:50051`, `booking-server:8001`). Host-run backends auto-rewrite to the matching `localhost` ports.
+   - Alternate local ASR/TTS use Compose profiles (`parakeet-ctc-asr`, `parakeet-rnnt-asr`, `chatterbox-tts`) and share ports with the default. Scale the default off (e.g. `--scale tts-service=0` or `--scale nemotron-asr-streaming-multilingual=0`). Stop an opt-in alternate before returning to the default if it still holds the shared ports.
    - Workstation local Compose runs ASR/TTS and NIM LLM on GPU `0` by default. Single-GPU deployments are supported only when at least 80 GB of VRAM is available.
 
 4. Apply and verify using `references/apply-changes.md`.
@@ -48,7 +48,7 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
 - `.env` changes: compose re-apply.
 - YAML catalog changes (`prompts.yaml`, `services.*.yaml`, `examples_registry.yaml`): compose restart of the example service. `./src` and `./examples_registry.yaml` are bind-mounted, so no rebuild needed.
 - Preserve unrelated keys, comments, and entries while editing.
-- ASR/TTS variants are selected by Compose profile. Parakeet variants use dedicated `parakeet-ctc-asr` / `parakeet-rnnt-asr` services; Magpie TTS uses `tts-service`.
+- Alternate local ASR/TTS use Compose profiles where needed (`parakeet-ctc-asr`, `parakeet-rnnt-asr`, `chatterbox-tts`). Magpie TTS uses `tts-service`.
 - Per-example slot defaults live in `examples_registry.yaml` `defaults`. The catalog file ordering only affects UI listings. The actual default is whatever `defaults` declares.
 
 ## Examples
@@ -62,7 +62,7 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
 
 1. Add the prompt to the active example's `prompts.yaml`.
 2. To make it the per-example default, update `examples_registry.yaml` `defaults.prompt` for that example to the new prompt key.
-3. Ensure the active example's catalog has multilingual-capable ASR (`parakeet-rnnt` or `nemotron-asr-streaming-multilingual`) and TTS (`magpie-multilingual-tts`).
+3. Ensure the active example's catalog has multilingual-capable ASR (`parakeet-rnnt` or `nemotron-asr-streaming-multilingual`) and TTS (`magpie-multilingual-tts` or `chatterbox-multilingual-tts`).
 4. Compose restart of the example service and refresh browser.
 
 ## Limitations

--- a/skills/configure-pipeline/SKILL.md
+++ b/skills/configure-pipeline/SKILL.md
@@ -36,7 +36,7 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
    - `<example-package>/prompts.yaml`: built-in prompt presets and prompt content for the active example.
 
 3. Validate:
-   - Multilingual prompts must use multilingual-capable ASR and TTS from the active catalog (e.g. `parakeet-rnnt`, `nemotron-asr-streaming-multilingual`, `magpie-tts`). Verify the keys exist before referencing them.
+   - Multilingual prompts must use multilingual-capable ASR and TTS from the active catalog (e.g. `parakeet-rnnt`, `nemotron-asr-streaming-multilingual`, `magpie-multilingual-tts`). Verify the keys exist before referencing them.
    - Local catalog endpoints must use Compose service names (`nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `parakeet-ctc-asr:50052`, `parakeet-rnnt-asr:50052`, `tts-service:50051`, `nvidia-llm:8000`, `nvidia-llm-vllm:8000`, `nvidia-llm-vllm-omni:8002`, `nemotron-speech:50051`, `booking-server:8001`). Host-run backends auto-rewrite to the matching `localhost` ports.
    - ASR/TTS variants are selected via Compose profile (e.g. `parakeet-ctc-asr`, `parakeet-rnnt-asr`).
    - Workstation local Compose runs ASR/TTS and NIM LLM on GPU `0` by default. Single-GPU deployments are supported only when at least 80 GB of VRAM is available.
@@ -62,7 +62,7 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
 
 1. Add the prompt to the active example's `prompts.yaml`.
 2. To make it the per-example default, update `examples_registry.yaml` `defaults.prompt` for that example to the new prompt key.
-3. Ensure the active example's catalog has multilingual-capable ASR (`parakeet-rnnt` or `nemotron-asr-streaming-multilingual`) and TTS (`magpie-tts`).
+3. Ensure the active example's catalog has multilingual-capable ASR (`parakeet-rnnt` or `nemotron-asr-streaming-multilingual`) and TTS (`magpie-multilingual-tts`).
 4. Compose restart of the example service and refresh browser.
 
 ## Limitations

--- a/skills/configure-pipeline/references/apply-changes.md
+++ b/skills/configure-pipeline/references/apply-changes.md
@@ -76,7 +76,7 @@ docker compose --profile generic-assistant/dgx-spark --profile tracing --profile
 
 - The selected recipe profile matches the example and hardware you want active.
 - `examples_registry.yaml` `defaults` references catalog keys that actually exist for that example.
-- Multilingual prompt selection is paired with multilingual-capable ASR (`parakeet-rnnt` by default, or `nemotron-asr-streaming-multilingual` when opted in) and TTS (`magpie-tts`) in the active catalog.
+- Multilingual prompt selection is paired with multilingual-capable ASR (`parakeet-rnnt` by default, or `nemotron-asr-streaming-multilingual` when opted in) and TTS (`magpie-multilingual-tts`) in the active catalog.
 - If `ENABLE_TRACING=true` with `phoenix:4317`, the `phoenix` service is started through the `tracing` profile.
 - Compose-managed local entries use service DNS names, not `localhost`.
 - ASR/TTS image variants use their Compose service DNS names (for example `nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `tts-service:50051`).

--- a/skills/configure-pipeline/references/apply-changes.md
+++ b/skills/configure-pipeline/references/apply-changes.md
@@ -16,6 +16,7 @@ The catalog stores Compose DNS endpoints. The backend rewrites them to `localhos
 | `http://nvidia-llm:8000/v1` | `http://localhost:18000/v1` |
 | `http://nvidia-llm-vllm:8000/v1` | `http://localhost:18000/v1` |
 | `tts-service:50051` | `localhost:50151` |
+| `chatterbox-tts-service:50051` | `localhost:50151` |
 | `nemotron-asr-streaming-english:50052` | `localhost:50152` |
 | `nemotron-asr-streaming-multilingual:50052` | `localhost:50152` |
 | `parakeet-ctc-asr:50052` | `localhost:50152` |
@@ -76,7 +77,7 @@ docker compose --profile generic-assistant/dgx-spark --profile tracing --profile
 
 - The selected recipe profile matches the example and hardware you want active.
 - `examples_registry.yaml` `defaults` references catalog keys that actually exist for that example.
-- Multilingual prompt selection is paired with multilingual-capable ASR (`parakeet-rnnt` by default, or `nemotron-asr-streaming-multilingual` when opted in) and TTS (`magpie-multilingual-tts`) in the active catalog.
+- Multilingual prompt selection is paired with multilingual-capable ASR (`parakeet-rnnt` by default, or `nemotron-asr-streaming-multilingual` when opted in) and TTS (`magpie-multilingual-tts` or `chatterbox-multilingual-tts`) in the active catalog.
 - If `ENABLE_TRACING=true` with `phoenix:4317`, the `phoenix` service is started through the `tracing` profile.
 - Compose-managed local entries use service DNS names, not `localhost`.
 - ASR/TTS image variants use their Compose service DNS names (for example `nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `tts-service:50051`).

--- a/src/examples/frontend_backend_agent/airline/database/README.md
+++ b/src/examples/frontend_backend_agent/airline/database/README.md
@@ -19,7 +19,7 @@ HTTP routes in `server.py`:
 | --- | --- |
 | **Booking lookup** | Look up a PNR, read back passenger / flight / status / seat / meal |
 | **Flight status** | Check status (scheduled / delayed / cancelled / diverted / misconnect) and delay minutes for any flight number |
-| **Rebook** | Move an active PNR to a different flight on the same or different route; optionally change seat / meal |
+| **Rebook** | Move an active PNR to a different flight on the same or different route. Optionally change seat / meal |
 | **Cancel** | Cancel an active PNR under the appropriate fare / IRROPS policy |
 | **New booking** | Create a fresh PNR on a scheduled flight, with optional seat / meal |
 | **Standby** | List a PNR on an earlier flight without giving up the original |
@@ -131,7 +131,7 @@ airports automatically.
   the origin airport** (no timezone suffix). The agent reads these back
   as wall-clock times — it does not perform timezone math.
 - The seeded date window is **2026-04-22 through 2026-05-10** for the
-  generated catalog; curated alternatives spread across the same range.
+  generated catalog. Curated alternatives spread across the same range.
 - Asking about dates outside that window will get a "no flights found"
   reply — that's the database, not a bug in the agent.
 
@@ -139,7 +139,7 @@ airports automatically.
 
 - Real-time pricing (the agent quotes a flat per-cabin rate from
   `BookingAPI.price_for`, with a 2× international surcharge).
-- Real seat maps (any seat string is accepted on input; `ancillaries.seat`
+- Real seat maps (any seat string is accepted on input. `ancillaries.seat`
   is stored verbatim).
 - Frequent-flyer balances (only the `elite_tier` enum is stored).
 - Connections / multi-segment itineraries (each PNR is a single
@@ -157,7 +157,7 @@ PYTHONPATH=src uv run python3 -m examples.frontend_backend_agent.airline.databas
 ```
 
 The flight catalog in `seed_data/flights.jsonl` and the PNR fixtures
-in `seed_data/pnrs.jsonl` are committed as-is; the OpenFlights
+in `seed_data/pnrs.jsonl` are committed as-is. The OpenFlights
 schedules were generated once and baked in. If you need to expand the
 hub set or extend the date range, edit `flights.jsonl` directly (one
 JSON record per line) — `seed.py` will pick the new rows up on the
@@ -184,5 +184,5 @@ directly with `curl` for debugging:
 | `POST` | `/pnrs/{pnr}/cancel` | Cancel |
 | `POST` | `/pnrs/{pnr}/standby` | Standby listing |
 
-Server defaults to `http://localhost:8001`; override the SQLite path
+Server defaults to `http://localhost:8001`. Override the SQLite path
 with `BOOKING_DB_PATH=...`.

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -217,18 +217,25 @@ async def bot(runner_args: RunnerArguments) -> None:
     # --- TTS ---
     tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
     tts_ssl = is_nvcf(tts_server)
-    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "Magpie-Multilingual.EN-US.Aria")
+    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
+    tts_synthesis_mode = body.get("tts_synthesis_mode", "")
     custom_dictionary = load_ipa_dictionary()
+    tts_settings_kwargs: dict = {"voice": tts_voice}
+    if tts_synthesis_mode:
+        tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
     tts = NvidiaTTSService(
         api_key=os.getenv("NVIDIA_API_KEY"),
         server=tts_server,
-        settings=NvidiaTTSSettings(voice=tts_voice),
+        settings=NvidiaTTSSettings(**tts_settings_kwargs),
         use_ssl=tts_ssl,
         text_filters=[NemotronSpeechTextFilter()],
         text_transforms=[("*", apply_frontend_backend_agent_pronunciation_for_tts)],
         custom_dictionary=custom_dictionary,
     )
-    logger.info(f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}")
+    logger.info(
+        f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
+        f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
+    )
 
     # --- Context + aggregators ---
     messages = _build_context_messages(talker_prompt, system_prompt)

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -219,7 +219,10 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
-    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    raw_tts_function_id = body.get("tts_function_id")
+    tts_function_id = (
+        str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
+    )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     custom_dictionary = load_ipa_dictionary()
     tts_settings_kwargs: dict = {"voice": tts_voice}

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -219,21 +219,30 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
+    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     custom_dictionary = load_ipa_dictionary()
     tts_settings_kwargs: dict = {"voice": tts_voice}
     if tts_synthesis_mode:
         tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
-    tts = NvidiaTTSService(
-        api_key=os.getenv("NVIDIA_API_KEY"),
-        server=tts_server,
-        settings=NvidiaTTSSettings(**tts_settings_kwargs),
-        use_ssl=tts_ssl,
-        text_filters=[NemotronSpeechTextFilter()],
-        text_transforms=[("*", apply_frontend_backend_agent_pronunciation_for_tts)],
-        custom_dictionary=custom_dictionary,
-    )
+    tts_kwargs: dict = {
+        "api_key": os.getenv("NVIDIA_API_KEY"),
+        "server": tts_server,
+        "settings": NvidiaTTSSettings(**tts_settings_kwargs),
+        "use_ssl": tts_ssl,
+        "text_filters": [NemotronSpeechTextFilter()],
+        "text_transforms": [("*", apply_frontend_backend_agent_pronunciation_for_tts)],
+        "custom_dictionary": custom_dictionary,
+    }
+    if tts_function_id or tts_model:
+        tts_kwargs["model_function_map"] = {
+            "function_id": tts_function_id,
+            "model_name": tts_model,
+        }
+    tts = NvidiaTTSService(**tts_kwargs)
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
+        f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
         f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
     )
 

--- a/src/examples/frontend_backend_agent/services.cloud.yaml
+++ b/src/examples/frontend_backend_agent/services.cloud.yaml
@@ -27,8 +27,16 @@ tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
-    function_id: ""
+    model: "magpie-tts-multilingual"
+    function_id: "877104f7-e885-42b9-8de8-f6e4c6303969"
     synthesis_mode: stitched
+
+  chatterbox-multilingual-tts:
+    name: "Chatterbox TTS Multilingual"
+    server: "grpc.nvcf.nvidia.com:443"
+    voice_id: "Chatterbox-Multilingual.en-US.Male"
+    model: "chatterbox-tts-multilingual"
+    function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
 
 asr:
   nemotron-asr-streaming-english:

--- a/src/examples/frontend_backend_agent/services.cloud.yaml
+++ b/src/examples/frontend_backend_agent/services.cloud.yaml
@@ -23,11 +23,12 @@ booking-server:
     server: "http://booking-server:8001"
 
 tts:
-  magpie-tts:
+  magpie-multilingual-tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     function_id: ""
+    synthesis_mode: stitched
 
 asr:
   nemotron-asr-streaming-english:

--- a/src/examples/frontend_backend_agent/services.local.yaml
+++ b/src/examples/frontend_backend_agent/services.local.yaml
@@ -22,11 +22,12 @@ workstation:
       name: "Booking Server"
       server: "http://booking-server:8001"
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -60,11 +61,12 @@ dgxspark:
       name: "Booking Server"
       server: "http://booking-server:8001"
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -98,11 +100,12 @@ jetson:
       name: "Booking Server"
       server: "http://booking-server:8001"
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "nemotron-speech:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
   asr:
     parakeet-ctc:
       name: "Parakeet CTC 1.1B"

--- a/src/examples/frontend_backend_agent/services.local.yaml
+++ b/src/examples/frontend_backend_agent/services.local.yaml
@@ -75,6 +75,12 @@ dgxspark:
       model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"

--- a/src/examples/frontend_backend_agent/services.local.yaml
+++ b/src/examples/frontend_backend_agent/services.local.yaml
@@ -26,8 +26,15 @@ workstation:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -65,6 +72,7 @@ dgxspark:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
   asr:
@@ -104,6 +112,7 @@ jetson:
       name: "Magpie TTS"
       server: "nemotron-speech:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
   asr:

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -132,7 +132,10 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
-    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    raw_tts_function_id = body.get("tts_function_id")
+    tts_function_id = (
+        str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
+    )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     custom_dictionary = load_ipa_dictionary()
 

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -130,19 +130,28 @@ async def bot(runner_args: RunnerArguments) -> None:
     # --- TTS ---
     tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
     tts_ssl = is_nvcf(tts_server)
-    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "Magpie-Multilingual.EN-US.Aria")
+    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
+    tts_synthesis_mode = body.get("tts_synthesis_mode", "")
     custom_dictionary = load_ipa_dictionary()
+
+    tts_settings_kwargs: dict = {"voice": tts_voice}
+    if tts_synthesis_mode:
+        tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
 
     tts = NvidiaTTSService(
         api_key=os.getenv("NVIDIA_API_KEY"),
         server=tts_server,
-        settings=NvidiaTTSSettings(voice=tts_voice),
+        settings=NvidiaTTSSettings(**tts_settings_kwargs),
         use_ssl=tts_ssl,
         text_filters=[NemotronSpeechTextFilter()],
         custom_dictionary=custom_dictionary,
     )
 
-    logger.info(f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, text_filters=[NemotronSpeechTextFilter]")
+    logger.info(
+        f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
+        f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
+        f"text_filters=[NemotronSpeechTextFilter]"
+    )
 
     # --- Context ---
     messages = build_context_messages(base_system_content, system_prompt)

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -132,23 +132,31 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
+    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     custom_dictionary = load_ipa_dictionary()
 
     tts_settings_kwargs: dict = {"voice": tts_voice}
     if tts_synthesis_mode:
         tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
-
-    tts = NvidiaTTSService(
-        api_key=os.getenv("NVIDIA_API_KEY"),
-        server=tts_server,
-        settings=NvidiaTTSSettings(**tts_settings_kwargs),
-        use_ssl=tts_ssl,
-        text_filters=[NemotronSpeechTextFilter()],
-        custom_dictionary=custom_dictionary,
-    )
+    tts_kwargs: dict = {
+        "api_key": os.getenv("NVIDIA_API_KEY"),
+        "server": tts_server,
+        "settings": NvidiaTTSSettings(**tts_settings_kwargs),
+        "use_ssl": tts_ssl,
+        "text_filters": [NemotronSpeechTextFilter()],
+        "custom_dictionary": custom_dictionary,
+    }
+    if tts_function_id or tts_model:
+        tts_kwargs["model_function_map"] = {
+            "function_id": tts_function_id,
+            "model_name": tts_model,
+        }
+    tts = NvidiaTTSService(**tts_kwargs)
 
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
+        f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
         f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
         f"text_filters=[NemotronSpeechTextFilter]"
     )

--- a/src/examples/generic/services.cloud.yaml
+++ b/src/examples/generic/services.cloud.yaml
@@ -39,8 +39,16 @@ tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
-    function_id: ""
+    model: "magpie-tts-multilingual"
+    function_id: "877104f7-e885-42b9-8de8-f6e4c6303969"
     synthesis_mode: stitched
+
+  chatterbox-multilingual-tts:
+    name: "Chatterbox TTS Multilingual"
+    server: "grpc.nvcf.nvidia.com:443"
+    voice_id: "Chatterbox-Multilingual.en-US.Male"
+    model: "chatterbox-tts-multilingual"
+    function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
 
 # ── ASR Services (Cascaded pipeline) ──
 asr:

--- a/src/examples/generic/services.cloud.yaml
+++ b/src/examples/generic/services.cloud.yaml
@@ -35,11 +35,12 @@ llm:
 
 # ── TTS Services (Cascaded pipeline) ──
 tts:
-  magpie-tts:
+  magpie-multilingual-tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     function_id: ""
+    synthesis_mode: stitched
 
 # ── ASR Services (Cascaded pipeline) ──
 asr:

--- a/src/examples/generic/services.local.yaml
+++ b/src/examples/generic/services.local.yaml
@@ -29,11 +29,12 @@ workstation:
       system_prompt: ""
       extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -66,11 +67,12 @@ dgxspark:
       system_prompt: ""
       extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -92,11 +94,12 @@ jetson:
       system_prompt: ""
       extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "nemotron-speech:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
   asr:
     parakeet-ctc:
       name: "Parakeet CTC 1.1B"

--- a/src/examples/generic/services.local.yaml
+++ b/src/examples/generic/services.local.yaml
@@ -81,6 +81,12 @@ dgxspark:
       model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"

--- a/src/examples/generic/services.local.yaml
+++ b/src/examples/generic/services.local.yaml
@@ -33,8 +33,15 @@ workstation:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -71,6 +78,7 @@ dgxspark:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
   asr:
@@ -98,6 +106,7 @@ jetson:
       name: "Magpie TTS"
       server: "nemotron-speech:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
   asr:

--- a/src/examples/multilingual/README.md
+++ b/src/examples/multilingual/README.md
@@ -124,6 +124,6 @@ Multilingual behavior depends on the ASR model, the LLM, and the selected TTS vo
 | Bot does not respond to a turn (no transcript) | Nemotron ASR Multilingual can drop a turn in noisy environments | Speak again, reduce background noise, and use a good microphone. See [Configure ASR](../../../docs/how-to/configure-asr.md#choosing-a-multilingual-asr-model) |
 | Weak or awkward replies in some languages (for example Hindi) | Nemotron 3 Nano has weaker conversation quality in a few languages | Use Nemotron 3 Super for better multilingual quality. See [Configure LLM](../../../docs/how-to/configure-llm.md) |
 | Port conflict on the ASR sidecar | Parakeet and Nemotron streaming both bind `50152` | Run only one local ASR. When opting into Parakeet, scale the Nemotron sidecar off (`--scale nemotron-asr-streaming-multilingual=0`) |
-| Random ASR text while silent | Parakeet RNNT noise sensitivity | Expected with the Parakeet opt-in. The default Nemotron ASR is less prone to this; otherwise reduce room noise and use a good mic |
+| Random ASR text while silent | Parakeet RNNT noise sensitivity | Expected with the Parakeet opt-in. The default Nemotron ASR is less prone to this. Otherwise reduce room noise and use a good mic |
 
 For ASR, LLM, and TTS model details and general failure modes, see [Configure ASR](../../../docs/how-to/configure-asr.md), [Configure TTS](../../../docs/how-to/configure-tts.md), [Configure LLM](../../../docs/how-to/configure-llm.md), and the [Troubleshooting guide](../../../docs/06-troubleshooting.md).

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -173,7 +173,7 @@ async def bot(runner_args: RunnerArguments) -> None:
 
     tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
     tts_ssl = is_nvcf(tts_server)
-    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "Magpie-Multilingual.EN-US.Aria")
+    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     lang_codes = await _prepare_session_language_codes(
         runner_args,
         tts_server=tts_server,
@@ -237,6 +237,10 @@ async def bot(runner_args: RunnerArguments) -> None:
             tts_voice = resolved_voice
             tts_settings_kwargs["voice"] = resolved_voice
 
+    tts_synthesis_mode = body.get("tts_synthesis_mode", "")
+    if tts_synthesis_mode:
+        tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
+
     tts = NvidiaTTSService(
         api_key=os.getenv("NVIDIA_API_KEY"),
         server=tts_server,
@@ -248,6 +252,7 @@ async def bot(runner_args: RunnerArguments) -> None:
 
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
+        f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
         f"lang_codes={lang_codes or '(no voices discovered)'}, "
         f"text_filters=[NemotronSpeechTextFilter]"
     )

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -36,7 +36,6 @@ from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 from pipecat.workers.runner import WorkerRunner
 
-import config_store
 from examples.multilingual.multilingual_processor import (
     FIXED_SESSION_GREETING_TRIGGER,
     FIXED_SESSION_LANGUAGE_ADDON_KEY,
@@ -116,11 +115,10 @@ async def _prepare_session_language_codes(
         logger.info("Skipping ASR/TTS service prewarm for eval transport startup")
         return ""
 
-    prewarm_tasks = [asyncio.to_thread(prewarm_asr, asr_server, asr_model, asr_function_id)]
-    if not config_store.get("tts"):
-        prewarm_tasks.append(
-            asyncio.to_thread(prewarm_tts, tts_server, tts_voice, tts_function_id, tts_model)
-        )
+    prewarm_tasks = [
+        asyncio.to_thread(prewarm_asr, asr_server, asr_model, asr_function_id),
+        asyncio.to_thread(prewarm_tts, tts_server, tts_voice, tts_function_id, tts_model),
+    ]
     await asyncio.gather(*prewarm_tasks)
     return get_lang_codes(
         asr_server=asr_server,

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -176,7 +176,10 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
-    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    raw_tts_function_id = body.get("tts_function_id")
+    tts_function_id = (
+        str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
+    )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     lang_codes = await _prepare_session_language_codes(
         runner_args,

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -244,7 +244,13 @@ async def bot(runner_args: RunnerArguments) -> None:
         tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
     if fixed_session_language:
         tts_settings_kwargs["language"] = fixed_session_language
-        resolved_voice = resolve_voice_for_language(fixed_session_language, tts_voice)
+        resolved_voice = resolve_voice_for_language(
+            fixed_session_language,
+            tts_voice,
+            server=tts_server,
+            function_id=tts_function_id,
+            model=tts_model,
+        )
         if resolved_voice:
             tts_voice = resolved_voice
             tts_settings_kwargs["voice"] = resolved_voice

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -105,6 +105,8 @@ async def _prepare_session_language_codes(
     *,
     tts_server: str,
     tts_voice: str,
+    tts_function_id: str,
+    tts_model: str,
     asr_server: str,
     asr_model: str,
     asr_function_id: str,
@@ -116,7 +118,9 @@ async def _prepare_session_language_codes(
 
     prewarm_tasks = [asyncio.to_thread(prewarm_asr, asr_server, asr_model, asr_function_id)]
     if not config_store.get("tts"):
-        prewarm_tasks.append(asyncio.to_thread(prewarm_tts, tts_server, tts_voice))
+        prewarm_tasks.append(
+            asyncio.to_thread(prewarm_tts, tts_server, tts_voice, tts_function_id, tts_model)
+        )
     await asyncio.gather(*prewarm_tasks)
     return get_lang_codes(
         asr_server=asr_server,
@@ -174,10 +178,14 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
+    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     lang_codes = await _prepare_session_language_codes(
         runner_args,
         tts_server=tts_server,
         tts_voice=tts_voice,
+        tts_function_id=tts_function_id,
+        tts_model=tts_model,
         asr_server=asr_server,
         asr_model=asr_model,
         asr_function_id=asr_function_id,
@@ -229,7 +237,10 @@ async def bot(runner_args: RunnerArguments) -> None:
 
     # --- TTS ---
     custom_dictionary = load_ipa_dictionary()
+    tts_synthesis_mode = body.get("tts_synthesis_mode", "")
     tts_settings_kwargs: dict = {"voice": tts_voice}
+    if tts_synthesis_mode:
+        tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
     if fixed_session_language:
         tts_settings_kwargs["language"] = fixed_session_language
         resolved_voice = resolve_voice_for_language(fixed_session_language, tts_voice)
@@ -237,21 +248,24 @@ async def bot(runner_args: RunnerArguments) -> None:
             tts_voice = resolved_voice
             tts_settings_kwargs["voice"] = resolved_voice
 
-    tts_synthesis_mode = body.get("tts_synthesis_mode", "")
-    if tts_synthesis_mode:
-        tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
-
-    tts = NvidiaTTSService(
-        api_key=os.getenv("NVIDIA_API_KEY"),
-        server=tts_server,
-        settings=NvidiaTTSSettings(**tts_settings_kwargs),
-        use_ssl=tts_ssl,
-        text_filters=[NemotronSpeechTextFilter()],
-        custom_dictionary=custom_dictionary,
-    )
+    tts_kwargs: dict = {
+        "api_key": os.getenv("NVIDIA_API_KEY"),
+        "server": tts_server,
+        "settings": NvidiaTTSSettings(**tts_settings_kwargs),
+        "use_ssl": tts_ssl,
+        "text_filters": [NemotronSpeechTextFilter()],
+        "custom_dictionary": custom_dictionary,
+    }
+    if tts_function_id or tts_model:
+        tts_kwargs["model_function_map"] = {
+            "function_id": tts_function_id,
+            "model_name": tts_model,
+        }
+    tts = NvidiaTTSService(**tts_kwargs)
 
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
+        f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
         f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
         f"lang_codes={lang_codes or '(no voices discovered)'}, "
         f"text_filters=[NemotronSpeechTextFilter]"

--- a/src/examples/multilingual/services.cloud.yaml
+++ b/src/examples/multilingual/services.cloud.yaml
@@ -39,8 +39,16 @@ tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
-    function_id: ""
+    model: "magpie-tts-multilingual"
+    function_id: "877104f7-e885-42b9-8de8-f6e4c6303969"
     synthesis_mode: stitched
+
+  chatterbox-multilingual-tts:
+    name: "Chatterbox TTS Multilingual"
+    server: "grpc.nvcf.nvidia.com:443"
+    voice_id: "Chatterbox-Multilingual.en-US.Male"
+    model: "chatterbox-tts-multilingual"
+    function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
 
 # ── ASR Services (Cascaded pipeline) ──
 asr:

--- a/src/examples/multilingual/services.cloud.yaml
+++ b/src/examples/multilingual/services.cloud.yaml
@@ -35,11 +35,12 @@ llm:
 
 # ── TTS Services (Cascaded pipeline) ──
 tts:
-  magpie-tts:
+  magpie-multilingual-tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     function_id: ""
+    synthesis_mode: stitched
 
 # ── ASR Services (Cascaded pipeline) ──
 asr:

--- a/src/examples/multilingual/services.local.yaml
+++ b/src/examples/multilingual/services.local.yaml
@@ -15,8 +15,15 @@ workstation:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
   asr:
     parakeet-rnnt:
       name: "Parakeet 1.1B RNNT Multilingual ASR"
@@ -43,6 +50,7 @@ dgxspark:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
   asr:

--- a/src/examples/multilingual/services.local.yaml
+++ b/src/examples/multilingual/services.local.yaml
@@ -11,11 +11,12 @@ workstation:
       system_prompt: ""
       extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
   asr:
     parakeet-rnnt:
       name: "Parakeet 1.1B RNNT Multilingual ASR"
@@ -38,11 +39,12 @@ dgxspark:
       system_prompt: ""
       extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
   asr:
     parakeet-rnnt:
       name: "Parakeet 1.1B RNNT Multilingual ASR"

--- a/src/examples/multilingual/services.local.yaml
+++ b/src/examples/multilingual/services.local.yaml
@@ -53,6 +53,12 @@ dgxspark:
       model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
   asr:
     parakeet-rnnt:
       name: "Parakeet 1.1B RNNT Multilingual ASR"

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -143,23 +143,31 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
+    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     custom_dictionary = load_ipa_dictionary()
 
     tts_settings_kwargs: dict = {"voice": tts_voice}
     if tts_synthesis_mode:
         tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
-
-    tts = NvidiaTTSService(
-        api_key=os.getenv("NVIDIA_API_KEY"),
-        server=tts_server,
-        settings=NvidiaTTSSettings(**tts_settings_kwargs),
-        use_ssl=tts_ssl,
-        text_filters=[NemotronSpeechTextFilter()],
-        custom_dictionary=custom_dictionary,
-        stop_frame_timeout_s=parse_env_float("TTS_STOP_FRAME_TIMEOUT_S", 30.0, min_value=5.0),
-    )
+    tts_kwargs: dict = {
+        "api_key": os.getenv("NVIDIA_API_KEY"),
+        "server": tts_server,
+        "settings": NvidiaTTSSettings(**tts_settings_kwargs),
+        "use_ssl": tts_ssl,
+        "text_filters": [NemotronSpeechTextFilter()],
+        "custom_dictionary": custom_dictionary,
+        "stop_frame_timeout_s": parse_env_float("TTS_STOP_FRAME_TIMEOUT_S", 30.0, min_value=5.0),
+    }
+    if tts_function_id or tts_model:
+        tts_kwargs["model_function_map"] = {
+            "function_id": tts_function_id,
+            "model_name": tts_model,
+        }
+    tts = NvidiaTTSService(**tts_kwargs)
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
+        f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
         f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
     )
 

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -143,7 +143,10 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
-    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    raw_tts_function_id = body.get("tts_function_id")
+    tts_function_id = (
+        str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
+    )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     custom_dictionary = load_ipa_dictionary()
 

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -141,19 +141,27 @@ async def bot(runner_args: RunnerArguments) -> None:
 
     tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
     tts_ssl = is_nvcf(tts_server)
-    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "Magpie-Multilingual.EN-US.Aria")
+    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
+    tts_synthesis_mode = body.get("tts_synthesis_mode", "")
     custom_dictionary = load_ipa_dictionary()
+
+    tts_settings_kwargs: dict = {"voice": tts_voice}
+    if tts_synthesis_mode:
+        tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
 
     tts = NvidiaTTSService(
         api_key=os.getenv("NVIDIA_API_KEY"),
         server=tts_server,
-        settings=NvidiaTTSSettings(voice=tts_voice),
+        settings=NvidiaTTSSettings(**tts_settings_kwargs),
         use_ssl=tts_ssl,
         text_filters=[NemotronSpeechTextFilter()],
         custom_dictionary=custom_dictionary,
         stop_frame_timeout_s=parse_env_float("TTS_STOP_FRAME_TIMEOUT_S", 30.0, min_value=5.0),
     )
-    logger.info(f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}")
+    logger.info(
+        f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
+        f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
+    )
 
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,

--- a/src/examples/omni_assistant/services.cloud.yaml
+++ b/src/examples/omni_assistant/services.cloud.yaml
@@ -13,5 +13,13 @@ tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
-    function_id: ""
+    model: "magpie-tts-multilingual"
+    function_id: "877104f7-e885-42b9-8de8-f6e4c6303969"
     synthesis_mode: stitched
+
+  chatterbox-multilingual-tts:
+    name: "Chatterbox TTS Multilingual"
+    server: "grpc.nvcf.nvidia.com:443"
+    voice_id: "Chatterbox-Multilingual.en-US.Male"
+    model: "chatterbox-tts-multilingual"
+    function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"

--- a/src/examples/omni_assistant/services.cloud.yaml
+++ b/src/examples/omni_assistant/services.cloud.yaml
@@ -9,8 +9,9 @@ llm:
     extra_params: '{"extra_body":{"top_k":1,"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
 
 tts:
-  magpie-tts:
+  magpie-multilingual-tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     function_id: ""
+    synthesis_mode: stitched

--- a/src/examples/omni_assistant/services.local.yaml
+++ b/src/examples/omni_assistant/services.local.yaml
@@ -18,11 +18,12 @@ workstation:
       system_prompt: ""
       extra_params: '{"extra_body":{"top_k":1,"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
 
 dgxspark:
   llm:
@@ -33,11 +34,12 @@ dgxspark:
       system_prompt: ""
       extra_params: '{"extra_body":{"top_k":1,"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
 
 jetson:
   llm:
@@ -48,8 +50,9 @@ jetson:
       system_prompt: ""
       extra_params: '{"extra_body":{"top_k":1,"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "nemotron-speech-tts:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched

--- a/src/examples/omni_assistant/services.local.yaml
+++ b/src/examples/omni_assistant/services.local.yaml
@@ -22,8 +22,15 @@ workstation:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
 
 dgxspark:
   llm:
@@ -38,6 +45,7 @@ dgxspark:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
 
@@ -54,5 +62,6 @@ jetson:
       name: "Magpie TTS"
       server: "nemotron-speech-tts:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched

--- a/src/examples/omni_assistant/services.local.yaml
+++ b/src/examples/omni_assistant/services.local.yaml
@@ -48,6 +48,12 @@ dgxspark:
       model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
 
 jetson:
   llm:

--- a/src/examples/omni_assistant_subagents/pipeline.py
+++ b/src/examples/omni_assistant_subagents/pipeline.py
@@ -125,6 +125,8 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
+    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     api_key = os.getenv("NVIDIA_API_KEY")
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
@@ -137,6 +139,8 @@ async def bot(runner_args: RunnerArguments) -> None:
         tts_ssl=tts_ssl,
         tts_voice=tts_voice,
         tts_synthesis_mode=tts_synthesis_mode,
+        tts_function_id=tts_function_id,
+        tts_model=tts_model,
         runner_args=runner_args,
         session_id=session_id,
         subagent_registry=registry,

--- a/src/examples/omni_assistant_subagents/pipeline.py
+++ b/src/examples/omni_assistant_subagents/pipeline.py
@@ -125,7 +125,10 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_ssl = is_nvcf(tts_server)
     tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
-    tts_function_id = body.get("tts_function_id", "") or default_tts.get("function_id", "")
+    raw_tts_function_id = body.get("tts_function_id")
+    tts_function_id = (
+        str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
+    )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
     api_key = os.getenv("NVIDIA_API_KEY")
 

--- a/src/examples/omni_assistant_subagents/pipeline.py
+++ b/src/examples/omni_assistant_subagents/pipeline.py
@@ -123,7 +123,8 @@ async def bot(runner_args: RunnerArguments) -> None:
 
     tts_server = body.get("tts_server", "") or default_tts.get("server", "grpc.nvcf.nvidia.com:443")
     tts_ssl = is_nvcf(tts_server)
-    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "Magpie-Multilingual.EN-US.Aria")
+    tts_voice = body.get("tts_voice_id", "") or default_tts.get("voice_id", "")
+    tts_synthesis_mode = body.get("tts_synthesis_mode", "")
     api_key = os.getenv("NVIDIA_API_KEY")
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
@@ -135,6 +136,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         tts_server=tts_server,
         tts_ssl=tts_ssl,
         tts_voice=tts_voice,
+        tts_synthesis_mode=tts_synthesis_mode,
         runner_args=runner_args,
         session_id=session_id,
         subagent_registry=registry,

--- a/src/examples/omni_assistant_subagents/services.cloud.yaml
+++ b/src/examples/omni_assistant_subagents/services.cloud.yaml
@@ -13,5 +13,13 @@ tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
-    function_id: ""
+    model: "magpie-tts-multilingual"
+    function_id: "877104f7-e885-42b9-8de8-f6e4c6303969"
     synthesis_mode: stitched
+
+  chatterbox-multilingual-tts:
+    name: "Chatterbox TTS Multilingual"
+    server: "grpc.nvcf.nvidia.com:443"
+    voice_id: "Chatterbox-Multilingual.en-US.Male"
+    model: "chatterbox-tts-multilingual"
+    function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"

--- a/src/examples/omni_assistant_subagents/services.cloud.yaml
+++ b/src/examples/omni_assistant_subagents/services.cloud.yaml
@@ -9,8 +9,9 @@ llm:
     extra_params: '{"extra_body":{"top_k":1,"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
 
 tts:
-  magpie-tts:
+  magpie-multilingual-tts:
     name: "Magpie TTS Multilingual"
     server: "grpc.nvcf.nvidia.com:443"
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     function_id: ""
+    synthesis_mode: stitched

--- a/src/examples/omni_assistant_subagents/services.local.yaml
+++ b/src/examples/omni_assistant_subagents/services.local.yaml
@@ -9,11 +9,12 @@ workstation:
       system_prompt: ""
       extra_params: '{"extra_body":{"top_k":1,"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched
 
 dgxspark:
   llm:
@@ -24,8 +25,9 @@ dgxspark:
       system_prompt: ""
       extra_params: '{"extra_body":{"top_k":1,"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
-    magpie-tts:
+    magpie-multilingual-tts:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       function_id: ""
+      synthesis_mode: stitched

--- a/src/examples/omni_assistant_subagents/services.local.yaml
+++ b/src/examples/omni_assistant_subagents/services.local.yaml
@@ -13,8 +13,15 @@ workstation:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""
 
 dgxspark:
   llm:
@@ -29,5 +36,6 @@ dgxspark:
       name: "Magpie TTS"
       server: "tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
+      model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched

--- a/src/examples/omni_assistant_subagents/services.local.yaml
+++ b/src/examples/omni_assistant_subagents/services.local.yaml
@@ -39,3 +39,9 @@ dgxspark:
       model: "magpie-tts-multilingual"
       function_id: ""
       synthesis_mode: stitched
+    chatterbox-multilingual-tts:
+      name: "Chatterbox TTS Multilingual"
+      server: "chatterbox-tts-service:50051"
+      voice_id: "Chatterbox-Multilingual.en-US.Male"
+      model: "chatterbox-tts-multilingual"
+      function_id: ""

--- a/src/examples/omni_assistant_subagents/subagents/transport/agent.py
+++ b/src/examples/omni_assistant_subagents/subagents/transport/agent.py
@@ -96,6 +96,8 @@ class OmniTransportAgent(PipelineWorker):
         tts_ssl: bool,
         tts_voice: str,
         tts_synthesis_mode: str,
+        tts_function_id: str,
+        tts_model: str,
         runner_args: RunnerArguments,
         session_id: str,
         subagent_registry: SubagentRegistry,
@@ -128,18 +130,26 @@ class OmniTransportAgent(PipelineWorker):
         tts_settings_kwargs: dict[str, Any] = {"voice": tts_voice}
         if tts_synthesis_mode:
             tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
-        self._tts = NvidiaTTSService(
-            api_key=api_key,
-            server=tts_server,
-            settings=NvidiaTTSSettings(**tts_settings_kwargs),
-            use_ssl=tts_ssl,
-            text_filters=[NemotronSpeechTextFilter()],
-            custom_dictionary=load_ipa_dictionary(),
-            stop_frame_timeout_s=parse_env_float("TTS_STOP_FRAME_TIMEOUT_S", 30.0, min_value=5.0),
-        )
+        tts_kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "server": tts_server,
+            "settings": NvidiaTTSSettings(**tts_settings_kwargs),
+            "use_ssl": tts_ssl,
+            "text_filters": [NemotronSpeechTextFilter()],
+            "custom_dictionary": load_ipa_dictionary(),
+            "stop_frame_timeout_s": parse_env_float("TTS_STOP_FRAME_TIMEOUT_S", 30.0, min_value=5.0),
+        }
+        if tts_function_id or tts_model:
+            tts_kwargs["model_function_map"] = {
+                "function_id": tts_function_id,
+                "model_name": tts_model,
+            }
+        self._tts = NvidiaTTSService(**tts_kwargs)
         logger.info(
             f"Nemotron Omni subagents TTS: server={tts_server}, ssl={tts_ssl}, "
-            f"voice={tts_voice}, synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
+            f"voice={tts_voice}, model={tts_model or '(pipecat default)'}, "
+            f"function_id={tts_function_id or '(pipecat default)'}, "
+            f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
         )
 
         self._speaker_context = SpeakerContextManager(context=self._context)

--- a/src/examples/omni_assistant_subagents/subagents/transport/agent.py
+++ b/src/examples/omni_assistant_subagents/subagents/transport/agent.py
@@ -95,6 +95,7 @@ class OmniTransportAgent(PipelineWorker):
         tts_server: str,
         tts_ssl: bool,
         tts_voice: str,
+        tts_synthesis_mode: str,
         runner_args: RunnerArguments,
         session_id: str,
         subagent_registry: SubagentRegistry,
@@ -112,6 +113,7 @@ class OmniTransportAgent(PipelineWorker):
         self._tts_server = tts_server
         self._tts_ssl = tts_ssl
         self._tts_voice = tts_voice
+        self._tts_synthesis_mode = tts_synthesis_mode
         self._runner_args = runner_args
         self._session_id = session_id
         self._latency_turn_count = 1
@@ -123,16 +125,22 @@ class OmniTransportAgent(PipelineWorker):
         self._assistant_speaking = False
         self._user_speaking = False
 
+        tts_settings_kwargs: dict[str, Any] = {"voice": tts_voice}
+        if tts_synthesis_mode:
+            tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
         self._tts = NvidiaTTSService(
             api_key=api_key,
             server=tts_server,
-            settings=NvidiaTTSSettings(voice=tts_voice),
+            settings=NvidiaTTSSettings(**tts_settings_kwargs),
             use_ssl=tts_ssl,
             text_filters=[NemotronSpeechTextFilter()],
             custom_dictionary=load_ipa_dictionary(),
             stop_frame_timeout_s=parse_env_float("TTS_STOP_FRAME_TIMEOUT_S", 30.0, min_value=5.0),
         )
-        logger.info(f"Nemotron Omni subagents TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}")
+        logger.info(
+            f"Nemotron Omni subagents TTS: server={tts_server}, ssl={tts_ssl}, "
+            f"voice={tts_voice}, synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
+        )
 
         self._speaker_context = SpeakerContextManager(context=self._context)
         self._subagent_board = SubagentStateBoard(

--- a/src/examples/shared/prewarm.py
+++ b/src/examples/shared/prewarm.py
@@ -14,13 +14,28 @@ import config_store
 from utils import is_nvcf, normalize_lang_code
 
 
-def _create_tts_service(server: str, voice_id: str) -> NvidiaTTSService:
-    return NvidiaTTSService(
-        api_key=os.getenv("NVIDIA_API_KEY"),
-        server=server,
-        settings=NvidiaTTSSettings(voice=voice_id),
-        use_ssl=is_nvcf(server),
-    )
+def _create_tts_service(
+    server: str,
+    voice_id: str,
+    function_id: str = "",
+    model: str = "",
+):
+    tts_kwargs: dict = {
+        "api_key": os.getenv("NVIDIA_API_KEY"),
+        "server": server,
+        "settings": NvidiaTTSSettings(voice=voice_id),
+        "use_ssl": is_nvcf(server),
+    }
+    if function_id or model:
+        tts_kwargs["model_function_map"] = {
+            "function_id": function_id,
+            "model_name": model,
+        }
+    return NvidiaTTSService(**tts_kwargs)
+
+
+def _tts_cache_key(server: str, function_id: str = "", model: str = "") -> str:
+    return f"tts:{server}:{function_id}:{model}"
 
 
 def _parse_language_codes_param(raw: str) -> list[str]:
@@ -116,9 +131,16 @@ def build_session_languages(
     asr_function_id: str,
     tts_server: str,
     tts_voice_id: str,
+    tts_function_id: str = "",
+    tts_model: str = "",
 ) -> dict:
     """Return the ASR∩TTS language catalog and TTS voices for session configuration."""
-    tts_config = prewarm_tts(tts_server, tts_voice_id)
+    tts_config = prewarm_tts(
+        tts_server,
+        tts_voice_id,
+        tts_function_id,
+        tts_model,
+    )
     asr_config = prewarm_asr(asr_server, asr_model, asr_function_id)
     languages = intersect_session_languages(asr_config, tts_config)
     return {
@@ -128,28 +150,31 @@ def build_session_languages(
     }
 
 
-def _tts_cache_key(server: str) -> str:
-    return f"tts:{server}"
-
-
 def _asr_cache_key(server: str, model: str, function_id: str) -> str:
     return f"asr:{server}:{model}:{function_id}"
 
 
-def prewarm_tts(server: str, voice_id: str) -> dict:
+def prewarm_tts(
+    server: str,
+    voice_id: str,
+    function_id: str = "",
+    model: str = "",
+) -> dict:
     """Pre-warm a TTS server and cache its voice/language config.
 
     Returns the TTS config dict (languages, voices, defaultVoiceId).
-    Results are cached per server in config_store.
+    Results are cached per server + function_id + model in config_store so
+    multiple cloud NIMs on ``grpc.nvcf.nvidia.com`` do not collide.
     """
-    cached = config_store.get(_tts_cache_key(server))
+    cache_key = _tts_cache_key(server, function_id, model)
+    cached = config_store.get(cache_key)
     if cached:
         logger.debug(f"TTS config for {server} already cached")
         return cached
 
     logger.info(f"Pre-warming TTS on {server} (this may take 10-20s on first run)...")
     try:
-        svc = _create_tts_service(server, voice_id)
+        svc = _create_tts_service(server, voice_id, function_id, model)
         svc._initialize_client()
         raw_config = svc._create_synthesis_config()
 
@@ -158,7 +183,7 @@ def prewarm_tts(server: str, voice_id: str) -> dict:
         tts_config["defaultVoiceId"] = voice_id
         tts_config["server"] = server
 
-        config_store.set(_tts_cache_key(server), tts_config)
+        config_store.set(cache_key, tts_config)
         config_store.set("tts", tts_config)
 
         n_langs = len(tts_config["languages"])
@@ -225,11 +250,16 @@ def prewarm_asr(server: str, model: str = "", function_id: str = "") -> dict:
         return {"languages": [], "server": server, "error": str(e)}
 
 
-def warmup_tts_synthesis(server: str, voice_id: str) -> bool:
+def warmup_tts_synthesis(
+    server: str,
+    voice_id: str,
+    function_id: str = "",
+    model: str = "",
+) -> bool:
     """Run a tiny synthesis request to verify the selected TTS is responsive."""
     logger.info(f"Warming up TTS synthesis on {server}...")
     try:
-        svc = _create_tts_service(server, voice_id)
+        svc = _create_tts_service(server, voice_id, function_id, model)
         svc._initialize_client()
 
         responses = svc._service.synthesize_online(

--- a/src/examples/shared/prewarm.py
+++ b/src/examples/shared/prewarm.py
@@ -170,8 +170,11 @@ def prewarm_tts(
     cached = config_store.get(cache_key)
     if cached:
         logger.debug(f"TTS config for {server} already cached")
-        config_store.set("tts", cached)
-        return cached
+        result = dict(cached)
+        if voice_id:
+            result["defaultVoiceId"] = voice_id
+        config_store.set("tts", result)
+        return result
 
     logger.info(f"Pre-warming TTS on {server} (this may take 10-20s on first run)...")
     try:
@@ -282,10 +285,21 @@ def warmup_tts_synthesis(
         return False
 
 
-def load_voice_map() -> dict[str, str]:
+def load_voice_map(
+    server: str = "",
+    function_id: str = "",
+    model: str = "",
+) -> dict[str, str]:
     """``{lower_lang_code: first_voice_id}`` from the prewarm cache."""
-    tts_config = config_store.get("tts", {})
-    voices = tts_config.get("voices", []) if isinstance(tts_config, dict) else []
+    tts_config: dict = {}
+    if server or function_id or model:
+        cached = config_store.get(_tts_cache_key(server, function_id, model), {})
+        if isinstance(cached, dict):
+            tts_config = cached
+    if not tts_config:
+        legacy = config_store.get("tts", {})
+        tts_config = legacy if isinstance(legacy, dict) else {}
+    voices = tts_config.get("voices", [])
     result: dict[str, str] = {}
     for v in voices:
         lang = (v.get("language") or "").strip()
@@ -295,12 +309,27 @@ def load_voice_map() -> dict[str, str]:
     return result
 
 
-def resolve_voice_for_language(language_code: str, preferred_voice_id: str = "") -> str:
+def resolve_voice_for_language(
+    language_code: str,
+    preferred_voice_id: str = "",
+    *,
+    server: str = "",
+    function_id: str = "",
+    model: str = "",
+) -> str:
     """Pick a TTS voice id for ``language_code`` from the prewarmed catalog."""
     normalized = normalize_lang_code(language_code).lower()
-    voice_map = load_voice_map()
+    tts_config: dict = {}
+    if server or function_id or model:
+        cached = config_store.get(_tts_cache_key(server, function_id, model), {})
+        if isinstance(cached, dict):
+            tts_config = cached
+    if not tts_config:
+        legacy = config_store.get("tts", {})
+        tts_config = legacy if isinstance(legacy, dict) else {}
+    voice_map = load_voice_map(server=server, function_id=function_id, model=model)
     if preferred_voice_id:
-        for voice in config_store.get("tts", {}).get("voices", []):
+        for voice in tts_config.get("voices", []):
             if voice.get("id") == preferred_voice_id and voice.get("language", "").lower() == normalized:
                 return preferred_voice_id
     voice_id = voice_map.get(normalized)

--- a/src/examples/shared/prewarm.py
+++ b/src/examples/shared/prewarm.py
@@ -170,6 +170,7 @@ def prewarm_tts(
     cached = config_store.get(cache_key)
     if cached:
         logger.debug(f"TTS config for {server} already cached")
+        config_store.set("tts", cached)
         return cached
 
     logger.info(f"Pre-warming TTS on {server} (this may take 10-20s on first run)...")

--- a/src/examples_registry.py
+++ b/src/examples_registry.py
@@ -145,7 +145,8 @@ def _rewrite_entry_for_host_runtime(entry: dict) -> dict:
             )
         else:
             out[field] = (
-                value.replace("tts-service:50051", "localhost:50151")
+                value.replace("chatterbox-tts-service:50051", "localhost:50151")
+                .replace("tts-service:50051", "localhost:50151")
                 .replace("nemotron-asr-streaming-english:50052", "localhost:50152")
                 .replace("nemotron-asr-streaming-multilingual:50052", "localhost:50152")
                 .replace("parakeet-ctc-asr:50052", "localhost:50152")

--- a/src/server.py
+++ b/src/server.py
@@ -254,11 +254,37 @@ def _resolve_config(session_id: str = "", fallback_example_key: str = "", **quer
     return _sanitize_session_config({k: v for k, v in base.items() if v}, fallback_example_key=fallback_example_key)
 
 
-def _get_default_tts_selection() -> tuple[str, str]:
+def _get_default_tts_selection() -> tuple[str, str, str, str]:
+    """Return default TTS ``(server, voice_id, function_id, model)`` from the catalog."""
     default_tts = load_service_entry("tts", "")
     return (
         default_tts.get("server", "grpc.nvcf.nvidia.com:443"),
         default_tts.get("voice_id", ""),
+        default_tts.get("function_id", ""),
+        default_tts.get("model", ""),
+    )
+
+
+def _resolve_tts_selection(
+    server: str = "",
+    voice_id: str = "",
+    function_id: str = "",
+    model: str = "",
+) -> tuple[str, str, str, str]:
+    """Bind server + metadata as one selection.
+
+    When ``server`` is omitted, fall back to the catalog default for server,
+    voice, function_id, and model together. When ``server`` is explicit, keep
+    empty function_id/model (do not borrow Magpie defaults for another NIM).
+    """
+    default_server, default_voice, default_function_id, default_model = _get_default_tts_selection()
+    if server:
+        return server, voice_id or default_voice, function_id, model
+    return (
+        default_server,
+        voice_id or default_voice,
+        function_id or default_function_id,
+        model or default_model,
     )
 
 
@@ -523,11 +549,12 @@ async def _ensure_tts_ready_for_connection(config: dict, example: dict) -> None:
     if _should_skip_tts_prewarm(example):
         return
 
-    default_tts_server, default_tts_voice = _get_default_tts_selection()
-    tts_server = config.get("tts_server", "") or default_tts_server
-    voice_id = config.get("tts_voice_id", "") or default_tts_voice
-    tts_function_id = config.get("tts_function_id", "")
-    tts_model = config.get("tts_model", "")
+    tts_server, voice_id, tts_function_id, tts_model = _resolve_tts_selection(
+        config.get("tts_server", ""),
+        config.get("tts_voice_id", ""),
+        config.get("tts_function_id", ""),
+        config.get("tts_model", ""),
+    )
 
     ready_url = _local_speech_ready_url("TTS", tts_server)
     if ready_url:
@@ -935,18 +962,19 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
     ):
         if asr_server or asr_model or asr_function_id:
             default_asr_server, default_asr_model, default_asr_function_id = _get_default_asr_catalog()
-            default_tts_server, default_tts_voice = _get_default_tts_selection()
-            default_tts = load_service_entry("tts", "")
+            tts_server, tts_voice, tts_function_id, tts_model = _resolve_tts_selection(
+                server, voice_id, function_id, model
+            )
             try:
                 return await _run_blocking(
                     build_session_languages,
                     asr_server or default_asr_server,
                     asr_model or default_asr_model,
                     asr_function_id or default_asr_function_id,
-                    server or default_tts_server,
-                    voice_id or default_tts_voice,
-                    function_id or default_tts.get("function_id", ""),
-                    model or default_tts.get("model", ""),
+                    tts_server,
+                    tts_voice,
+                    tts_function_id,
+                    tts_model,
                     timeout=_CONNECT_PREWARM_TIMEOUT_SECS,
                 )
             except TimeoutError:
@@ -960,19 +988,21 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
                 )
 
         if server:
-            _, default_tts_voice = _get_default_tts_selection()
-            default_tts = load_service_entry("tts", "")
-            resolved_function_id = function_id or default_tts.get("function_id", "")
-            resolved_model = model or default_tts.get("model", "")
-            cached = config_store.get(f"tts:{server}:{resolved_function_id}:{resolved_model}")
+            tts_server, tts_voice, tts_function_id, tts_model = _resolve_tts_selection(
+                server, voice_id, function_id, model
+            )
+            cached = config_store.get(f"tts:{tts_server}:{tts_function_id}:{tts_model}")
             if cached:
-                return cached
+                result = dict(cached)
+                if tts_voice:
+                    result["defaultVoiceId"] = tts_voice
+                return result
             return await _run_blocking(
                 prewarm_tts,
-                server,
-                voice_id or default_tts_voice,
-                resolved_function_id,
-                resolved_model,
+                tts_server,
+                tts_voice,
+                tts_function_id,
+                tts_model,
             )
         return config_store.get("tts", {"languages": [], "voices": []})
 

--- a/src/server.py
+++ b/src/server.py
@@ -258,7 +258,7 @@ def _get_default_tts_selection() -> tuple[str, str]:
     default_tts = load_service_entry("tts", "")
     return (
         default_tts.get("server", "grpc.nvcf.nvidia.com:443"),
-        default_tts.get("voice_id", "Magpie-Multilingual.EN-US.Aria"),
+        default_tts.get("voice_id", ""),
     )
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -526,6 +526,8 @@ async def _ensure_tts_ready_for_connection(config: dict, example: dict) -> None:
     default_tts_server, default_tts_voice = _get_default_tts_selection()
     tts_server = config.get("tts_server", "") or default_tts_server
     voice_id = config.get("tts_voice_id", "") or default_tts_voice
+    tts_function_id = config.get("tts_function_id", "")
+    tts_model = config.get("tts_model", "")
 
     ready_url = _local_speech_ready_url("TTS", tts_server)
     if ready_url:
@@ -551,6 +553,8 @@ async def _ensure_tts_ready_for_connection(config: dict, example: dict) -> None:
             warmup_tts_synthesis,
             tts_server,
             voice_id,
+            tts_function_id,
+            tts_model,
             timeout=_CONNECT_PREWARM_TIMEOUT_SECS,
         )
     except TimeoutError as exc:
@@ -923,6 +927,8 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
     async def tts_config(
         server: str = Query(default=""),
         voice_id: str = Query(default=""),
+        function_id: str = Query(default=""),
+        model: str = Query(default=""),
         asr_server: str = Query(default=""),
         asr_model: str = Query(default=""),
         asr_function_id: str = Query(default=""),
@@ -930,6 +936,7 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
         if asr_server or asr_model or asr_function_id:
             default_asr_server, default_asr_model, default_asr_function_id = _get_default_asr_catalog()
             default_tts_server, default_tts_voice = _get_default_tts_selection()
+            default_tts = load_service_entry("tts", "")
             try:
                 return await _run_blocking(
                     build_session_languages,
@@ -938,6 +945,8 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
                     asr_function_id or default_asr_function_id,
                     server or default_tts_server,
                     voice_id or default_tts_voice,
+                    function_id or default_tts.get("function_id", ""),
+                    model or default_tts.get("model", ""),
                     timeout=_CONNECT_PREWARM_TIMEOUT_SECS,
                 )
             except TimeoutError:
@@ -952,10 +961,19 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
 
         if server:
             _, default_tts_voice = _get_default_tts_selection()
-            cached = config_store.get(f"tts:{server}")
+            default_tts = load_service_entry("tts", "")
+            resolved_function_id = function_id or default_tts.get("function_id", "")
+            resolved_model = model or default_tts.get("model", "")
+            cached = config_store.get(f"tts:{server}:{resolved_function_id}:{resolved_model}")
             if cached:
                 return cached
-            return await _run_blocking(prewarm_tts, server, voice_id or default_tts_voice)
+            return await _run_blocking(
+                prewarm_tts,
+                server,
+                voice_id or default_tts_voice,
+                resolved_function_id,
+                resolved_model,
+            )
         return config_store.get("tts", {"languages": [], "voices": []})
 
     # ---- WebRTC ICE servers (TURN credentials) ----

--- a/src/server.py
+++ b/src/server.py
@@ -103,7 +103,7 @@ _SPEECH_READY_ENDPOINTS = {
         50152,
         9001,
     ),
-    "tts": (("tts-service",), 50051, 50151, 9000),
+    "tts": (("tts-service", "chatterbox-tts-service"), 50051, 50151, 9000),
 }
 _TURN_LISTEN_PORT = 3478
 _INDEX_NO_CACHE_HEADERS = {"Cache-Control": "no-store"}

--- a/src/utils.py
+++ b/src/utils.py
@@ -45,7 +45,14 @@ _SLOT_CONFIG_KEYS: dict[str, frozenset[str]] = {
     ),
     "asr": frozenset({"asr_id", "asr_server", "asr_model", "asr_function_id", "asr_language_code"}),
     "tts": frozenset(
-        {"tts_id", "tts_server", "tts_voice_id", "tts_function_id", "tts_synthesis_mode"}
+        {
+            "tts_id",
+            "tts_server",
+            "tts_voice_id",
+            "tts_function_id",
+            "tts_model",
+            "tts_synthesis_mode",
+        }
     ),
 }
 _SLOT_AGNOSTIC_KEYS: frozenset[str] = frozenset({"pipeline_mode", "prompt_key", "prompt_content"})
@@ -470,6 +477,7 @@ SESSION_CONFIG_KEYS: frozenset[str] = frozenset(
         "tts_server",
         "tts_voice_id",
         "tts_function_id",
+        "tts_model",
         "tts_synthesis_mode",
     }
 )
@@ -515,6 +523,7 @@ _CATALOG_HYDRATION: tuple[tuple[str, str, dict[str, str]], ...] = (
         {
             "server": "tts_server",
             "function_id": "tts_function_id",
+            "model": "tts_model",
             "voice_id": "tts_voice_id",
             "synthesis_mode": "tts_synthesis_mode",
         },

--- a/src/utils.py
+++ b/src/utils.py
@@ -222,6 +222,7 @@ _HOST_RUNTIME_PORT_OVERRIDES: dict[tuple[str, int], int] = {
     ("nvidia-llm", 8000): 18000,
     ("nvidia-llm-vllm", 8000): 18000,
     ("tts-service", 50051): 50151,
+    ("chatterbox-tts-service", 50051): 50151,
     ("nemotron-asr-streaming-english", 50052): 50152,
     ("nemotron-asr-streaming-multilingual", 50052): 50152,
     ("parakeet-ctc-asr", 50052): 50152,

--- a/src/utils.py
+++ b/src/utils.py
@@ -44,7 +44,9 @@ _SLOT_CONFIG_KEYS: dict[str, frozenset[str]] = {
         {"thinker_llm_id", "thinker_model_id", "thinker_base_url", "thinker_max_tokens", "thinker_extra_params"}
     ),
     "asr": frozenset({"asr_id", "asr_server", "asr_model", "asr_function_id", "asr_language_code"}),
-    "tts": frozenset({"tts_id", "tts_server", "tts_voice_id", "tts_function_id"}),
+    "tts": frozenset(
+        {"tts_id", "tts_server", "tts_voice_id", "tts_function_id", "tts_synthesis_mode"}
+    ),
 }
 _SLOT_AGNOSTIC_KEYS: frozenset[str] = frozenset({"pipeline_mode", "prompt_key", "prompt_content"})
 _active_slots: frozenset[str] | None = None
@@ -468,12 +470,13 @@ SESSION_CONFIG_KEYS: frozenset[str] = frozenset(
         "tts_server",
         "tts_voice_id",
         "tts_function_id",
+        "tts_synthesis_mode",
     }
 )
 
 # For each category, map YAML field → session-body field. YAML is the source of
-# truth for built-in selections. `tts_voice_id` is intentionally absent — voice
-# is a user-driven runtime choice.
+# truth for built-in selections. Client-overridable fields keep a non-empty
+# user value (voice picker / session language) instead of the catalog default.
 _CATALOG_HYDRATION: tuple[tuple[str, str, dict[str, str]], ...] = (
     (
         "llm_id",
@@ -512,12 +515,14 @@ _CATALOG_HYDRATION: tuple[tuple[str, str, dict[str, str]], ...] = (
         {
             "server": "tts_server",
             "function_id": "tts_function_id",
+            "voice_id": "tts_voice_id",
+            "synthesis_mode": "tts_synthesis_mode",
         },
     ),
 )
 
 # Body fields the client may set explicitly; catalog hydration must not overwrite them.
-_CLIENT_OVERRIDABLE_BODY_FIELDS = frozenset({"asr_language_code"})
+_CLIENT_OVERRIDABLE_BODY_FIELDS = frozenset({"asr_language_code", "tts_voice_id"})
 
 
 def hydrate_config_from_catalog(config: dict) -> None:

--- a/tests/unit/test_multilingual_turn_strategy.py
+++ b/tests/unit/test_multilingual_turn_strategy.py
@@ -105,7 +105,6 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
         prewarm_asr = Mock(name="prewarm_asr")
 
         with (
-            patch("examples.multilingual.pipeline.config_store.get", return_value=None),
             patch("examples.multilingual.pipeline.asyncio.to_thread", to_thread),
             patch("examples.multilingual.pipeline.prewarm_tts", prewarm_tts),
             patch("examples.multilingual.pipeline.prewarm_asr", prewarm_asr),
@@ -117,7 +116,13 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
         to_thread.assert_has_awaits(
             [
                 call(prewarm_asr, "asr.example:443", "parakeet", "fn-123"),
-                call(prewarm_tts, "tts.example:443", "Magpie-Multilingual.EN-US.Aria"),
+                call(
+                    prewarm_tts,
+                    "tts.example:443",
+                    "Magpie-Multilingual.EN-US.Aria",
+                    "tts-fn-456",
+                    "magpie-tts-multilingual",
+                ),
             ]
         )
         get_lang_codes.assert_called_once_with(
@@ -128,31 +133,14 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
             tts_voice_id="Magpie-Multilingual.EN-US.Aria",
         )
 
-    def test_non_eval_transport_skips_tts_prewarm_when_tts_is_configured(self) -> None:
-        to_thread = AsyncMock()
-        get_lang_codes = Mock(return_value="en-US,de-DE")
-        prewarm_tts = Mock(name="prewarm_tts")
-        prewarm_asr = Mock(name="prewarm_asr")
-
-        with (
-            patch("examples.multilingual.pipeline.config_store.get", return_value=object()),
-            patch("examples.multilingual.pipeline.asyncio.to_thread", to_thread),
-            patch("examples.multilingual.pipeline.prewarm_tts", prewarm_tts),
-            patch("examples.multilingual.pipeline.prewarm_asr", prewarm_asr),
-            patch("examples.multilingual.pipeline.get_lang_codes", get_lang_codes),
-        ):
-            lang_codes = self._run_prepare_session_language_codes(RunnerArguments())
-
-        self.assertEqual(lang_codes, "en-US,de-DE")
-        to_thread.assert_awaited_once_with(prewarm_asr, "asr.example:443", "parakeet", "fn-123")
-        prewarm_tts.assert_not_called()
-
     def _run_prepare_session_language_codes(self, runner_args: RunnerArguments) -> str:
         return asyncio.run(
             _prepare_session_language_codes(
                 runner_args,
                 tts_server="tts.example:443",
                 tts_voice="Magpie-Multilingual.EN-US.Aria",
+                tts_function_id="tts-fn-456",
+                tts_model="magpie-tts-multilingual",
                 asr_server="asr.example:443",
                 asr_model="parakeet",
                 asr_function_id="fn-123",

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -224,9 +224,13 @@ llm:
             utils._service_context.reset(token)
 
         self_hosted = [entry for entry in tts if entry["source"] == "self-hosted"]
-        self.assertEqual(len(self_hosted), 1)
-        self.assertEqual(self_hosted[0]["id"], "self-hosted:magpie-multilingual-tts")
-        self.assertEqual(self_hosted[0]["server"], "localhost:50151")
+        self_hosted_ids = {entry["id"] for entry in self_hosted}
+        self.assertEqual(
+            self_hosted_ids,
+            {"self-hosted:magpie-multilingual-tts", "self-hosted:chatterbox-multilingual-tts"},
+        )
+        for entry in self_hosted:
+            self.assertEqual(entry["server"], "localhost:50151")
 
     def test_runtime_platform_filters_local_services(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -40,6 +40,7 @@ tts:
     name: Magpie
     server: catalog-tts:443
     function_id: catalog-tts-function
+    model: magpie-tts-multilingual
     voice_id: Magpie-Multilingual.EN-US.Aria
     synthesis_mode: stitched
 """,
@@ -60,6 +61,7 @@ tts:
                 "tts_id": "cloud-nim:magpie",
                 "tts_server": "client-tts:443",
                 "tts_function_id": "client-tts-function",
+                "tts_model": "client-tts-model",
                 "tts_voice_id": "client-voice",
                 "tts_synthesis_mode": "per_sentence",
             }
@@ -86,6 +88,7 @@ tts:
             self.assertEqual(config["asr_language_code"], "client-asr-language")
             self.assertEqual(config["tts_server"], "catalog-tts:443")
             self.assertEqual(config["tts_function_id"], "catalog-tts-function")
+            self.assertEqual(config["tts_model"], "magpie-tts-multilingual")
             self.assertEqual(config["tts_voice_id"], "client-voice")
             self.assertEqual(config["tts_synthesis_mode"], "stitched")
 

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -40,6 +40,8 @@ tts:
     name: Magpie
     server: catalog-tts:443
     function_id: catalog-tts-function
+    voice_id: Magpie-Multilingual.EN-US.Aria
+    synthesis_mode: stitched
 """,
                 encoding="utf-8",
             )
@@ -58,6 +60,8 @@ tts:
                 "tts_id": "cloud-nim:magpie",
                 "tts_server": "client-tts:443",
                 "tts_function_id": "client-tts-function",
+                "tts_voice_id": "client-voice",
+                "tts_synthesis_mode": "per_sentence",
             }
 
             with patch.dict(
@@ -82,6 +86,8 @@ tts:
             self.assertEqual(config["asr_language_code"], "client-asr-language")
             self.assertEqual(config["tts_server"], "catalog-tts:443")
             self.assertEqual(config["tts_function_id"], "catalog-tts-function")
+            self.assertEqual(config["tts_voice_id"], "client-voice")
+            self.assertEqual(config["tts_synthesis_mode"], "stitched")
 
     def test_hydrates_raw_catalog_key_for_direct_clients(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -216,7 +222,7 @@ llm:
 
         self_hosted = [entry for entry in tts if entry["source"] == "self-hosted"]
         self.assertEqual(len(self_hosted), 1)
-        self.assertEqual(self_hosted[0]["id"], "self-hosted:magpie-tts")
+        self.assertEqual(self_hosted[0]["id"], "self-hosted:magpie-multilingual-tts")
         self.assertEqual(self_hosted[0]["server"], "localhost:50151")
 
     def test_runtime_platform_filters_local_services(self) -> None:


### PR DESCRIPTION
1. Make TTS synthesis_mode catalog-driven: Magpie uses stitched; omit on other models for Pipecat’s default per_sentence (no Magpie fallback when switching TTS).
2. Rename Magpie catalog key to magpie-multilingual-tts.
3. Add Chatterbox TTS Multilingual (chatterbox-multilingual-tts) for cloud + local workstation, with compose sidecar and docs.
4. Wire TTS model + function_id through catalog hydration, pipelines, prewarm, /api/tts-config, and the voice UI (same pattern as ASR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in local **Chatterbox Multilingual TTS** Docker Compose profile.
  * Enabled app-wide **TTS model/function** selection (with **voice** and optional **synthesis mode**) and surfaced it through the voice catalog and pipelines.
* **Bug Fixes**
  * Improved local TTS readiness and warmup to account for both **Magpie** and **Chatterbox**, including correct selection when using model/function.
* **Documentation**
  * Expanded TTS configuration guides and examples for **Magpie Multilingual** and **Chatterbox Multilingual**, including catalog keys and synthesis mode notes.
* **Tests**
  * Updated multilingual TTS catalog hydration and prewarm assertions for the new model/function/synthesis inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->