### PR TITLE
Tune turn strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,13 +42,17 @@ NVIDIA_API_KEY=
 # AUDIO_OUT_10MS_CHUNKS=10
 
 # Default: Pipecat Smart Turn is enabled (Silero VAD stop_secs=0.2, Smart Turn
-# silence fallback=1.0s). Set USE_SILERO_VAD_TURN_DETECTION=true to disable Smart
-# Turn and use pure Silero VAD-based end-of-utterance detection instead.
+# silence fallback default 1.0s via SMART_TURN_STOP_SECS). Set
+# USE_SILERO_VAD_TURN_DETECTION=true to disable Smart Turn and use pure Silero
+# VAD-based end-of-utterance detection instead.
 # USE_SILERO_VAD_TURN_DETECTION=false
 # SILERO_VAD_STOP_SECS=0.5
+# SMART_TURN_STOP_SECS=1.0
 
-# Welcome message: when true (default), the bot greets/introduces itself as
-# soon as the client connects. Set false to wait for the user to speak first.
+# Welcome message: the bot greets/introduces itself as soon as the client
+# connects. Configure per example via `welcome_message` in examples_registry.yaml
+# (default true). This env var is a GLOBAL override across all examples: when set
+# it wins over the registry value (used by the workstation-perf profile).
 # ENABLE_WELCOME_MESSAGE=true
 
 # Audio debugging

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,10 @@ NVIDIA_API_KEY=
 # USE_SILERO_VAD_TURN_DETECTION=false
 # SILERO_VAD_STOP_SECS=0.5
 
+# Bot introduction: when true (default), the bot greets/introduces itself as
+# soon as the client connects. Set false to wait for the user to speak first.
+# ENABLE_BOT_INTRODUCTION=true
+
 # Audio debugging
 # ENABLE_ASR_AUDIO_DUMP=false
 # ENABLE_TTS_AUDIO_DUMP=false

--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,9 @@ NVIDIA_API_KEY=
 # Audio output buffering (WebRTC: 5, WebSocket: 10)
 # AUDIO_OUT_10MS_CHUNKS=10
 
-# Default: Pipecat Smart Turn is enabled, and it uses Silero VAD with stop_secs=0.2.
-# Set USE_SILERO_VAD_TURN_DETECTION=true to disable Smart Turn and use pure Silero
-# VAD-based end-of-utterance detection instead.
+# Default: Pipecat Smart Turn is enabled (Silero VAD stop_secs=0.2, Smart Turn
+# silence fallback=1.0s). Set USE_SILERO_VAD_TURN_DETECTION=true to disable Smart
+# Turn and use pure Silero VAD-based end-of-utterance detection instead.
 # USE_SILERO_VAD_TURN_DETECTION=false
 # SILERO_VAD_STOP_SECS=0.5
 

--- a/.env.example
+++ b/.env.example
@@ -47,9 +47,9 @@ NVIDIA_API_KEY=
 # USE_SILERO_VAD_TURN_DETECTION=false
 # SILERO_VAD_STOP_SECS=0.5
 
-# Bot introduction: when true (default), the bot greets/introduces itself as
+# Welcome message: when true (default), the bot greets/introduces itself as
 # soon as the client connects. Set false to wait for the user to speak first.
-# ENABLE_BOT_INTRODUCTION=true
+# ENABLE_WELCOME_MESSAGE=true
 
 # Audio debugging
 # ENABLE_ASR_AUDIO_DUMP=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
       USE_SILERO_VAD_TURN_DETECTION: "true"
       SILERO_VAD_STOP_SECS: "0.5"
       AUDIO_OUT_10MS_CHUNKS: "40"
-      ENABLE_BOT_INTRODUCTION: "false"
+      ENABLE_WELCOME_MESSAGE: "false"
 
   multilingual-assistant:
     <<: *app-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,7 @@ services:
       USE_SILERO_VAD_TURN_DETECTION: "true"
       SILERO_VAD_STOP_SECS: "0.5"
       AUDIO_OUT_10MS_CHUNKS: "40"
+      ENABLE_BOT_INTRODUCTION: "false"
 
   multilingual-assistant:
     <<: *app-base

--- a/docs/02-configuration-guide.md
+++ b/docs/02-configuration-guide.md
@@ -23,6 +23,22 @@ What ASR / LLM / TTS models are available, their VRAM, precision, and known issu
 | [Enable a TURN Server](how-to/enable-turn-server.md) | TURN server for remote / cross-network WebRTC access |
 | [Enable the Audio Recorder](how-to/enable-audio-recorder.md) | Capture raw ASR/TTS audio per turn for debugging |
 
+## Welcome Message
+
+When a client connects, the bot sends a welcome message (greets/introduces itself) before the user speaks. Disable it to have the bot wait for the user instead. This applies to the Generic, Multilingual, Omni, and Frontend/Backend Agent examples.
+
+- **Per example (backend-only):** set `welcome_message: false` on an example in [`examples_registry.yaml`](../examples_registry.yaml). The default is `true` when the key is omitted.
+- **Global override:** set `ENABLE_WELCOME_MESSAGE` in `.env`. When set it wins over every example's registry value — this is how the `generic-assistant/workstation-perf` profile disables the greeting.
+
+```yaml
+# examples_registry.yaml: keep one example quiet until the user speaks
+examples:
+  generic-assistant:
+    welcome_message: false
+```
+
+While the welcome message is enabled, the user is muted until the bot finishes its opening turn (`MuteUntilFirstBotCompleteUserMuteStrategy`) so the greeting isn't interrupted. Disabling it drops that mute strategy — there is no first bot turn to wait on — so the user is unmuted immediately.
+
 ## Performance tuning
 
 Pipeline tuning knobs (smart turn, chat-history window, audio buffering, transport) live in [Tune Pipeline Performance](how-to/tune-pipeline-performance.md). For benchmark results, see [Evaluation and Performance](04-evaluation-and-performance.md).

--- a/docs/how-to/tune-pipeline-performance.md
+++ b/docs/how-to/tune-pipeline-performance.md
@@ -3,6 +3,7 @@
 This section covers pipeline configurations for optimizing the performance and user experience of the Nemotron Voice Agent.
 
 - [Smart Turn Detection](#smart-turn-detection)
+- [Bot Introduction](#bot-introduction)
 - [Chat History Limit](#chat-history-limit)
 - [Audio Output Buffering](#audio-output-buffering)
 - [Uvicorn Worker Scaling](#uvicorn-worker-scaling)
@@ -38,6 +39,21 @@ By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https:
 | `MuteUntilFirstBotCompleteUserMuteStrategy` | The user-mute strategy. Mutes user input until the first bot response completes |
 
 The [Omni examples](../../src/examples/omni_assistant/README.md) run ASR inside the model, so there is no upstream `TranscriptionFrame` for Pipecat's stock Smart Turn stop strategy to wait on. They use a custom `AudioOnlySmartTurnStopStrategy` that wraps the same [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) model (`LocalSmartTurnAnalyzerV3`, fallback `stop_secs=1.0`) plus a `VADUserTurnStartStrategy`, and finalizes the turn as soon as the analyzer returns `COMPLETE`. The same `MuteUntilFirstBotCompleteUserMuteStrategy` applies.
+
+## Bot Introduction
+
+By default, when a client connects the bot introduces itself (greets the user) before the user says anything. This is driven by a synthetic first turn queued on `on_client_ready`. Set `ENABLE_BOT_INTRODUCTION=false` to skip that greeting so the bot stays silent until the user speaks first.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_BOT_INTRODUCTION` | `true` | When `true`, the bot greets/introduces itself on connect. Set `false` to wait for the user to speak first. |
+
+This applies to the Generic, Multilingual, Omni, and Frontend/Backend Agent examples. The `generic-assistant/workstation-perf` profile sets `ENABLE_BOT_INTRODUCTION=false` so benchmark runs start from a clean user turn.
+
+```bash
+# .env: keep the bot quiet until the user speaks
+ENABLE_BOT_INTRODUCTION=false
+```
 
 ## Chat History Limit
 

--- a/docs/how-to/tune-pipeline-performance.md
+++ b/docs/how-to/tune-pipeline-performance.md
@@ -3,7 +3,7 @@
 This section covers pipeline configurations for optimizing the performance and user experience of the Nemotron Voice Agent.
 
 - [Smart Turn Detection](#smart-turn-detection)
-- [Bot Introduction](#bot-introduction)
+- [Welcome Message](#welcome-message)
 - [Chat History Limit](#chat-history-limit)
 - [Audio Output Buffering](#audio-output-buffering)
 - [Uvicorn Worker Scaling](#uvicorn-worker-scaling)
@@ -40,19 +40,15 @@ By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https:
 
 The [Omni examples](../../src/examples/omni_assistant/README.md) run ASR inside the model, so there is no upstream `TranscriptionFrame` for Pipecat's stock Smart Turn stop strategy to wait on. They use a custom `AudioOnlySmartTurnStopStrategy` that wraps the same [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) model (`LocalSmartTurnAnalyzerV3`, fallback `stop_secs=1.0`) plus a `VADUserTurnStartStrategy`, and finalizes the turn as soon as the analyzer returns `COMPLETE`. The same `MuteUntilFirstBotCompleteUserMuteStrategy` applies.
 
-## Bot Introduction
+## Welcome Message
 
-By default, when a client connects the bot introduces itself (greets the user) before the user says anything. This is driven by a synthetic first turn queued on `on_client_ready`. Set `ENABLE_BOT_INTRODUCTION=false` to skip that greeting so the bot stays silent until the user speaks first.
+By default, when a client connects the bot sends a welcome message (greets/introduces itself) before the user says anything. This is driven by a synthetic first turn queued on `on_client_ready`. Set `ENABLE_WELCOME_MESSAGE=false` to skip that greeting so the bot stays silent until the user speaks first.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ENABLE_BOT_INTRODUCTION` | `true` | When `true`, the bot greets/introduces itself on connect. Set `false` to wait for the user to speak first. |
-
-This applies to the Generic, Multilingual, Omni, and Frontend/Backend Agent examples. The `generic-assistant/workstation-perf` profile sets `ENABLE_BOT_INTRODUCTION=false` so benchmark runs start from a clean user turn.
+This applies to the Generic, Multilingual, Omni, and Frontend/Backend Agent examples. The `generic-assistant/workstation-perf` profile sets `ENABLE_WELCOME_MESSAGE=false` so benchmark runs start from a clean user turn.
 
 ```bash
 # .env: keep the bot quiet until the user speaks
-ENABLE_BOT_INTRODUCTION=false
+ENABLE_WELCOME_MESSAGE=false
 ```
 
 ## Chat History Limit

--- a/docs/how-to/tune-pipeline-performance.md
+++ b/docs/how-to/tune-pipeline-performance.md
@@ -10,13 +10,13 @@ This section covers pipeline configurations for optimizing the performance and u
 
 ## Smart Turn Detection
 
-By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) detection to decide when the user has finished speaking, so the agent replies promptly without cutting the user off. [Silero VAD](https://docs.pipecat.ai/server/utilities/audio/silero-vad-analyzer) (`stop_secs=0.2`) detects the pause, and the Smart Turn model then judges whether the turn is actually complete.
+By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) detection to decide when the user has finished speaking, so the agent replies promptly without cutting the user off. [Silero VAD](https://docs.pipecat.ai/server/utilities/audio/silero-vad-analyzer) (`stop_secs=0.2`) detects the pause, and the Smart Turn model then judges whether the turn is actually complete. If the model still has not finalized after **1.0 s** of silence, the turn completes anyway (fallback).
 
 ### How It Works
 
 1. The user speaks, and ASR emits interim transcripts as audio streams in.
 2. Silero VAD detects a pause in speech.
-3. The Smart Turn model analyzes the recent audio and classifies the turn as **complete** or **incomplete**. If it's incomplete but silence continues past the stop threshold, the turn completes anyway (fallback).
+3. The Smart Turn model analyzes the recent audio and classifies the turn as **complete** or **incomplete**. If it's incomplete but silence continues past the 1.0 s stop threshold, the turn completes anyway (fallback).
 4. On a completed turn, the transcript goes to the LLM and TTS streams the reply back.
 
 ### Configuration
@@ -26,18 +26,18 @@ By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https:
 | `USE_SILERO_VAD_TURN_DETECTION` | `false` | Keep `false` for Smart Turn. Set `true` to disable it and use pure Silero VAD end-of-utterance detection instead. |
 | `SILERO_VAD_STOP_SECS` | `0.5` | Silence (seconds) before end-of-utterance. Applies **only** in pure-VAD mode (`USE_SILERO_VAD_TURN_DETECTION=true`). |
 
-> The default Smart Turn path uses a fixed `0.2 s` Silero floor (`stop_secs=0.2`), so `SILERO_VAD_STOP_SECS` does not apply there. The two thresholds are independent and never both active.
+> The default Smart Turn path uses a fixed `0.2 s` Silero floor (`stop_secs=0.2`) and a `1.0 s` Smart Turn silence fallback. `SILERO_VAD_STOP_SECS` does not apply on the Smart Turn path. The two thresholds are independent and never both active. The `generic-assistant/workstation-perf` profile forces pure Silero VAD (`USE_SILERO_VAD_TURN_DETECTION=true`, `SILERO_VAD_STOP_SECS=0.5`) for lower-overhead load testing.
 
 ### Key Components
 
 | Component | Purpose |
 |-----------|---------|
 | [`SileroVADAnalyzer`](https://docs.pipecat.ai/server/utilities/audio/silero-vad-analyzer) | Voice activity detection with a configurable silence threshold |
-| [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) (default) | ML end-of-utterance detection for natural turn-taking |
+| [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) (default) | ML end-of-utterance detection for natural turn-taking (`LocalSmartTurnAnalyzerV3`, fallback `stop_secs=1.0`) |
 | `SpeechTimeoutUserTurnStopStrategy` | End-of-turn strategy used **only** in pure-VAD mode (`USE_SILERO_VAD_TURN_DETECTION=true`). Ends the turn on a VAD silence timeout instead of the Smart Turn model |
 | `MuteUntilFirstBotCompleteUserMuteStrategy` | The user-mute strategy. Mutes user input until the first bot response completes |
 
-The [Omni examples](../../src/examples/omni_assistant/README.md) run ASR inside the model, so there is no upstream `TranscriptionFrame` for Pipecat's stock Smart Turn stop strategy to wait on. They use a custom `AudioOnlySmartTurnStopStrategy` that wraps the same [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) model (`LocalSmartTurnAnalyzerV3`, `stop_secs=0.7`) plus a `VADUserTurnStartStrategy`, and finalizes the turn as soon as the analyzer returns `COMPLETE`. The same `MuteUntilFirstBotCompleteUserMuteStrategy` applies.
+The [Omni examples](../../src/examples/omni_assistant/README.md) run ASR inside the model, so there is no upstream `TranscriptionFrame` for Pipecat's stock Smart Turn stop strategy to wait on. They use a custom `AudioOnlySmartTurnStopStrategy` that wraps the same [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) model (`LocalSmartTurnAnalyzerV3`, fallback `stop_secs=1.0`) plus a `VADUserTurnStartStrategy`, and finalizes the turn as soon as the analyzer returns `COMPLETE`. The same `MuteUntilFirstBotCompleteUserMuteStrategy` applies.
 
 ## Chat History Limit
 

--- a/docs/how-to/tune-pipeline-performance.md
+++ b/docs/how-to/tune-pipeline-performance.md
@@ -27,7 +27,7 @@ By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https:
 | `USE_SILERO_VAD_TURN_DETECTION` | `false` | Keep `false` for Smart Turn. Set `true` to disable it and use pure Silero VAD end-of-utterance detection instead. |
 | `SILERO_VAD_STOP_SECS` | `0.5` | Silence (seconds) before end-of-utterance. Applies **only** in pure-VAD mode (`USE_SILERO_VAD_TURN_DETECTION=true`). |
 
-> The default Smart Turn path uses a fixed `0.2 s` Silero floor (`stop_secs=0.2`) and a `1.0 s` Smart Turn silence fallback. `SILERO_VAD_STOP_SECS` does not apply on the Smart Turn path. The two thresholds are independent and never both active. The `generic-assistant/workstation-perf` profile forces pure Silero VAD (`USE_SILERO_VAD_TURN_DETECTION=true`, `SILERO_VAD_STOP_SECS=0.5`) for lower-overhead load testing.
+> On the Smart Turn path the two thresholds apply **sequentially**: a fixed `0.2 s` Silero VAD pause (`stop_secs=0.2`) first detects the silence, then the Smart Turn model gets up to a `1.0 s` silence fallback to finalize the turn. Only `SILERO_VAD_STOP_SECS` is ignored in Smart Turn mode. The `generic-assistant/workstation-perf` profile forces pure Silero VAD (`USE_SILERO_VAD_TURN_DETECTION=true`, `SILERO_VAD_STOP_SECS=0.5`) for lower-overhead load testing.
 
 ### Key Components
 

--- a/docs/how-to/tune-pipeline-performance.md
+++ b/docs/how-to/tune-pipeline-performance.md
@@ -3,7 +3,6 @@
 This section covers pipeline configurations for optimizing the performance and user experience of the Nemotron Voice Agent.
 
 - [Smart Turn Detection](#smart-turn-detection)
-- [Welcome Message](#welcome-message)
 - [Chat History Limit](#chat-history-limit)
 - [Audio Output Buffering](#audio-output-buffering)
 - [Uvicorn Worker Scaling](#uvicorn-worker-scaling)
@@ -11,13 +10,13 @@ This section covers pipeline configurations for optimizing the performance and u
 
 ## Smart Turn Detection
 
-By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) detection to decide when the user has finished speaking, so the agent replies promptly without cutting the user off. [Silero VAD](https://docs.pipecat.ai/server/utilities/audio/silero-vad-analyzer) (`stop_secs=0.2`) detects the pause, and the Smart Turn model then judges whether the turn is actually complete. If the model still has not finalized after **1.0 s** of silence, the turn completes anyway (fallback).
+By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) detection to decide when the user has finished speaking, so the agent replies promptly without cutting the user off. [Silero VAD](https://docs.pipecat.ai/server/utilities/audio/silero-vad-analyzer) (`stop_secs=0.2`) detects the pause, and the Smart Turn model then judges whether the turn is actually complete. If the model still has not finalized after the Smart Turn silence fallback (default **1.0 s**, `SMART_TURN_STOP_SECS`), the turn completes anyway (fallback).
 
 ### How It Works
 
 1. The user speaks, and ASR emits interim transcripts as audio streams in.
 2. Silero VAD detects a pause in speech.
-3. The Smart Turn model analyzes the recent audio and classifies the turn as **complete** or **incomplete**. If it's incomplete but silence continues past the 1.0 s stop threshold, the turn completes anyway (fallback).
+3. The Smart Turn model analyzes the recent audio and classifies the turn as **complete** or **incomplete**. If it's incomplete but silence continues past the Smart Turn stop threshold (default 1.0 s, `SMART_TURN_STOP_SECS`), the turn completes anyway (fallback).
 4. On a completed turn, the transcript goes to the LLM and TTS streams the reply back.
 
 ### Configuration
@@ -26,30 +25,19 @@ By default the cascaded pipeline uses Pipecat's ML-based [**Smart Turn**](https:
 |----------|---------|-------------|
 | `USE_SILERO_VAD_TURN_DETECTION` | `false` | Keep `false` for Smart Turn. Set `true` to disable it and use pure Silero VAD end-of-utterance detection instead. |
 | `SILERO_VAD_STOP_SECS` | `0.5` | Silence (seconds) before end-of-utterance. Applies **only** in pure-VAD mode (`USE_SILERO_VAD_TURN_DETECTION=true`). |
+| `SMART_TURN_STOP_SECS` | `1.0` | Smart Turn silence fallback (seconds) before the turn completes without a `COMPLETE` classification. Applies **only** in Smart Turn mode (`USE_SILERO_VAD_TURN_DETECTION=false`). |
 
-> On the Smart Turn path the two thresholds apply **sequentially**: a fixed `0.2 s` Silero VAD pause (`stop_secs=0.2`) first detects the silence, then the Smart Turn model gets up to a `1.0 s` silence fallback to finalize the turn. Only `SILERO_VAD_STOP_SECS` is ignored in Smart Turn mode. The `generic-assistant/workstation-perf` profile forces pure Silero VAD (`USE_SILERO_VAD_TURN_DETECTION=true`, `SILERO_VAD_STOP_SECS=0.5`) for lower-overhead load testing.
+> On the Smart Turn path the two thresholds apply **sequentially**: a fixed `0.2 s` Silero VAD pause (`stop_secs=0.2`) first detects the silence, then the Smart Turn model gets up to the Smart Turn silence fallback (default `1.0 s`, `SMART_TURN_STOP_SECS`) to finalize the turn. Only `SILERO_VAD_STOP_SECS` is ignored in Smart Turn mode. The `generic-assistant/workstation-perf` profile forces pure Silero VAD (`USE_SILERO_VAD_TURN_DETECTION=true`, `SILERO_VAD_STOP_SECS=0.5`) for lower-overhead load testing.
 
 ### Key Components
 
 | Component | Purpose |
 |-----------|---------|
 | [`SileroVADAnalyzer`](https://docs.pipecat.ai/server/utilities/audio/silero-vad-analyzer) | Voice activity detection with a configurable silence threshold |
-| [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) (default) | ML end-of-utterance detection for natural turn-taking (`LocalSmartTurnAnalyzerV3`, fallback `stop_secs=1.0`) |
+| [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) (default) | ML end-of-utterance detection for natural turn-taking (`LocalSmartTurnAnalyzerV3`, fallback `stop_secs` default `1.0`, `SMART_TURN_STOP_SECS`) |
 | `SpeechTimeoutUserTurnStopStrategy` | End-of-turn strategy used **only** in pure-VAD mode (`USE_SILERO_VAD_TURN_DETECTION=true`). Ends the turn on a VAD silence timeout instead of the Smart Turn model |
-| `MuteUntilFirstBotCompleteUserMuteStrategy` | The user-mute strategy. Mutes user input until the first bot response completes |
 
-The [Omni examples](../../src/examples/omni_assistant/README.md) run ASR inside the model, so there is no upstream `TranscriptionFrame` for Pipecat's stock Smart Turn stop strategy to wait on. They use a custom `AudioOnlySmartTurnStopStrategy` that wraps the same [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) model (`LocalSmartTurnAnalyzerV3`, fallback `stop_secs=1.0`) plus a `VADUserTurnStartStrategy`, and finalizes the turn as soon as the analyzer returns `COMPLETE`. The same `MuteUntilFirstBotCompleteUserMuteStrategy` applies.
-
-## Welcome Message
-
-By default, when a client connects the bot sends a welcome message (greets/introduces itself) before the user says anything. This is driven by a synthetic first turn queued on `on_client_ready`. Set `ENABLE_WELCOME_MESSAGE=false` to skip that greeting so the bot stays silent until the user speaks first.
-
-This applies to the Generic, Multilingual, Omni, and Frontend/Backend Agent examples. The `generic-assistant/workstation-perf` profile sets `ENABLE_WELCOME_MESSAGE=false` so benchmark runs start from a clean user turn.
-
-```bash
-# .env: keep the bot quiet until the user speaks
-ENABLE_WELCOME_MESSAGE=false
-```
+The [Omni examples](../../src/examples/omni_assistant/README.md) run ASR inside the model, so there is no upstream `TranscriptionFrame` for Pipecat's stock Smart Turn stop strategy to wait on. They use a custom `AudioOnlySmartTurnStopStrategy` that wraps the same [Smart Turn](https://docs.pipecat.ai/api-reference/server/utilities/turn-detection/smart-turn-overview) model (`LocalSmartTurnAnalyzerV3`, fallback `stop_secs` default `1.0`, `SMART_TURN_STOP_SECS`) plus a `VADUserTurnStartStrategy`, and finalizes the turn as soon as the analyzer returns `COMPLETE`.
 
 ## Chat History Limit
 

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -27,6 +27,7 @@ from pipecat.services.nvidia.tts import NvidiaTTSService, NvidiaTTSSettings
 from pipecat.transports.base_transport import TransportParams
 from pipecat.workers.runner import WorkerRunner
 
+import examples_registry
 from examples.frontend_backend_agent.airline.backend import HTTPBookingBackend
 from examples.frontend_backend_agent.airline.thinker import ThinkerBackend
 from examples.frontend_backend_agent.airline.tools import TOOLS_SCHEMA
@@ -36,7 +37,7 @@ from examples.frontend_backend_agent.src.tool_handlers import build_handlers
 from examples.frontend_backend_agent.src.tts_filter import apply_frontend_backend_agent_pronunciation_for_tts
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
-from examples.shared.pipeline_utils import build_user_aggregator_params, welcome_message_enabled
+from examples.shared.pipeline_utils import build_user_aggregator_params
 from tracing import IS_TRACING_ENABLED
 from utils import (
     is_nvcf,
@@ -99,6 +100,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     logger.info("Starting Frontend/Backend Agent cascaded pipeline")
     transport = _create_transport(runner_args)
     body = runner_args.body if isinstance(runner_args.body, dict) else {}
+    welcome_enabled = examples_registry.welcome_message_enabled(body.get("pipeline_mode", ""))
 
     prompt_key, talker_prompt = resolve_prompt(
         __file__,
@@ -252,7 +254,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     preserve_prompt_messages = len(messages)
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
-        user_params=build_user_aggregator_params(),
+        user_params=build_user_aggregator_params(welcome_enabled),
     )
     audio_recorder = create_audio_recorder()
 
@@ -317,7 +319,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if not welcome_message_enabled():
+        if not welcome_enabled:
             logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": "Please greet the user briefly."})

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -36,7 +36,7 @@ from examples.frontend_backend_agent.src.tool_handlers import build_handlers
 from examples.frontend_backend_agent.src.tts_filter import apply_frontend_backend_agent_pronunciation_for_tts
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
-from examples.shared.pipeline_utils import build_user_aggregator_params
+from examples.shared.pipeline_utils import bot_introduction_enabled, build_user_aggregator_params
 from tracing import IS_TRACING_ENABLED
 from utils import (
     is_nvcf,
@@ -317,6 +317,9 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
+        if not bot_introduction_enabled():
+            logger.info("Bot introduction disabled; waiting for the user to speak first")
+            return
         context.add_message({"role": "user", "content": "Please greet the user briefly."})
         await task.queue_frames([LLMRunFrame()])
 

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -11,8 +11,6 @@ from datetime import timedelta
 
 from dotenv import load_dotenv
 from loguru import logger
-from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.frames.frames import LLMRunFrame, TTSUpdateSettingsFrame
 from pipecat.observers.user_bot_latency_observer import UserBotLatencyObserver
 from pipecat.pipeline.pipeline import Pipeline
@@ -20,7 +18,6 @@ from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
-    LLMUserAggregatorParams,
 )
 from pipecat.processors.frameworks.rtvi.frames import RTVIServerMessageFrame
 from pipecat.runner.types import RunnerArguments
@@ -28,7 +25,6 @@ from pipecat.services.nvidia.llm import NvidiaLLMService, NvidiaLLMSettings
 from pipecat.services.nvidia.stt import NvidiaSTTService, NvidiaSTTSettings
 from pipecat.services.nvidia.tts import NvidiaTTSService, NvidiaTTSSettings
 from pipecat.transports.base_transport import TransportParams
-from pipecat.turns.user_mute import MuteUntilFirstBotCompleteUserMuteStrategy
 from pipecat.workers.runner import WorkerRunner
 
 from examples.frontend_backend_agent.airline.backend import HTTPBookingBackend
@@ -40,6 +36,7 @@ from examples.frontend_backend_agent.src.tool_handlers import build_handlers
 from examples.frontend_backend_agent.src.tts_filter import apply_frontend_backend_agent_pronunciation_for_tts
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
+from examples.shared.pipeline_utils import build_user_aggregator_params
 from tracing import IS_TRACING_ENABLED
 from utils import (
     is_nvcf,
@@ -255,10 +252,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     preserve_prompt_messages = len(messages)
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
-        user_params=LLMUserAggregatorParams(
-            vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-            user_mute_strategies=[MuteUntilFirstBotCompleteUserMuteStrategy()],
-        ),
+        user_params=build_user_aggregator_params(),
     )
     audio_recorder = create_audio_recorder()
 

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -36,7 +36,7 @@ from examples.frontend_backend_agent.src.tool_handlers import build_handlers
 from examples.frontend_backend_agent.src.tts_filter import apply_frontend_backend_agent_pronunciation_for_tts
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
-from examples.shared.pipeline_utils import bot_introduction_enabled, build_user_aggregator_params
+from examples.shared.pipeline_utils import build_user_aggregator_params, welcome_message_enabled
 from tracing import IS_TRACING_ENABLED
 from utils import (
     is_nvcf,
@@ -317,8 +317,8 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if not bot_introduction_enabled():
-            logger.info("Bot introduction disabled; waiting for the user to speak first")
+        if not welcome_message_enabled():
+            logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": "Please greet the user briefly."})
         await task.queue_frames([LLMRunFrame()])

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -34,6 +34,7 @@ from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
 from examples.shared.pipeline_utils import (
     apply_pinned_prompt_summary,
+    bot_introduction_enabled,
     build_context_messages,
     build_user_aggregator_params,
     create_transport,
@@ -285,6 +286,9 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
+        if not bot_introduction_enabled():
+            logger.info("Bot introduction disabled; waiting for the user to speak first")
+            return
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
         await task.queue_frames([LLMRunFrame()])
 

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -34,10 +34,10 @@ from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
 from examples.shared.pipeline_utils import (
     apply_pinned_prompt_summary,
-    bot_introduction_enabled,
     build_context_messages,
     build_user_aggregator_params,
     create_transport,
+    welcome_message_enabled,
 )
 from tracing import IS_TRACING_ENABLED
 from utils import (
@@ -286,8 +286,8 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if not bot_introduction_enabled():
-            logger.info("Bot introduction disabled; waiting for the user to speak first")
+        if not welcome_message_enabled():
+            logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
         await task.queue_frames([LLMRunFrame()])

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -29,6 +29,7 @@ from pipecat.services.nvidia.stt import NvidiaSTTService, NvidiaSTTSettings
 from pipecat.services.nvidia.tts import NvidiaTTSService, NvidiaTTSSettings
 from pipecat.workers.runner import WorkerRunner
 
+import examples_registry
 from examples.generic.tools import TOOL_HANDLERS, build_tools_schema
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
@@ -37,7 +38,6 @@ from examples.shared.pipeline_utils import (
     build_context_messages,
     build_user_aggregator_params,
     create_transport,
-    welcome_message_enabled,
 )
 from tracing import IS_TRACING_ENABLED
 from utils import (
@@ -59,6 +59,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     """Build and run the NVIDIA cascaded pipeline for a single session."""
     transport = create_transport(runner_args)
     body = runner_args.body if isinstance(runner_args.body, dict) else {}
+    welcome_enabled = examples_registry.welcome_message_enabled(body.get("pipeline_mode", ""))
     prompt_key, base_system_content = resolve_prompt(
         __file__,
         body.get("prompt_content", ""),
@@ -176,7 +177,7 @@ async def bot(runner_args: RunnerArguments) -> None:
 
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
-        user_params=build_user_aggregator_params(),
+        user_params=build_user_aggregator_params(welcome_enabled),
     )
     logger.info(
         f"Chat history summarization enabled: recent_turns={CHAT_HISTORY_RECENT_TURNS}, "
@@ -286,7 +287,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if not welcome_message_enabled():
+        if not welcome_enabled:
             logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -50,6 +50,7 @@ from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
 from examples.shared.pipeline_utils import (
     apply_pinned_prompt_summary,
     build_context_messages,
+    build_smart_turn_stop_strategies,
     create_transport,
 )
 from examples.shared.prewarm import prewarm_asr, prewarm_tts, resolve_voice_for_language
@@ -85,7 +86,10 @@ def _build_multilingual_user_aggregator_params() -> LLMUserAggregatorParams:
         return LLMUserAggregatorParams(
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
             user_mute_strategies=[MuteUntilFirstBotCompleteUserMuteStrategy()],
-            user_turn_strategies=UserTurnStrategies(start=[VADUserTurnStartStrategy()]),
+            user_turn_strategies=UserTurnStrategies(
+                start=[VADUserTurnStartStrategy()],
+                stop=build_smart_turn_stop_strategies(),
+            ),
         )
 
     stop_secs = parse_env_float("SILERO_VAD_STOP_SECS", 0.5, min_value=0.0)

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -48,11 +48,11 @@ from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
 from examples.shared.pipeline_utils import (
     apply_pinned_prompt_summary,
-    bot_introduction_enabled,
     build_context_messages,
     build_smart_turn_stop_strategies,
     build_user_mute_strategies,
     create_transport,
+    welcome_message_enabled,
 )
 from examples.shared.prewarm import prewarm_asr, prewarm_tts, resolve_voice_for_language
 from tracing import IS_TRACING_ENABLED
@@ -409,8 +409,8 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if not bot_introduction_enabled():
-            logger.info("Bot introduction disabled; waiting for the user to speak first")
+        if not welcome_message_enabled():
+            logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": FIXED_SESSION_GREETING_TRIGGER})
         await task.queue_frames([LLMRunFrame()])

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -35,6 +35,7 @@ from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 from pipecat.workers.runner import WorkerRunner
 
+import examples_registry
 from examples.multilingual.multilingual_processor import (
     FIXED_SESSION_GREETING_TRIGGER,
     FIXED_SESSION_LANGUAGE_ADDON_KEY,
@@ -52,7 +53,6 @@ from examples.shared.pipeline_utils import (
     build_smart_turn_stop_strategies,
     build_user_mute_strategies,
     create_transport,
-    welcome_message_enabled,
 )
 from examples.shared.prewarm import prewarm_asr, prewarm_tts, resolve_voice_for_language
 from tracing import IS_TRACING_ENABLED
@@ -81,12 +81,12 @@ def _is_eval_transport(runner_args: RunnerArguments) -> bool:
     return cli_transport == "eval" or isinstance(runner_args, EvalRunnerArguments)
 
 
-def _build_multilingual_user_aggregator_params() -> LLMUserAggregatorParams:
+def _build_multilingual_user_aggregator_params(welcome_enabled: bool) -> LLMUserAggregatorParams:
     """Use VAD-only turn starts so interim ASR text does not start a user turn."""
     if not parse_env_bool("USE_SILERO_VAD_TURN_DETECTION", default=False):
         return LLMUserAggregatorParams(
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-            user_mute_strategies=build_user_mute_strategies(),
+            user_mute_strategies=build_user_mute_strategies(welcome_enabled),
             user_turn_strategies=UserTurnStrategies(
                 start=[VADUserTurnStartStrategy()],
                 stop=build_smart_turn_stop_strategies(),
@@ -96,7 +96,7 @@ def _build_multilingual_user_aggregator_params() -> LLMUserAggregatorParams:
     stop_secs = parse_env_float("SILERO_VAD_STOP_SECS", 0.5, min_value=0.0)
     return LLMUserAggregatorParams(
         vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=stop_secs)),
-        user_mute_strategies=build_user_mute_strategies(),
+        user_mute_strategies=build_user_mute_strategies(welcome_enabled),
         user_turn_strategies=UserTurnStrategies(
             start=[VADUserTurnStartStrategy()],
             stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0)],
@@ -138,6 +138,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     """Build and run the multilingual NVIDIA cascaded pipeline for a single session."""
     transport = create_transport(runner_args)
     body = runner_args.body if isinstance(runner_args.body, dict) else {}
+    welcome_enabled = examples_registry.welcome_message_enabled(body.get("pipeline_mode", ""))
     prompt_key, base_system_content = resolve_prompt(
         __file__,
         body.get("prompt_content", ""),
@@ -298,7 +299,7 @@ async def bot(runner_args: RunnerArguments) -> None:
 
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
         context,
-        user_params=_build_multilingual_user_aggregator_params(),
+        user_params=_build_multilingual_user_aggregator_params(welcome_enabled),
     )
     logger.info(
         f"Chat history summarization enabled: recent_turns={CHAT_HISTORY_RECENT_TURNS}, "
@@ -409,7 +410,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if not welcome_message_enabled():
+        if not welcome_enabled:
             logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": FIXED_SESSION_GREETING_TRIGGER})

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -49,6 +49,7 @@ from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
 from examples.shared.pipeline_utils import (
     apply_pinned_prompt_summary,
+    bot_introduction_enabled,
     build_context_messages,
     build_smart_turn_stop_strategies,
     create_transport,
@@ -408,6 +409,9 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
+        if not bot_introduction_enabled():
+            logger.info("Bot introduction disabled; waiting for the user to speak first")
+            return
         context.add_message({"role": "user", "content": FIXED_SESSION_GREETING_TRIGGER})
         await task.queue_frames([LLMRunFrame()])
 

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -30,7 +30,6 @@ from pipecat.runner.types import EvalRunnerArguments, RunnerArguments
 from pipecat.services.nvidia.llm import NvidiaLLMService, NvidiaLLMSettings
 from pipecat.services.nvidia.stt import NvidiaSTTService, NvidiaSTTSettings
 from pipecat.services.nvidia.tts import NvidiaTTSService, NvidiaTTSSettings
-from pipecat.turns.user_mute import MuteUntilFirstBotCompleteUserMuteStrategy
 from pipecat.turns.user_start.vad_user_turn_start_strategy import VADUserTurnStartStrategy
 from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
@@ -52,6 +51,7 @@ from examples.shared.pipeline_utils import (
     bot_introduction_enabled,
     build_context_messages,
     build_smart_turn_stop_strategies,
+    build_user_mute_strategies,
     create_transport,
 )
 from examples.shared.prewarm import prewarm_asr, prewarm_tts, resolve_voice_for_language
@@ -86,7 +86,7 @@ def _build_multilingual_user_aggregator_params() -> LLMUserAggregatorParams:
     if not parse_env_bool("USE_SILERO_VAD_TURN_DETECTION", default=False):
         return LLMUserAggregatorParams(
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-            user_mute_strategies=[MuteUntilFirstBotCompleteUserMuteStrategy()],
+            user_mute_strategies=build_user_mute_strategies(),
             user_turn_strategies=UserTurnStrategies(
                 start=[VADUserTurnStartStrategy()],
                 stop=build_smart_turn_stop_strategies(),
@@ -96,7 +96,7 @@ def _build_multilingual_user_aggregator_params() -> LLMUserAggregatorParams:
     stop_secs = parse_env_float("SILERO_VAD_STOP_SECS", 0.5, min_value=0.0)
     return LLMUserAggregatorParams(
         vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=stop_secs)),
-        user_mute_strategies=[MuteUntilFirstBotCompleteUserMuteStrategy()],
+        user_mute_strategies=build_user_mute_strategies(),
         user_turn_strategies=UserTurnStrategies(
             start=[VADUserTurnStartStrategy()],
             stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0)],

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -51,7 +51,7 @@ from examples.omni_assistant.nvidia_omni_multimodal_service import (
 )
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
-from examples.shared.pipeline_utils import build_smart_turn_analyzer
+from examples.shared.pipeline_utils import bot_introduction_enabled, build_smart_turn_analyzer
 from tracing import IS_TRACING_ENABLED
 from utils import (
     is_nvcf,
@@ -338,6 +338,9 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
+        if not bot_introduction_enabled():
+            logger.info("Bot introduction disabled; waiting for the user to speak first")
+            return
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
         await task.queue_frames([LLMRunFrame()])
 

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -18,8 +18,6 @@ from typing import Any
 
 from dotenv import load_dotenv
 from loguru import logger
-from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
-from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnalyzerV3
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.frames.frames import (
@@ -53,6 +51,7 @@ from examples.omni_assistant.nvidia_omni_multimodal_service import (
 )
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
+from examples.shared.pipeline_utils import build_smart_turn_analyzer
 from tracing import IS_TRACING_ENABLED
 from utils import (
     is_nvcf,
@@ -74,9 +73,7 @@ def _build_user_turn_strategies() -> UserTurnStrategies:
     return UserTurnStrategies(
         start=[VADUserTurnStartStrategy()],
         stop=[
-            AudioOnlySmartTurnStopStrategy(
-                turn_analyzer=LocalSmartTurnAnalyzerV3(params=SmartTurnParams(stop_secs=0.7))
-            )
+            AudioOnlySmartTurnStopStrategy(turn_analyzer=build_smart_turn_analyzer())
         ],
     )
 

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -36,9 +36,6 @@ from pipecat.processors.frameworks.rtvi.frames import RTVIServerMessageFrame
 from pipecat.runner.types import RunnerArguments
 from pipecat.services.nvidia.tts import NvidiaTTSService, NvidiaTTSSettings
 from pipecat.transports.base_transport import TransportParams
-from pipecat.turns.user_mute.mute_until_first_bot_complete_user_mute_strategy import (
-    MuteUntilFirstBotCompleteUserMuteStrategy,
-)
 from pipecat.turns.user_start.vad_user_turn_start_strategy import VADUserTurnStartStrategy
 from pipecat.turns.user_turn_processor import UserTurnProcessor
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
@@ -51,7 +48,11 @@ from examples.omni_assistant.nvidia_omni_multimodal_service import (
 )
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
-from examples.shared.pipeline_utils import bot_introduction_enabled, build_smart_turn_analyzer
+from examples.shared.pipeline_utils import (
+    bot_introduction_enabled,
+    build_smart_turn_analyzer,
+    build_user_mute_strategies,
+)
 from tracing import IS_TRACING_ENABLED
 from utils import (
     is_nvcf,
@@ -72,9 +73,7 @@ def _build_user_turn_strategies() -> UserTurnStrategies:
     """Build VAD-start + Smart Turn-stop strategies for Omni audio turns."""
     return UserTurnStrategies(
         start=[VADUserTurnStartStrategy()],
-        stop=[
-            AudioOnlySmartTurnStopStrategy(turn_analyzer=build_smart_turn_analyzer())
-        ],
+        stop=[AudioOnlySmartTurnStopStrategy(turn_analyzer=build_smart_turn_analyzer())],
     )
 
 
@@ -175,7 +174,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         context,
         user_params=LLMUserAggregatorParams(
             vad_analyzer=SileroVADAnalyzer(params=VADParams()),
-            user_mute_strategies=[MuteUntilFirstBotCompleteUserMuteStrategy()],
+            user_mute_strategies=build_user_mute_strategies(),
             user_turn_strategies=_build_user_turn_strategies(),
         ),
     )

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -41,6 +41,7 @@ from pipecat.turns.user_turn_processor import UserTurnProcessor
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 from pipecat.workers.runner import WorkerRunner
 
+import examples_registry
 from examples.omni_assistant.audio_only_smart_turn_strategy import AudioOnlySmartTurnStopStrategy
 from examples.omni_assistant.nvidia_omni_multimodal_service import (
     NvidiaOmniService,
@@ -51,7 +52,6 @@ from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
 from examples.shared.pipeline_utils import (
     build_smart_turn_analyzer,
     build_user_mute_strategies,
-    welcome_message_enabled,
 )
 from tracing import IS_TRACING_ENABLED
 from utils import (
@@ -86,6 +86,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     """Build and run the Nemotron Omni cascaded pipeline for one session."""
     transport = _create_transport(runner_args)
     body = runner_args.body if isinstance(runner_args.body, dict) else {}
+    welcome_enabled = examples_registry.welcome_message_enabled(body.get("pipeline_mode", ""))
 
     prompt_key, base_system_content = resolve_prompt(
         __file__,
@@ -174,7 +175,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         context,
         user_params=LLMUserAggregatorParams(
             vad_analyzer=SileroVADAnalyzer(params=VADParams()),
-            user_mute_strategies=build_user_mute_strategies(),
+            user_mute_strategies=build_user_mute_strategies(welcome_enabled),
             user_turn_strategies=_build_user_turn_strategies(),
         ),
     )
@@ -337,7 +338,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if not welcome_message_enabled():
+        if not welcome_enabled:
             logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -49,9 +49,9 @@ from examples.omni_assistant.nvidia_omni_multimodal_service import (
 from examples.shared.audio_recorder import create_audio_recorder
 from examples.shared.nemotron_speech_text_filter import NemotronSpeechTextFilter
 from examples.shared.pipeline_utils import (
-    bot_introduction_enabled,
     build_smart_turn_analyzer,
     build_user_mute_strategies,
+    welcome_message_enabled,
 )
 from tracing import IS_TRACING_ENABLED
 from utils import (
@@ -337,8 +337,8 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
-        if not bot_introduction_enabled():
-            logger.info("Bot introduction disabled; waiting for the user to speak first")
+        if not welcome_message_enabled():
+            logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": "Please introduce yourself to the user."})
         await task.queue_frames([LLMRunFrame()])

--- a/src/examples/shared/pipeline_utils.py
+++ b/src/examples/shared/pipeline_utils.py
@@ -30,18 +30,15 @@ from pipecat.utils.context.llm_context_summarization import (
 
 from utils import parse_env_bool, parse_env_float, parse_env_int
 
-# Smart Turn silence fallback (seconds). Pipecat's stock default is 3.0s.
+# Smart Turn silence fallback default (seconds); override via SMART_TURN_STOP_SECS.
+# Pipecat's stock default is 3.0s.
 SMART_TURN_FALLBACK_SECS = 1.0
 
 
-def welcome_message_enabled() -> bool:
-    """Return whether the bot sends a welcome message at session start (ENABLE_WELCOME_MESSAGE)."""
-    return parse_env_bool("ENABLE_WELCOME_MESSAGE", default=True)
-
-
 def build_smart_turn_analyzer() -> LocalSmartTurnAnalyzerV3:
-    """Return LocalSmartTurnAnalyzerV3 with the blueprint fallback timeout."""
-    return LocalSmartTurnAnalyzerV3(params=SmartTurnParams(stop_secs=SMART_TURN_FALLBACK_SECS))
+    """Return LocalSmartTurnAnalyzerV3 with the configurable silence fallback."""
+    stop_secs = parse_env_float("SMART_TURN_STOP_SECS", SMART_TURN_FALLBACK_SECS, min_value=0.0)
+    return LocalSmartTurnAnalyzerV3(params=SmartTurnParams(stop_secs=stop_secs))
 
 
 def build_smart_turn_stop_strategies() -> list[TurnAnalyzerUserTurnStopStrategy]:
@@ -49,32 +46,32 @@ def build_smart_turn_stop_strategies() -> list[TurnAnalyzerUserTurnStopStrategy]
     return [TurnAnalyzerUserTurnStopStrategy(turn_analyzer=build_smart_turn_analyzer())]
 
 
-def build_user_mute_strategies() -> list[MuteUntilFirstBotCompleteUserMuteStrategy]:
+def build_user_mute_strategies(welcome_enabled: bool) -> list[MuteUntilFirstBotCompleteUserMuteStrategy]:
     """Return the user-mute strategy, or none when there is no welcome message.
 
     ``MuteUntilFirstBotCompleteUserMuteStrategy`` keeps the user muted until the
-    bot finishes its first turn. When ``ENABLE_WELCOME_MESSAGE`` is off the bot
-    waits for the user, so that first turn never happens and muting would
-    deadlock — return an empty list instead.
+    bot finishes its first turn. When the welcome message is off the bot waits
+    for the user, so that first turn never happens and muting would deadlock —
+    return an empty list instead.
     """
-    if not welcome_message_enabled():
+    if not welcome_enabled:
         return []
     return [MuteUntilFirstBotCompleteUserMuteStrategy()]
 
 
-def build_user_aggregator_params() -> LLMUserAggregatorParams:
+def build_user_aggregator_params(welcome_enabled: bool) -> LLMUserAggregatorParams:
     """Return user-turn configuration, defaulting to Pipecat smart turn."""
     if not parse_env_bool("USE_SILERO_VAD_TURN_DETECTION", default=False):
         return LLMUserAggregatorParams(
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-            user_mute_strategies=build_user_mute_strategies(),
+            user_mute_strategies=build_user_mute_strategies(welcome_enabled),
             user_turn_strategies=UserTurnStrategies(stop=build_smart_turn_stop_strategies()),
         )
 
     stop_secs = parse_env_float("SILERO_VAD_STOP_SECS", 0.5, min_value=0.0)
     return LLMUserAggregatorParams(
         vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=stop_secs)),
-        user_mute_strategies=build_user_mute_strategies(),
+        user_mute_strategies=build_user_mute_strategies(welcome_enabled),
         user_turn_strategies=UserTurnStrategies(
             stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0)],
         ),

--- a/src/examples/shared/pipeline_utils.py
+++ b/src/examples/shared/pipeline_utils.py
@@ -49,19 +49,32 @@ def build_smart_turn_stop_strategies() -> list[TurnAnalyzerUserTurnStopStrategy]
     return [TurnAnalyzerUserTurnStopStrategy(turn_analyzer=build_smart_turn_analyzer())]
 
 
+def build_user_mute_strategies() -> list[MuteUntilFirstBotCompleteUserMuteStrategy]:
+    """Return the user-mute strategy, or none when there is no bot introduction.
+
+    ``MuteUntilFirstBotCompleteUserMuteStrategy`` keeps the user muted until the
+    bot finishes its first turn. When ``ENABLE_BOT_INTRODUCTION`` is off the bot
+    waits for the user, so that first turn never happens and muting would
+    deadlock — return an empty list instead.
+    """
+    if not bot_introduction_enabled():
+        return []
+    return [MuteUntilFirstBotCompleteUserMuteStrategy()]
+
+
 def build_user_aggregator_params() -> LLMUserAggregatorParams:
     """Return user-turn configuration, defaulting to Pipecat smart turn."""
     if not parse_env_bool("USE_SILERO_VAD_TURN_DETECTION", default=False):
         return LLMUserAggregatorParams(
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
-            user_mute_strategies=[MuteUntilFirstBotCompleteUserMuteStrategy()],
+            user_mute_strategies=build_user_mute_strategies(),
             user_turn_strategies=UserTurnStrategies(stop=build_smart_turn_stop_strategies()),
         )
 
     stop_secs = parse_env_float("SILERO_VAD_STOP_SECS", 0.5, min_value=0.0)
     return LLMUserAggregatorParams(
         vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=stop_secs)),
-        user_mute_strategies=[MuteUntilFirstBotCompleteUserMuteStrategy()],
+        user_mute_strategies=build_user_mute_strategies(),
         user_turn_strategies=UserTurnStrategies(
             stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0)],
         ),

--- a/src/examples/shared/pipeline_utils.py
+++ b/src/examples/shared/pipeline_utils.py
@@ -6,6 +6,8 @@
 import asyncio
 
 from loguru import logger
+from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
+from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnalyzerV3
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.processors.aggregators.llm_context import LLMContext
@@ -16,7 +18,10 @@ from pipecat.runner.types import RunnerArguments
 from pipecat.services.nvidia.llm import NvidiaLLMService
 from pipecat.transports.base_transport import TransportParams
 from pipecat.turns.user_mute import MuteUntilFirstBotCompleteUserMuteStrategy
-from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
+from pipecat.turns.user_stop import (
+    SpeechTimeoutUserTurnStopStrategy,
+    TurnAnalyzerUserTurnStopStrategy,
+)
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 from pipecat.utils.context.llm_context_summarization import (
     DEFAULT_SUMMARIZATION_PROMPT,
@@ -25,6 +30,19 @@ from pipecat.utils.context.llm_context_summarization import (
 
 from utils import parse_env_bool, parse_env_float, parse_env_int
 
+# Smart Turn silence fallback (seconds). Pipecat's stock default is 3.0s.
+SMART_TURN_FALLBACK_SECS = 1.0
+
+
+def build_smart_turn_analyzer() -> LocalSmartTurnAnalyzerV3:
+    """Return LocalSmartTurnAnalyzerV3 with the blueprint fallback timeout."""
+    return LocalSmartTurnAnalyzerV3(params=SmartTurnParams(stop_secs=SMART_TURN_FALLBACK_SECS))
+
+
+def build_smart_turn_stop_strategies() -> list[TurnAnalyzerUserTurnStopStrategy]:
+    """Return the default Smart Turn stop strategy used by cascaded pipelines."""
+    return [TurnAnalyzerUserTurnStopStrategy(turn_analyzer=build_smart_turn_analyzer())]
+
 
 def build_user_aggregator_params() -> LLMUserAggregatorParams:
     """Return user-turn configuration, defaulting to Pipecat smart turn."""
@@ -32,6 +50,7 @@ def build_user_aggregator_params() -> LLMUserAggregatorParams:
         return LLMUserAggregatorParams(
             vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
             user_mute_strategies=[MuteUntilFirstBotCompleteUserMuteStrategy()],
+            user_turn_strategies=UserTurnStrategies(stop=build_smart_turn_stop_strategies()),
         )
 
     stop_secs = parse_env_float("SILERO_VAD_STOP_SECS", 0.5, min_value=0.0)

--- a/src/examples/shared/pipeline_utils.py
+++ b/src/examples/shared/pipeline_utils.py
@@ -34,6 +34,11 @@ from utils import parse_env_bool, parse_env_float, parse_env_int
 SMART_TURN_FALLBACK_SECS = 1.0
 
 
+def bot_introduction_enabled() -> bool:
+    """Return whether the bot introduces itself at session start (ENABLE_BOT_INTRODUCTION)."""
+    return parse_env_bool("ENABLE_BOT_INTRODUCTION", default=True)
+
+
 def build_smart_turn_analyzer() -> LocalSmartTurnAnalyzerV3:
     """Return LocalSmartTurnAnalyzerV3 with the blueprint fallback timeout."""
     return LocalSmartTurnAnalyzerV3(params=SmartTurnParams(stop_secs=SMART_TURN_FALLBACK_SECS))

--- a/src/examples/shared/pipeline_utils.py
+++ b/src/examples/shared/pipeline_utils.py
@@ -34,9 +34,9 @@ from utils import parse_env_bool, parse_env_float, parse_env_int
 SMART_TURN_FALLBACK_SECS = 1.0
 
 
-def bot_introduction_enabled() -> bool:
-    """Return whether the bot introduces itself at session start (ENABLE_BOT_INTRODUCTION)."""
-    return parse_env_bool("ENABLE_BOT_INTRODUCTION", default=True)
+def welcome_message_enabled() -> bool:
+    """Return whether the bot sends a welcome message at session start (ENABLE_WELCOME_MESSAGE)."""
+    return parse_env_bool("ENABLE_WELCOME_MESSAGE", default=True)
 
 
 def build_smart_turn_analyzer() -> LocalSmartTurnAnalyzerV3:
@@ -50,14 +50,14 @@ def build_smart_turn_stop_strategies() -> list[TurnAnalyzerUserTurnStopStrategy]
 
 
 def build_user_mute_strategies() -> list[MuteUntilFirstBotCompleteUserMuteStrategy]:
-    """Return the user-mute strategy, or none when there is no bot introduction.
+    """Return the user-mute strategy, or none when there is no welcome message.
 
     ``MuteUntilFirstBotCompleteUserMuteStrategy`` keeps the user muted until the
-    bot finishes its first turn. When ``ENABLE_BOT_INTRODUCTION`` is off the bot
+    bot finishes its first turn. When ``ENABLE_WELCOME_MESSAGE`` is off the bot
     waits for the user, so that first turn never happens and muting would
     deadlock — return an empty list instead.
     """
-    if not bot_introduction_enabled():
+    if not welcome_message_enabled():
         return []
     return [MuteUntilFirstBotCompleteUserMuteStrategy()]
 

--- a/src/examples_registry.py
+++ b/src/examples_registry.py
@@ -24,6 +24,7 @@ class ExampleEntry(TypedDict):
     capabilities: list[str]
     agent_prompt_keys: list[str]
     defaults: dict[str, list[str] | str]
+    welcome_message: bool
     bot: str
 
 
@@ -327,6 +328,20 @@ def prompt_default_key(example_key: str = "", *, ignore_lock: bool = False) -> s
     return prompt_keys[0] if prompt_keys else None
 
 
+def welcome_message_enabled(example_key: str = "") -> bool:
+    """Return whether an example greets the user at session start.
+
+    Resolution order: the ``ENABLE_WELCOME_MESSAGE`` environment variable wins
+    when set (a global override used by the ``generic-assistant/workstation-perf``
+    compose profile), otherwise the per-example ``welcome_message`` registry value
+    applies (default ``True``).
+    """
+    override = os.getenv("ENABLE_WELCOME_MESSAGE", "").strip()
+    if override:
+        return override.lower() == "true"
+    return bool(find(example_key).get("welcome_message", True))
+
+
 def agent_prompt_keys(example_key: str = "") -> frozenset[str]:
     """Return prompt-catalog keys that are pipeline-only (hidden from the UI selector)."""
     return frozenset(find(example_key).get("agent_prompt_keys", []))
@@ -355,6 +370,9 @@ def _load_examples(data: dict) -> dict[str, ExampleEntry]:
             raise RuntimeError(f"Example {example_id!r} capabilities must be a list of strings")
         if not isinstance(agent_prompt_keys, list) or not all(isinstance(key, str) for key in agent_prompt_keys):
             raise RuntimeError(f"Example {example_id!r} agent_prompt_keys must be a list of strings")
+        welcome_message = entry.get("welcome_message", True)
+        if not isinstance(welcome_message, bool):
+            raise RuntimeError(f"Example {example_id!r} welcome_message must be a boolean")
         if not isinstance(defaults, dict):
             raise RuntimeError(f"Example {example_id!r} defaults must be a mapping")
         normalized_defaults: dict[str, list[str] | str] = {}
@@ -373,6 +391,7 @@ def _load_examples(data: dict) -> dict[str, ExampleEntry]:
             "capabilities": list(capabilities),
             "agent_prompt_keys": list(agent_prompt_keys),
             "defaults": normalized_defaults,
+            "welcome_message": welcome_message,
             "bot": bot_spec,
         }
     return examples

--- a/tests/unit/test_multilingual_turn_strategy.py
+++ b/tests/unit/test_multilingual_turn_strategy.py
@@ -59,7 +59,10 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
 
     def test_default_multilingual_turn_start_is_vad_only(self) -> None:
         with (
-            patch.dict(os.environ, {"USE_SILERO_VAD_TURN_DETECTION": "false"}),
+            patch.dict(
+                os.environ,
+                {"USE_SILERO_VAD_TURN_DETECTION": "false", "ENABLE_BOT_INTRODUCTION": "true"},
+            ),
             patch("examples.multilingual.pipeline.SileroVADAnalyzer", return_value=_FakeVADAnalyzer()),
             patch(
                 "examples.shared.pipeline_utils.LocalSmartTurnAnalyzerV3",
@@ -76,6 +79,25 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
         analyzer = params.user_turn_strategies.stop[0]._turn_analyzer
         self.assertIsInstance(analyzer, _FakeTurnAnalyzer)
         self.assertEqual(analyzer.params.stop_secs, SMART_TURN_FALLBACK_SECS)
+        # With an introduction the bot speaks first, so the user is muted until then.
+        self.assertEqual(len(params.user_mute_strategies), 1)
+
+    def test_disabled_introduction_drops_user_mute_strategy(self) -> None:
+        with (
+            patch.dict(
+                os.environ,
+                {"USE_SILERO_VAD_TURN_DETECTION": "false", "ENABLE_BOT_INTRODUCTION": "false"},
+            ),
+            patch("examples.multilingual.pipeline.SileroVADAnalyzer", return_value=_FakeVADAnalyzer()),
+            patch(
+                "examples.shared.pipeline_utils.LocalSmartTurnAnalyzerV3",
+                side_effect=_FakeTurnAnalyzer,
+            ),
+        ):
+            params = _build_multilingual_user_aggregator_params()
+
+        # No introduction means no first bot turn, so muting would deadlock.
+        self.assertEqual(params.user_mute_strategies, [])
 
     def test_silero_timeout_multilingual_turn_start_is_vad_only(self) -> None:
         with (

--- a/tests/unit/test_multilingual_turn_strategy.py
+++ b/tests/unit/test_multilingual_turn_strategy.py
@@ -59,17 +59,14 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
 
     def test_default_multilingual_turn_start_is_vad_only(self) -> None:
         with (
-            patch.dict(
-                os.environ,
-                {"USE_SILERO_VAD_TURN_DETECTION": "false", "ENABLE_WELCOME_MESSAGE": "true"},
-            ),
+            patch.dict(os.environ, {"USE_SILERO_VAD_TURN_DETECTION": "false"}),
             patch("examples.multilingual.pipeline.SileroVADAnalyzer", return_value=_FakeVADAnalyzer()),
             patch(
                 "examples.shared.pipeline_utils.LocalSmartTurnAnalyzerV3",
                 side_effect=_FakeTurnAnalyzer,
             ),
         ):
-            params = _build_multilingual_user_aggregator_params()
+            params = _build_multilingual_user_aggregator_params(welcome_enabled=True)
 
         self.assertIsInstance(params.vad_analyzer, _FakeVADAnalyzer)
         _assert_vad_only_start(self, params.user_turn_strategies)
@@ -82,21 +79,18 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
         # With an introduction the bot speaks first, so the user is muted until then.
         self.assertEqual(len(params.user_mute_strategies), 1)
 
-    def test_disabled_introduction_drops_user_mute_strategy(self) -> None:
+    def test_disabled_welcome_message_drops_user_mute_strategy(self) -> None:
         with (
-            patch.dict(
-                os.environ,
-                {"USE_SILERO_VAD_TURN_DETECTION": "false", "ENABLE_WELCOME_MESSAGE": "false"},
-            ),
+            patch.dict(os.environ, {"USE_SILERO_VAD_TURN_DETECTION": "false"}),
             patch("examples.multilingual.pipeline.SileroVADAnalyzer", return_value=_FakeVADAnalyzer()),
             patch(
                 "examples.shared.pipeline_utils.LocalSmartTurnAnalyzerV3",
                 side_effect=_FakeTurnAnalyzer,
             ),
         ):
-            params = _build_multilingual_user_aggregator_params()
+            params = _build_multilingual_user_aggregator_params(welcome_enabled=False)
 
-        # No introduction means no first bot turn, so muting would deadlock.
+        # No welcome message means no first bot turn, so muting would deadlock.
         self.assertEqual(params.user_mute_strategies, [])
 
     def test_silero_timeout_multilingual_turn_start_is_vad_only(self) -> None:
@@ -110,7 +104,7 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
             ),
             patch("examples.multilingual.pipeline.SileroVADAnalyzer", return_value=_FakeVADAnalyzer()),
         ):
-            params = _build_multilingual_user_aggregator_params()
+            params = _build_multilingual_user_aggregator_params(welcome_enabled=True)
 
         self.assertIsInstance(params.vad_analyzer, _FakeVADAnalyzer)
         _assert_vad_only_start(self, params.user_turn_strategies)

--- a/tests/unit/test_multilingual_turn_strategy.py
+++ b/tests/unit/test_multilingual_turn_strategy.py
@@ -12,16 +12,19 @@ from unittest.mock import AsyncMock, Mock, call, patch
 from pipecat.runner.types import EvalRunnerArguments, RunnerArguments
 from pipecat.turns.user_start.transcription_user_turn_start_strategy import TranscriptionUserTurnStartStrategy
 from pipecat.turns.user_start.vad_user_turn_start_strategy import VADUserTurnStartStrategy
+from pipecat.turns.user_stop.turn_analyzer_user_turn_stop_strategy import TurnAnalyzerUserTurnStopStrategy
 
 from examples.multilingual.pipeline import (
     _build_multilingual_user_aggregator_params,
     _is_eval_transport,
     _prepare_session_language_codes,
 )
+from examples.shared.pipeline_utils import SMART_TURN_FALLBACK_SECS
 
 
 class _FakeTurnAnalyzer:
-    pass
+    def __init__(self, *args, **kwargs):
+        self.params = kwargs.get("params")
 
 
 class _FakeVADAnalyzer:
@@ -59,14 +62,20 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
             patch.dict(os.environ, {"USE_SILERO_VAD_TURN_DETECTION": "false"}),
             patch("examples.multilingual.pipeline.SileroVADAnalyzer", return_value=_FakeVADAnalyzer()),
             patch(
-                "pipecat.audio.turn.smart_turn.local_smart_turn_v3.LocalSmartTurnAnalyzerV3",
-                return_value=_FakeTurnAnalyzer(),
+                "examples.shared.pipeline_utils.LocalSmartTurnAnalyzerV3",
+                side_effect=_FakeTurnAnalyzer,
             ),
         ):
             params = _build_multilingual_user_aggregator_params()
 
         self.assertIsInstance(params.vad_analyzer, _FakeVADAnalyzer)
         _assert_vad_only_start(self, params.user_turn_strategies)
+        assert params.user_turn_strategies is not None
+        self.assertEqual(len(params.user_turn_strategies.stop), 1)
+        self.assertIsInstance(params.user_turn_strategies.stop[0], TurnAnalyzerUserTurnStopStrategy)
+        analyzer = params.user_turn_strategies.stop[0]._turn_analyzer
+        self.assertIsInstance(analyzer, _FakeTurnAnalyzer)
+        self.assertEqual(analyzer.params.stop_secs, SMART_TURN_FALLBACK_SECS)
 
     def test_silero_timeout_multilingual_turn_start_is_vad_only(self) -> None:
         with (

--- a/tests/unit/test_multilingual_turn_strategy.py
+++ b/tests/unit/test_multilingual_turn_strategy.py
@@ -61,7 +61,7 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
         with (
             patch.dict(
                 os.environ,
-                {"USE_SILERO_VAD_TURN_DETECTION": "false", "ENABLE_BOT_INTRODUCTION": "true"},
+                {"USE_SILERO_VAD_TURN_DETECTION": "false", "ENABLE_WELCOME_MESSAGE": "true"},
             ),
             patch("examples.multilingual.pipeline.SileroVADAnalyzer", return_value=_FakeVADAnalyzer()),
             patch(
@@ -86,7 +86,7 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
         with (
             patch.dict(
                 os.environ,
-                {"USE_SILERO_VAD_TURN_DETECTION": "false", "ENABLE_BOT_INTRODUCTION": "false"},
+                {"USE_SILERO_VAD_TURN_DETECTION": "false", "ENABLE_WELCOME_MESSAGE": "false"},
             ),
             patch("examples.multilingual.pipeline.SileroVADAnalyzer", return_value=_FakeVADAnalyzer()),
             patch(

--- a/tests/unit/test_welcome_message.py
+++ b/tests/unit/test_welcome_message.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# ruff: noqa: D100, D101, D102
+
+import os
+import unittest
+from unittest.mock import patch
+
+import examples_registry
+
+_EXAMPLE_KEY = "generic-assistant"
+
+
+class WelcomeMessageResolutionTests(unittest.TestCase):
+    def _example_with_welcome(self, value: bool) -> dict:
+        return {**examples_registry.EXAMPLES[_EXAMPLE_KEY], "welcome_message": value}
+
+    def test_defaults_to_enabled(self) -> None:
+        # Empty string is treated as unset, so the registry value (default True) applies.
+        with patch.dict(os.environ, {"ENABLE_WELCOME_MESSAGE": ""}):
+            self.assertTrue(examples_registry.welcome_message_enabled(_EXAMPLE_KEY))
+
+    def test_registry_value_disables_per_example(self) -> None:
+        with (
+            patch.dict(os.environ, {"ENABLE_WELCOME_MESSAGE": ""}),
+            patch.dict(examples_registry.EXAMPLES, {_EXAMPLE_KEY: self._example_with_welcome(False)}),
+        ):
+            self.assertFalse(examples_registry.welcome_message_enabled(_EXAMPLE_KEY))
+
+    def test_env_override_wins_over_registry(self) -> None:
+        with (
+            patch.dict(os.environ, {"ENABLE_WELCOME_MESSAGE": "false"}),
+            patch.dict(examples_registry.EXAMPLES, {_EXAMPLE_KEY: self._example_with_welcome(True)}),
+        ):
+            self.assertFalse(examples_registry.welcome_message_enabled(_EXAMPLE_KEY))
+
+    def test_env_override_can_force_enabled(self) -> None:
+        with (
+            patch.dict(os.environ, {"ENABLE_WELCOME_MESSAGE": "true"}),
+            patch.dict(examples_registry.EXAMPLES, {_EXAMPLE_KEY: self._example_with_welcome(False)}),
+        ):
+            self.assertTrue(examples_registry.welcome_message_enabled(_EXAMPLE_KEY))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Aligns end-of-turn detection across the example pipelines on Pipecat Smart Turn with a shorter, consistent fallback, and adds an opt-out for the on-connect bot greeting. Both are wired through shared helpers in pipeline_utils.py so behavior stays consistent and each example only carries a minimal call site.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/standardized an option to disable automatic welcome introductions, including per-example enablement plus a global `ENABLE_WELCOME_MESSAGE` override.
* **Documentation**
  * Updated Smart Turn guidance with explicit silence-fallback behavior (Silero VAD stop followed by Smart Turn fallback up to **1.0s**), and clarified defaults and example configurations.
  * Improved `.env.example` comments for Smart Turn + Silero VAD settings.
* **Configuration**
  * Updated the workstation performance profile to disable welcome messages.
* **Tests**
  * Expanded unit coverage for welcome-message resolution and multilingual Smart Turn stop-strategy wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->