### PR TITLE
feat: add Magpie TTS Zeroshot as local opt-in catalog TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Built on the open-source [Pipecat framework](https://github.com/pipecat-ai/pipec
 | | [Parakeet CTC 1.1B ASR](https://build.nvidia.com/nvidia/parakeet-ctc-1_1b-asr/modelcard) | |
 | | [Parakeet 1.1B RNNT Multilingual ASR](https://build.nvidia.com/nvidia/parakeet-1_1b-rnnt-multilingual-asr/modelcard) | |
 | **TTS** | [Magpie TTS Multilingual](https://build.nvidia.com/nvidia/magpie-tts-multilingual/modelcard) | Any NIM TTS |
+| | [Magpie TTS Zeroshot](https://build.nvidia.com/nvidia/magpie-tts-zeroshot/modelcard) | |
+| | [Chatterbox TTS Multilingual](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) | |
 | **LLM** | [Nemotron 3 Nano 30B A3B](https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b/modelcard) | Any OpenAI-compatible |
 | | [Nemotron 3 Super 120B A12B](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard) | |
 | | [Nemotron 3 Nano Omni 30B A3B](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) | |
@@ -136,56 +138,6 @@ npx skills add .
 
 - [`deploy`](skills/deploy/SKILL.md): NGC login, deployment-profile selection, and compose bring-up.
 - [`configure-pipeline`](skills/configure-pipeline/SKILL.md): edit `.env`, prompts, and example service catalogs, then re-apply the change.
-
----
-
-## Magpie TTS Zeroshot (local opt-in)
-
-Magpie TTS Zeroshot is a **local-only** alternate TTS (no cloud NVCF function). It synthesizes speech in en-US, es-US, fr-FR, de-DE, zh-CN, vi-VN, it-IT, hi-IN, ja-JP, ar-AR, pt-BR, and ko-KR from built-in voices or a 3–10 second audio prompt for zero-shot cloning. It shares Magpie Multilingual's host ports (`50151` / `9000`), so only one of Magpie Multilingual, Chatterbox, or Zeroshot can run at a time. NGC access to the image is restricted.
-
-### Enable the sidecar and select the catalog entry
-
-```bash
-docker compose --profile generic-assistant/workstation --profile magpie-zeroshot-tts \
-  up -d --scale tts-service=0
-```
-
-Use `generic-assistant/dgx-spark` (or another recipe) the same way. Then open the UI Services tab and select **Magpie TTS Zeroshot** (`magpie-zeroshot-tts`), or set `defaults.tts: [magpie-zeroshot-tts]` in `examples_registry.yaml`.
-
-Built-in voices (same across supported languages):
-
-- `Magpie-ZeroShot-Multilingual.Female` (default)
-- `Magpie-ZeroShot-Multilingual.Male`
-
-Compose uses `NIM_TAGS_SELECTOR=name=magpie-tts-zeroshot,batch_size=8` (~10.87 GB GPU). Prefer that on the shared H100 layout. `batch_size=32` needs ~41.3 GB GPU.
-
-To return to Magpie Multilingual:
-
-```bash
-docker compose --profile magpie-zeroshot-tts stop magpie-zeroshot-tts-service
-docker compose --profile generic-assistant/workstation up -d
-```
-
-### Voice cloning from an audio prompt
-
-1. Prepare a short reference clip (16-bit mono WAV, sample rate ≥ 22.05 kHz, about 3–10 seconds).
-2. Edit the active example's `services.local.yaml` under `workstation` or `dgxspark`:
-
-   ```yaml
-   magpie-zeroshot-tts:
-     name: "Magpie TTS Zeroshot"
-     server: "magpie-zeroshot-tts-service:50051"
-     voice_id: "Magpie-ZeroShot-Multilingual.Female"
-     model: "magpie-tts-zeroshot"
-     function_id: ""
-     synthesis_mode: stitched
-     zero_shot_audio_prompt_file: "/path/visible/to/the/voice-agent/process/prompt.wav"
-   ```
-
-3. If the voice agent runs in Docker, mount that file into the app container and use the container path. Host-native runs can use a host absolute path.
-4. Restart or reselect the TTS entry so catalog hydration picks up the field, then start a new session.
-
-Omit `zero_shot_audio_prompt_file` to use built-in Zeroshot voices only. Full model notes: [Configure TTS](docs/how-to/configure-tts.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,56 @@ npx skills add .
 
 ---
 
+## Magpie TTS Zeroshot (local opt-in)
+
+Magpie TTS Zeroshot is a **local-only** alternate TTS (no cloud NVCF function). It synthesizes speech in en-US, es-US, fr-FR, de-DE, zh-CN, vi-VN, it-IT, hi-IN, ja-JP, ar-AR, pt-BR, and ko-KR from built-in voices or a 3–10 second audio prompt for zero-shot cloning. It shares Magpie Multilingual's host ports (`50151` / `9000`), so only one of Magpie Multilingual, Chatterbox, or Zeroshot can run at a time. NGC access to the image is restricted.
+
+### Enable the sidecar and select the catalog entry
+
+```bash
+docker compose --profile generic-assistant/workstation --profile magpie-zeroshot-tts \
+  up -d --scale tts-service=0
+```
+
+Use `generic-assistant/dgx-spark` (or another recipe) the same way. Then open the UI Services tab and select **Magpie TTS Zeroshot** (`magpie-zeroshot-tts`), or set `defaults.tts: [magpie-zeroshot-tts]` in `examples_registry.yaml`.
+
+Built-in voices (same across supported languages):
+
+- `Magpie-ZeroShot-Multilingual.Female` (default)
+- `Magpie-ZeroShot-Multilingual.Male`
+
+Compose uses `NIM_TAGS_SELECTOR=name=magpie-tts-zeroshot,batch_size=8` (~10.87 GB GPU). Prefer that on the shared H100 layout. `batch_size=32` needs ~41.3 GB GPU.
+
+To return to Magpie Multilingual:
+
+```bash
+docker compose --profile magpie-zeroshot-tts stop magpie-zeroshot-tts-service
+docker compose --profile generic-assistant/workstation up -d
+```
+
+### Voice cloning from an audio prompt
+
+1. Prepare a short reference clip (16-bit mono WAV, sample rate ≥ 22.05 kHz, about 3–10 seconds).
+2. Edit the active example's `services.local.yaml` under `workstation` or `dgxspark`:
+
+   ```yaml
+   magpie-zeroshot-tts:
+     name: "Magpie TTS Zeroshot"
+     server: "magpie-zeroshot-tts-service:50051"
+     voice_id: "Magpie-ZeroShot-Multilingual.Female"
+     model: "magpie-tts-zeroshot"
+     function_id: ""
+     synthesis_mode: stitched
+     zero_shot_audio_prompt_file: "/path/visible/to/the/voice-agent/process/prompt.wav"
+   ```
+
+3. If the voice agent runs in Docker, mount that file into the app container and use the container path. Host-native runs can use a host absolute path.
+4. Restart or reselect the TTS entry so catalog hydration picks up the field, then start a new session.
+
+Omit `zero_shot_audio_prompt_file` to use built-in Zeroshot voices only. Full model notes: [Configure TTS](docs/how-to/configure-tts.md).
+
+---
+
 ## Documentation
 
 | Type | Guide | Description |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ include:
   - path: docker/docker-compose.parakeet-asr.yaml
   - path: docker/docker-compose.magpie-tts.yaml
   - path: docker/docker-compose.chatterbox-tts.yaml
+  - path: docker/docker-compose.magpie-zeroshot-tts.yaml
   - path: docker/docker-compose.nemotron3-omni.yaml
   - path: docker/docker-compose.speech-jetson.yaml
   - path: docker/docker-compose.coturn.yaml

--- a/docker/docker-compose.magpie-zeroshot-tts.yaml
+++ b/docker/docker-compose.magpie-zeroshot-tts.yaml
@@ -1,0 +1,60 @@
+# Magpie TTS Zeroshot: alternate to Magpie Multilingual (local only).
+# Access is restricted on NGC. Apply for access before pulling the image.
+#
+# Opt-in alternate (shared ports 50151/9000. Only one TTS can run):
+#   docker compose --profile <recipe>/workstation --profile magpie-zeroshot-tts \
+#     up -d --scale tts-service=0
+#   # same with <recipe>/dgx-spark instead of workstation
+# Omitting --profile magpie-zeroshot-tts leaves Zeroshot running and holding the
+# ports. Stop it before Magpie can bind again:
+#   docker compose --profile magpie-zeroshot-tts stop magpie-zeroshot-tts-service
+#   docker compose --profile <recipe>/workstation up -d
+# Then pick magpie-zeroshot-tts (or Magpie Multilingual) in the Services tab.
+#
+# NGC publishes this image as :latest (restricted). Pin a numeric tag when NGC
+# lists one for your release train.
+
+services:
+  magpie-zeroshot-tts-service:
+    image: nvcr.io/nim/nvidia/magpie-tts-zeroshot:latest
+    user: "0:0"
+    profiles:
+      - magpie-zeroshot-tts
+    environment:
+      NGC_API_KEY: ${NVIDIA_API_KEY}
+      NIM_HTTP_API_PORT: "9000"
+      NIM_GRPC_API_PORT: "50051"
+      # batch_size=8 (~10.87 GB GPU / ~9.74 GB CPU). Use batch_size=32 (~41.3 GB GPU)
+      # only on a dedicated GPU — it does not fit the shared H100 layout.
+      NIM_TAGS_SELECTOR: name=magpie-tts-zeroshot,batch_size=8
+    ports:
+      - "50151:50051"
+      - "9000:9000"
+    volumes:
+      - magpie_zeroshot_tts_cache:/opt/nim/.cache
+    shm_size: 16GB
+    ulimits:
+      nofile: 2048
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c 'import json, urllib.request; data=json.load(urllib.request.urlopen(\"http://127.0.0.1:9000/v1/health/ready\", timeout=5)); raise SystemExit(0 if data.get(\"status\") == \"ready\" or data.get(\"ready\") is True else 1)'"]
+      interval: 60s
+      timeout: 10s
+      retries: 10
+      start_period: 3000s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            # ~10.87 GB VRAM at batch_size=8. Edit device_ids for a second GPU.
+            - driver: nvidia
+              device_ids: ['0']
+              capabilities: [gpu]
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+volumes:
+  magpie_zeroshot_tts_cache:

--- a/docker/docker-compose.magpie-zeroshot-tts.yaml
+++ b/docker/docker-compose.magpie-zeroshot-tts.yaml
@@ -1,5 +1,5 @@
 # Magpie TTS Zeroshot: alternate to Magpie Multilingual (local only).
-# Access is restricted on NGC. Apply for access before pulling the image.
+# Access is restricted on NGC. Apply for access at https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/magpie-tts-zeroshot before pulling the image.
 #
 # Opt-in alternate (shared ports 50151/9000. Only one TTS can run):
 #   docker compose --profile <recipe>/workstation --profile magpie-zeroshot-tts \
@@ -10,9 +10,6 @@
 #   docker compose --profile magpie-zeroshot-tts stop magpie-zeroshot-tts-service
 #   docker compose --profile <recipe>/workstation up -d
 # Then pick magpie-zeroshot-tts (or Magpie Multilingual) in the Services tab.
-#
-# NGC publishes this image as :latest (restricted). Pin a numeric tag when NGC
-# lists one for your release train.
 
 services:
   magpie-zeroshot-tts-service:

--- a/docker/docker-compose.magpie-zeroshot-tts.yaml
+++ b/docker/docker-compose.magpie-zeroshot-tts.yaml
@@ -13,7 +13,7 @@
 
 services:
   magpie-zeroshot-tts-service:
-    image: nvcr.io/nim/nvidia/magpie-tts-zeroshot:latest
+    image: nvcr.io/nim/nvidia/magpie-tts-zeroshot:1.2.0
     user: "0:0"
     profiles:
       - magpie-zeroshot-tts

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -9,11 +9,12 @@ TTS services are declared per example in `services.cloud.yaml` (remote / NVCF) a
 | Model | Catalog key | Self-hosted compose service | Modelcard |
 |-------|-------------|-----------------------------|-----------|
 | **Magpie TTS Multilingual**: default, streaming multilingual TTS with per-language voices | `magpie-multilingual-tts` | [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml) | [model card](https://build.nvidia.com/nvidia/magpie-tts-multilingual/modelcard) |
+| **Magpie TTS Zeroshot**: ZeroShot voice cloning-capable multilingual streaming TTS with built-in Female/Male voices | `magpie-zeroshot-tts` | [`docker-compose.magpie-zeroshot-tts.yaml`](../../docker/docker-compose.magpie-zeroshot-tts.yaml) | [model card](https://build.nvidia.com/nvidia/magpie-tts-zeroshot/modelcard) |
 | **Chatterbox TTS Multilingual**: alternate streaming multilingual TTS | `chatterbox-multilingual-tts` | [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml) | [model card](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) |
 
-> Magpie is the registry default and the TTS sidecar started by local recipes. Chatterbox is opt-in: select `chatterbox-multilingual-tts` in the Services tab (or `defaults.tts`). For local NIM, also enable the `chatterbox-tts` Compose profile (see [Hardware requirements](#hardware-requirements-and-deployment-configs)).
+> Magpie Multilingual is the registry default and the TTS sidecar started by local recipes. Chatterbox and Magpie Zeroshot are opt-in: select their catalog key in the Services tab (or `defaults.tts` in [`examples_registry.yaml`](../../examples_registry.yaml)). For local NIM, also enable the matching Compose profile (see [Hardware requirements](#hardware-requirements-and-deployment-configs)).
 
-Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). The available voices and emotions depend on the deployed NIM. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
+Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Magpie-ZeroShot-Multilingual.Female`, `Chatterbox-Multilingual.en-US.Male`). The available voices and emotions depend on the deployed NIM. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 
 ### Supported languages
 
@@ -22,47 +23,68 @@ The client discovers the active TTS service's available voices and language code
 | Model | Supported languages |
 | --- | --- |
 | [Magpie TTS Multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#magpie-tts-multilingual) | English (`en-US`) · Spanish (`es-US`) · French (`fr-FR`) · German (`de-DE`) · Italian (`it-IT`) · Vietnamese (`vi-VN`) · Mandarin (`zh-CN`) · Hindi (`hi-IN`) · Japanese (`ja-JP`) · Modern Standard Arabic (`ar-AR`) · Korean (`ko-KR`) · Brazilian Portuguese (`pt-BR`) |
+| [Magpie TTS Zeroshot](https://build.nvidia.com/nvidia/magpie-tts-zeroshot/modelcard) | English (`en-US`) · Spanish (`es-US`) · French (`fr-FR`) · German (`de-DE`) · Mandarin (`zh-CN`) · Vietnamese (`vi-VN`) · Italian (`it-IT`) · Hindi (`hi-IN`) · Japanese (`ja-JP`) · Modern Standard Arabic (`ar-AR`) · Brazilian Portuguese (`pt-BR`) · Korean (`ko-KR`) |
 | [Chatterbox TTS Multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#chatterbox-tts-multilingual) | Arabic (`ar-SA`) · Danish (`da-DK`) · German (`de-DE`) · Greek (`el-GR`) · English (`en-US`) · Spanish (`es-ES`) · Finnish (`fi-FI`) · French (`fr-FR`) · Hebrew (`he-IL`) · Hindi (`hi-IN`) · Italian (`it-IT`) · Japanese (`ja-JP`) · Korean (`ko-KR`) · Malay (`ms-MY`) · Dutch (`nl-NL`) · Norwegian (`nb-NO`) · Polish (`pl-PL`) · Brazilian Portuguese (`pt-BR`) · Russian (`ru-RU`) · Swedish (`sv-SE`) · Swahili (`sw-KE`) · Turkish (`tr-TR`) · Mandarin (`zh-CN`) |
 
 For NVIDIA's current model and deployment support details, see the [TTS support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html).
 
 > The active default per slot is set in [`examples_registry.yaml`](../../examples_registry.yaml) (`defaults`).
 >
-> **Streaming only.** The real-time pipeline needs a **streaming** TTS model. The streaming-capable TTS NIMs are **Magpie TTS Multilingual**, **Magpie TTS Zeroshot**, and **Chatterbox TTS Multilingual**. Check the [Pipecat NVIDIA TTS service](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/nvidia/tts.py) for supported request fields and model-specific options. This blueprint ships Magpie TTS Multilingual as the default local TTS sidecar.
+> **Streaming only.** The real-time pipeline needs a **streaming** TTS model. The streaming-capable TTS NIMs are **Magpie TTS Multilingual**, **Magpie TTS Zeroshot**, and **Chatterbox TTS Multilingual**. Check the [Pipecat NVIDIA TTS service](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/nvidia/tts.py) for supported request fields and model-specific options.
 
 ## Hardware requirements and deployment configs
 
-TTS runs one of three ways, and the repo wires the right one per profile:
+TTS runs one of these ways, and the repo wires the right one per profile:
 
-- **Cloud (NVCF)**: no local GPU. Magpie and Chatterbox both appear in the Services tab. Pick either one (no Compose change).
-- **Magpie TTS (default local)**: started by `*/workstation` and `*/dgx-spark` recipes as `tts-service` ([`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml)).
-- **Chatterbox TTS (local alternate)**: listed in Compose but does **not** start with the default recipe. Enable the opt-in profile and scale Magpie off (they share ports `50151`/`9000`):
+- **Cloud (NVCF)**: no local GPU. Magpie Multilingual and Chatterbox appear in the Services tab (no Compose change). Magpie Zeroshot has no cloud function.
+- **Magpie TTS Multilingual (default local)**: started by `*/workstation` and `*/dgx-spark` recipes as `tts-service` ([`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml)).
+- **Opt-in local TTS (Chatterbox or Magpie Zeroshot)**: both are listed in Compose but do **not** start with the default recipe. They share Magpie Multilingual's host ports (`50151` / `9000`), so only one of Magpie Multilingual, Chatterbox, or Zeroshot can run at a time. Enable the opt-in profile and scale Magpie off:
+
+  | Alternate | Compose profile | Catalog key | Compose file |
+  |-----------|-----------------|-------------|--------------|
+  | Chatterbox | `chatterbox-tts` | `chatterbox-multilingual-tts` | [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml) |
+  | Magpie Zeroshot | `magpie-zeroshot-tts` | `magpie-zeroshot-tts` | [`docker-compose.magpie-zeroshot-tts.yaml`](../../docker/docker-compose.magpie-zeroshot-tts.yaml) |
 
   ```bash
-  docker compose --profile generic-assistant/workstation --profile chatterbox-tts \
+  # Example: Magpie Zeroshot on workstation (same pattern for Chatterbox / dgx-spark)
+  docker compose --profile generic-assistant/workstation --profile magpie-zeroshot-tts \
     up -d --scale tts-service=0
   ```
 
-  Same with `generic-assistant/dgx-spark` (or any other recipe). Omitting `--profile chatterbox-tts` leaves Chatterbox running and holding the ports. Stop it before Magpie can bind again (`docker compose --profile chatterbox-tts stop chatterbox-tts-service`, then recipe `up -d`). Then select the matching catalog key in the Services tab (or `defaults.tts`). See [`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml).
+  Then select the matching catalog key in the Services tab (or `defaults.tts`). Omitting the opt-in profile leaves that sidecar running and holding the ports—stop it before Magpie Multilingual can bind again (`docker compose --profile <profile> stop <service>`, then recipe `up -d`).
+
+  Magpie Zeroshot NGC access is restricted — apply at the [Magpie TTS Zeroshot NGC page](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/magpie-tts-zeroshot). For audio-prompt cloning, see [Voice cloning / zero-shot](#voice-cloning--zero-shot).
 - **Riva embedded (Jetson Thor)**: on `*/jetson-thor`, on-device Riva serves TTS: `nemotron-speech` (ASR + TTS together) or `nemotron-speech-tts` (TTS only). See [Jetson Thor](../03-jetson-thor.md).
 
 ### VRAM & hardware support
 
-**Magpie TTS** uses roughly **~14 GB VRAM** and, on local profiles, can share a single ~80 GB GPU with ASR (~15 GB) and the LLM (~30 GB FP8). To split Magpie across GPUs, set `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support) for that Magpie + ASR + LLM layout.
-
-**Chatterbox TTS** needs about **~52.5 GB VRAM** (~6.4 GB CPU) with Compose profile `NIM_TAGS_SELECTOR=name=chatterbox-tts-multilingual` (GPU `0` by default, same as Magpie). It does **not** fit the Magpie single-80-GB shared layout with the LLM and ASR on a typical workstation GPU. Locally it uses the same ports as Magpie, so scale Magpie off when starting Chatterbox ([`docker-compose.chatterbox-tts.yaml`](../../docker/docker-compose.chatterbox-tts.yaml)).
+| Model | Typical VRAM | Notes |
+|-------|--------------|-------|
+| Magpie TTS Multilingual | **~14 GB** | Can share a single ~80 GB GPU with ASR (~15 GB) and the LLM (~30 GB FP8). Split across GPUs with `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support). |
+| Magpie TTS Zeroshot | **~10.87 GB** GPU / ~9.74 GB CPU at `batch_size=8` | Default `NIM_TAGS_SELECTOR=name=magpie-tts-zeroshot,batch_size=8`. Fits the shared H100 layout when Magpie Multilingual is scaled off. `batch_size=32` needs **~41.3 GB** and should not share a single 80 GB GPU with ASR + LLM. |
+| Chatterbox TTS | **~52.5 GB** GPU / ~6.4 GB CPU | `NIM_TAGS_SELECTOR=name=chatterbox-tts-multilingual` (GPU `0` by default). Does **not** fit the Magpie single-80-GB shared layout with LLM + ASR on a typical workstation GPU. |
 
 ### Performance & scaling
 
-`batch_size` (set on the Magpie service via `NIM_TAGS_SELECTOR=name=magpie-tts-multilingual,batch_size=8`) is the main Magpie throughput knob. Tune it per deployment shape, and benchmark before raising it on shared single-GPU profiles. Chatterbox exposes a **single** profile (`name=chatterbox-tts-multilingual`) with no `batch_size` selector. For first-chunk / inter-chunk latency and throughput (RTFX) across GPUs, see the **[TTS performance benchmarks](https://docs.nvidia.com/nim/speech/latest/reference/performances/tts/performance.html)**. For end-to-end pipeline latency (TTS time-to-first-byte) in this blueprint, see [Evaluation and Performance](../04-evaluation-and-performance.md).
+`batch_size` is the main Magpie throughput knob (`NIM_TAGS_SELECTOR`):
+
+- Magpie Multilingual: `name=magpie-tts-multilingual,batch_size=8`
+- Magpie Zeroshot: `batch_size=8` (default) or `batch_size=32` — keep `8` on shared single-GPU recipes
+- Chatterbox: single profile `name=chatterbox-tts-multilingual` (no `batch_size` selector)
+
+For first-chunk / inter-chunk latency and throughput (RTFX) across GPUs, see the **[TTS performance benchmarks](https://docs.nvidia.com/nim/speech/latest/reference/performances/tts/performance.html)**. For end-to-end pipeline latency (TTS time-to-first-byte) in this blueprint, see [Evaluation and Performance](../04-evaluation-and-performance.md).
 
 ## Customization
 
 ### Voices & emotions
 
-The active voice is the `voice_id` in the catalog entry. The client UI also has a voice selector that auto-discovers the connected service's available voices and languages, so you can switch mid-session. Voice IDs follow `Model.Language.VoiceName` (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). Magpie supports multiple voices and emotional styles per locale. Chatterbox ships **one default speaker per locale**. Available voices/emotions depend on the deployed NIM (and can be discovered at runtime over gRPC/HTTP). See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
+The active voice is the `voice_id` in the catalog entry. The client UI also has a voice selector that auto-discovers the connected service's available voices and languages, so you can switch mid-session. Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Magpie-ZeroShot-Multilingual.Female`, `Chatterbox-Multilingual.en-US.Male`). Available voices/emotions depend on the deployed NIM (and can be discovered at runtime over gRPC/HTTP); see [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 
-To change the **default**, edit `voice_id` in the example's `services.cloud.yaml` / `services.local.yaml`. For a local Magpie NIM, point the entry at the sidecar (`tts-service:50051`) under the active platform block. See [Configure Services](configure-services.md).
+- **Magpie Multilingual**: multiple voices and emotional styles per locale.
+- **Magpie Zeroshot**: languages listed in [Supported languages](#supported-languages); built-in voices across locales are `Magpie-ZeroShot-Multilingual.Female` (default) and `Magpie-ZeroShot-Multilingual.Male` ([model card](https://build.nvidia.com/nvidia/magpie-tts-zeroshot/modelcard)).
+- **Chatterbox**: **one default speaker per locale**.
+
+To change the **default**, edit `voice_id` in the example's `services.cloud.yaml` / `services.local.yaml`. For a local Magpie NIM, point the entry at the sidecar (`tts-service:50051` or `magpie-zeroshot-tts-service:50051`) under the active platform block. See [Configure Services](configure-services.md).
 
 ```yaml
 tts:
@@ -80,9 +102,20 @@ tts:
     voice_id: "Chatterbox-Multilingual.en-US.Male"
     model: "chatterbox-tts-multilingual"
     function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
+
+  # Local only (services.local.yaml workstation / dgxspark). No cloud function_id.
+  magpie-zeroshot-tts:
+    name: "Magpie TTS Zeroshot"
+    server: "magpie-zeroshot-tts-service:50051"
+    voice_id: "Magpie-ZeroShot-Multilingual.Female"
+    model: "magpie-tts-zeroshot"
+    function_id: ""
+    synthesis_mode: stitched
+    # optional voice cloning:
+    # zero_shot_audio_prompt_file: "/path/to/prompt.wav"
 ```
 
-Catalog `model` + `function_id` are hydrated into the session and passed to Pipecat's `NvidiaTTSService` as `model_function_map`. Magpie remains the registry default. Pick Chatterbox in the Services tab to switch.
+Catalog `model` + `function_id` (+ optional `zero_shot_audio_prompt_file`) are hydrated into the session and passed to Pipecat's `NvidiaTTSService`.
 
 ### Synthesis mode
 
@@ -157,7 +190,25 @@ tts = NvidiaTTSService(
 
 ### Voice cloning / zero-shot
 
-Magpie TTS Zeroshot clones a voice from a short reference clip. See [voice cloning](https://docs.nvidia.com/nim/speech/latest/tts/voice-cloning.html). Verify the current [Pipecat NVIDIA TTS service](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/nvidia/tts.py) request fields before wiring zero-shot voice cloning into a pipeline.
+Magpie TTS Zeroshot clones a voice from a short reference clip via Pipecat's `NvidiaTTSService(zero_shot_audio_prompt_file=...)`. Set the path only in catalog YAML (`services.local.yaml`); it is not accepted from the client session body. See also [voice cloning](https://docs.nvidia.com/nim/speech/latest/tts/voice-cloning.html).
+
+1. Enable the Zeroshot sidecar and select `magpie-zeroshot-tts` (see [Hardware requirements](#hardware-requirements-and-deployment-configs)).
+2. Prepare a 16-bit mono WAV (sample rate ≥ 22.05 kHz, about 3–10 seconds).
+3. In the example's `services.local.yaml` (`workstation` or `dgxspark`), keep or set `voice_id` to a built-in such as `Magpie-ZeroShot-Multilingual.Female`, and add an **absolute path visible to the voice-agent process**:
+
+   ```yaml
+   magpie-zeroshot-tts:
+     ...
+     zero_shot_audio_prompt_file: "/data/prompts/clone.wav"
+   ```
+
+   - **Host-native** (`uv run` / local Python): use a host absolute path (for example `/home/you/prompts/clone.wav`).
+   - **Compose / Docker**: mount the file into the app container (for example add a bind mount under the `voice-agent` service), then set `zero_shot_audio_prompt_file` to that **container** absolute path. Relative paths are not resolved from the repo root.
+
+   The catalog field is hydrated as `tts_zero_shot_audio_prompt_file` and passed into `NvidiaTTSService`.
+4. Start a session.
+
+Omit `zero_shot_audio_prompt_file` to use only built-in Zeroshot voices.
 
 ## Reference
 

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -223,6 +223,9 @@ async def bot(runner_args: RunnerArguments) -> None:
         str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
     )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
+    tts_zero_shot_audio_prompt_file = body.get("tts_zero_shot_audio_prompt_file", "") or default_tts.get(
+        "zero_shot_audio_prompt_file", ""
+    )
     custom_dictionary = load_ipa_dictionary()
     tts_settings_kwargs: dict = {"voice": tts_voice}
     if tts_synthesis_mode:
@@ -241,11 +244,14 @@ async def bot(runner_args: RunnerArguments) -> None:
             "function_id": tts_function_id,
             "model_name": tts_model,
         }
+    if tts_zero_shot_audio_prompt_file:
+        tts_kwargs["zero_shot_audio_prompt_file"] = tts_zero_shot_audio_prompt_file
     tts = NvidiaTTSService(**tts_kwargs)
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
         f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
-        f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
+        f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
+        f"zero_shot_audio_prompt_file={tts_zero_shot_audio_prompt_file or '(none)'}"
     )
 
     # --- Context + aggregators ---

--- a/src/examples/frontend_backend_agent/services.local.yaml
+++ b/src/examples/frontend_backend_agent/services.local.yaml
@@ -35,6 +35,13 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -81,6 +88,13 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -139,6 +139,9 @@ async def bot(runner_args: RunnerArguments) -> None:
         str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
     )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
+    tts_zero_shot_audio_prompt_file = body.get("tts_zero_shot_audio_prompt_file", "") or default_tts.get(
+        "zero_shot_audio_prompt_file", ""
+    )
     custom_dictionary = load_ipa_dictionary()
 
     tts_settings_kwargs: dict = {"voice": tts_voice}
@@ -157,12 +160,15 @@ async def bot(runner_args: RunnerArguments) -> None:
             "function_id": tts_function_id,
             "model_name": tts_model,
         }
+    if tts_zero_shot_audio_prompt_file:
+        tts_kwargs["zero_shot_audio_prompt_file"] = tts_zero_shot_audio_prompt_file
     tts = NvidiaTTSService(**tts_kwargs)
 
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
         f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
         f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
+        f"zero_shot_audio_prompt_file={tts_zero_shot_audio_prompt_file or '(none)'}, "
         f"text_filters=[NemotronSpeechTextFilter]"
     )
 

--- a/src/examples/generic/services.local.yaml
+++ b/src/examples/generic/services.local.yaml
@@ -42,6 +42,13 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -87,6 +94,13 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -245,6 +245,9 @@ async def bot(runner_args: RunnerArguments) -> None:
     # --- TTS ---
     custom_dictionary = load_ipa_dictionary()
     tts_synthesis_mode = body.get("tts_synthesis_mode", "")
+    tts_zero_shot_audio_prompt_file = body.get("tts_zero_shot_audio_prompt_file", "") or default_tts.get(
+        "zero_shot_audio_prompt_file", ""
+    )
     tts_settings_kwargs: dict = {"voice": tts_voice}
     if tts_synthesis_mode:
         tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
@@ -274,12 +277,15 @@ async def bot(runner_args: RunnerArguments) -> None:
             "function_id": tts_function_id,
             "model_name": tts_model,
         }
+    if tts_zero_shot_audio_prompt_file:
+        tts_kwargs["zero_shot_audio_prompt_file"] = tts_zero_shot_audio_prompt_file
     tts = NvidiaTTSService(**tts_kwargs)
 
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
         f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
         f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
+        f"zero_shot_audio_prompt_file={tts_zero_shot_audio_prompt_file or '(none)'}, "
         f"lang_codes={lang_codes or '(no voices discovered)'}, "
         f"text_filters=[NemotronSpeechTextFilter]"
     )

--- a/src/examples/multilingual/services.local.yaml
+++ b/src/examples/multilingual/services.local.yaml
@@ -24,6 +24,13 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
   asr:
     parakeet-rnnt:
       name: "Parakeet 1.1B RNNT Multilingual ASR"
@@ -59,6 +66,13 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
   asr:
     parakeet-rnnt:
       name: "Parakeet 1.1B RNNT Multilingual ASR"

--- a/src/examples/omni_assistant/pipeline.py
+++ b/src/examples/omni_assistant/pipeline.py
@@ -145,6 +145,9 @@ async def bot(runner_args: RunnerArguments) -> None:
         str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
     )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
+    tts_zero_shot_audio_prompt_file = body.get("tts_zero_shot_audio_prompt_file", "") or default_tts.get(
+        "zero_shot_audio_prompt_file", ""
+    )
     custom_dictionary = load_ipa_dictionary()
 
     tts_settings_kwargs: dict = {"voice": tts_voice}
@@ -164,11 +167,14 @@ async def bot(runner_args: RunnerArguments) -> None:
             "function_id": tts_function_id,
             "model_name": tts_model,
         }
+    if tts_zero_shot_audio_prompt_file:
+        tts_kwargs["zero_shot_audio_prompt_file"] = tts_zero_shot_audio_prompt_file
     tts = NvidiaTTSService(**tts_kwargs)
     logger.info(
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
         f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
-        f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
+        f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
+        f"zero_shot_audio_prompt_file={tts_zero_shot_audio_prompt_file or '(none)'}"
     )
 
     user_aggregator, assistant_aggregator = LLMContextAggregatorPair(

--- a/src/examples/omni_assistant/services.local.yaml
+++ b/src/examples/omni_assistant/services.local.yaml
@@ -31,6 +31,13 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
 
 dgxspark:
   llm:
@@ -54,6 +61,13 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
 
 jetson:
   llm:

--- a/src/examples/omni_assistant_subagents/pipeline.py
+++ b/src/examples/omni_assistant_subagents/pipeline.py
@@ -130,6 +130,9 @@ async def bot(runner_args: RunnerArguments) -> None:
         str(raw_tts_function_id) if raw_tts_function_id is not None else default_tts.get("function_id", "")
     )
     tts_model = body.get("tts_model", "") or default_tts.get("model", "")
+    tts_zero_shot_audio_prompt_file = body.get("tts_zero_shot_audio_prompt_file", "") or default_tts.get(
+        "zero_shot_audio_prompt_file", ""
+    )
     api_key = os.getenv("NVIDIA_API_KEY")
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
@@ -144,6 +147,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         tts_synthesis_mode=tts_synthesis_mode,
         tts_function_id=tts_function_id,
         tts_model=tts_model,
+        tts_zero_shot_audio_prompt_file=tts_zero_shot_audio_prompt_file,
         runner_args=runner_args,
         session_id=session_id,
         subagent_registry=registry,

--- a/src/examples/omni_assistant_subagents/services.local.yaml
+++ b/src/examples/omni_assistant_subagents/services.local.yaml
@@ -22,6 +22,13 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched
 
 dgxspark:
   llm:
@@ -45,3 +52,10 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+    magpie-zeroshot-tts:
+      name: "Magpie TTS Zeroshot"
+      server: "magpie-zeroshot-tts-service:50051"
+      voice_id: "Magpie-ZeroShot-Multilingual.Female"
+      model: "magpie-tts-zeroshot"
+      function_id: ""
+      synthesis_mode: stitched

--- a/src/examples/omni_assistant_subagents/subagents/transport/agent.py
+++ b/src/examples/omni_assistant_subagents/subagents/transport/agent.py
@@ -98,6 +98,7 @@ class OmniTransportAgent(PipelineWorker):
         tts_synthesis_mode: str,
         tts_function_id: str,
         tts_model: str,
+        tts_zero_shot_audio_prompt_file: str,
         runner_args: RunnerArguments,
         session_id: str,
         subagent_registry: SubagentRegistry,
@@ -144,12 +145,15 @@ class OmniTransportAgent(PipelineWorker):
                 "function_id": tts_function_id,
                 "model_name": tts_model,
             }
+        if tts_zero_shot_audio_prompt_file:
+            tts_kwargs["zero_shot_audio_prompt_file"] = tts_zero_shot_audio_prompt_file
         self._tts = NvidiaTTSService(**tts_kwargs)
         logger.info(
             f"Nemotron Omni subagents TTS: server={tts_server}, ssl={tts_ssl}, "
             f"voice={tts_voice}, model={tts_model or '(pipecat default)'}, "
             f"function_id={tts_function_id or '(pipecat default)'}, "
-            f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}"
+            f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
+            f"zero_shot_audio_prompt_file={tts_zero_shot_audio_prompt_file or '(none)'}"
         )
 
         self._speaker_context = SpeakerContextManager(context=self._context)

--- a/src/examples/shared/prewarm.py
+++ b/src/examples/shared/prewarm.py
@@ -48,8 +48,14 @@ def _parse_language_codes_param(raw: str) -> list[str]:
 def _parse_tts_config(raw_config, model_prefix: str) -> dict:
     """Parse the TTS synthesis config into a frontend-friendly structure.
 
-    Voice IDs are returned in full form (e.g. "Magpie-Multilingual.EN-US.Aria")
-    so the frontend can use them as-is without any prefix manipulation.
+    Voice IDs are returned in full form so the frontend can use them as-is:
+
+    - Magpie Multilingual ``subvoices`` entries look like ``EN-US.Aria:0`` and
+      become ``{prefix}.EN-US.Aria``.
+    - Magpie Zeroshot ``subvoices`` entries look like ``Female:0`` / ``Male:6``
+      (no language in the token). The same voice IDs are valid across every
+      ``language_code``, so each subvoice is expanded once per language as
+      ``{prefix}.Female`` / ``{prefix}.Male``.
     """
     if not raw_config or not raw_config.model_config:
         return {"languages": [], "voices": []}
@@ -57,24 +63,41 @@ def _parse_tts_config(raw_config, model_prefix: str) -> dict:
     params = dict(raw_config.model_config[0].parameters)
     languages = _parse_language_codes_param(params.get("language_code", ""))
     subvoices_raw = params.get("subvoices", "")
+    prefix = (model_prefix or params.get("voice_name", "") or "").strip()
 
     voices: list[dict] = []
     seen: set[str] = set()
     for entry in subvoices_raw.split(","):
         entry = entry.strip()
-        if ":" not in entry or "." not in entry:
+        if ":" not in entry:
             continue
-        short_id = entry.split(":")[0]
-        parts = short_id.split(".")
-        if len(parts) < 2:
+        short_id = entry.split(":", 1)[0].strip()
+        if not short_id:
             continue
-        if short_id in seen:
+
+        if "." in short_id:
+            # Magpie Multilingual: Language.VoiceName:index
+            parts = short_id.split(".")
+            if len(parts) < 2:
+                continue
+            lang = parts[0]
+            name = ".".join(parts[1:])
+            full_id = f"{prefix}.{short_id}" if prefix else short_id
+            if full_id in seen:
+                continue
+            seen.add(full_id)
+            voices.append({"id": full_id, "name": name, "language": lang})
             continue
-        seen.add(short_id)
-        full_id = f"{model_prefix}.{short_id}" if model_prefix else short_id
-        lang = parts[0]
-        name = ".".join(parts[1:])
-        voices.append({"id": full_id, "name": name, "language": lang})
+
+        # Magpie Zeroshot: VoiceName:index (same voices for every locale)
+        name = short_id
+        full_id = f"{prefix}.{name}" if prefix else name
+        for lang in languages or ["en-US"]:
+            key = f"{full_id}|{lang}"
+            if key in seen:
+                continue
+            seen.add(key)
+            voices.append({"id": full_id, "name": name, "language": lang})
 
     return {
         "languages": languages,

--- a/src/examples/shared/prewarm.py
+++ b/src/examples/shared/prewarm.py
@@ -80,7 +80,7 @@ def _parse_tts_config(raw_config, model_prefix: str) -> dict:
             parts = short_id.split(".")
             if len(parts) < 2:
                 continue
-            lang = parts[0]
+            lang = normalize_lang_code(parts[0])
             name = ".".join(parts[1:])
             full_id = f"{prefix}.{short_id}" if prefix else short_id
             if full_id in seen:

--- a/src/examples_registry.py
+++ b/src/examples_registry.py
@@ -146,7 +146,8 @@ def _rewrite_entry_for_host_runtime(entry: dict) -> dict:
             )
         else:
             out[field] = (
-                value.replace("chatterbox-tts-service:50051", "localhost:50151")
+                value.replace("magpie-zeroshot-tts-service:50051", "localhost:50151")
+                .replace("chatterbox-tts-service:50051", "localhost:50151")
                 .replace("tts-service:50051", "localhost:50151")
                 .replace("nemotron-asr-streaming-english:50052", "localhost:50152")
                 .replace("nemotron-asr-streaming-multilingual:50052", "localhost:50152")

--- a/src/server.py
+++ b/src/server.py
@@ -103,7 +103,12 @@ _SPEECH_READY_ENDPOINTS = {
         50152,
         9001,
     ),
-    "tts": (("tts-service", "chatterbox-tts-service"), 50051, 50151, 9000),
+    "tts": (
+        ("tts-service", "chatterbox-tts-service", "magpie-zeroshot-tts-service"),
+        50051,
+        50151,
+        9000,
+    ),
 }
 _TURN_LISTEN_PORT = 3478
 _INDEX_NO_CACHE_HEADERS = {"Cache-Control": "no-store"}

--- a/src/utils.py
+++ b/src/utils.py
@@ -52,6 +52,7 @@ _SLOT_CONFIG_KEYS: dict[str, frozenset[str]] = {
             "tts_function_id",
             "tts_model",
             "tts_synthesis_mode",
+            "tts_zero_shot_audio_prompt_file",
         }
     ),
 }
@@ -223,6 +224,7 @@ _HOST_RUNTIME_PORT_OVERRIDES: dict[tuple[str, int], int] = {
     ("nvidia-llm-vllm", 8000): 18000,
     ("tts-service", 50051): 50151,
     ("chatterbox-tts-service", 50051): 50151,
+    ("magpie-zeroshot-tts-service", 50051): 50151,
     ("nemotron-asr-streaming-english", 50052): 50152,
     ("nemotron-asr-streaming-multilingual", 50052): 50152,
     ("parakeet-ctc-asr", 50052): 50152,
@@ -480,6 +482,7 @@ SESSION_CONFIG_KEYS: frozenset[str] = frozenset(
         "tts_function_id",
         "tts_model",
         "tts_synthesis_mode",
+        "tts_zero_shot_audio_prompt_file",
     }
 )
 
@@ -527,6 +530,7 @@ _CATALOG_HYDRATION: tuple[tuple[str, str, dict[str, str]], ...] = (
             "model": "tts_model",
             "voice_id": "tts_voice_id",
             "synthesis_mode": "tts_synthesis_mode",
+            "zero_shot_audio_prompt_file": "tts_zero_shot_audio_prompt_file",
         },
     ),
 )

--- a/src/utils.py
+++ b/src/utils.py
@@ -52,7 +52,6 @@ _SLOT_CONFIG_KEYS: dict[str, frozenset[str]] = {
             "tts_function_id",
             "tts_model",
             "tts_synthesis_mode",
-            "tts_zero_shot_audio_prompt_file",
         }
     ),
 }
@@ -482,7 +481,6 @@ SESSION_CONFIG_KEYS: frozenset[str] = frozenset(
         "tts_function_id",
         "tts_model",
         "tts_synthesis_mode",
-        "tts_zero_shot_audio_prompt_file",
     }
 )
 
@@ -569,6 +567,8 @@ def filter_session_config(data: dict) -> dict:
 
     Keeps only keys in ``SESSION_CONFIG_KEYS`` and hydrates built-in catalog
     selections from YAML (see :func:`hydrate_config_from_catalog`).
+    Client-supplied ``tts_zero_shot_audio_prompt_file`` is always dropped;
+    catalog hydration may re-add a trusted path afterward.
     """
     filtered = {k: v for k, v in data.items() if k in SESSION_CONFIG_KEYS and v not in ("", None)}
     active_slots = _effective_active_slots()
@@ -577,6 +577,8 @@ def filter_session_config(data: dict) -> dict:
         for slot in active_slots:
             allowed |= _SLOT_CONFIG_KEYS.get(slot, frozenset())
         filtered = {k: v for k, v in filtered.items() if k in allowed}
+    # Defense in depth: never trust a client path even if it bypasses the allowlists.
+    filtered.pop("tts_zero_shot_audio_prompt_file", None)
     hydrate_config_from_catalog(filtered)
     return filtered
 

--- a/tests/unit/test_parse_tts_config.py
+++ b/tests/unit/test_parse_tts_config.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# ruff: noqa: D100, D101, D102
+
+import unittest
+from types import SimpleNamespace
+
+from examples.shared.prewarm import _parse_tts_config
+
+
+def _raw_config(parameters: dict[str, str]):
+    return SimpleNamespace(model_config=[SimpleNamespace(parameters=parameters)])
+
+
+class ParseTtsConfigTests(unittest.TestCase):
+    def test_parses_magpie_multilingual_language_scoped_subvoices(self) -> None:
+        raw = _raw_config(
+            {
+                "language_code": "en-US,es-US",
+                "voice_name": "Magpie-Multilingual",
+                "subvoices": "EN-US.Aria:0,ES-US.Isabela:1",
+            }
+        )
+        parsed = _parse_tts_config(raw, "Magpie-Multilingual")
+        self.assertEqual(parsed["languages"], ["en-US", "es-US"])
+        self.assertEqual(
+            parsed["voices"],
+            [
+                {"id": "Magpie-Multilingual.EN-US.Aria", "name": "Aria", "language": "EN-US"},
+                {"id": "Magpie-Multilingual.ES-US.Isabela", "name": "Isabela", "language": "ES-US"},
+            ],
+        )
+
+    def test_parses_magpie_zeroshot_locale_shared_subvoices(self) -> None:
+        raw = _raw_config(
+            {
+                "language_code": "en-US,es-US,fr-FR",
+                "voice_name": "Magpie-ZeroShot-Multilingual",
+                "subvoices": "Male:6,Female:0",
+            }
+        )
+        parsed = _parse_tts_config(raw, "Magpie-ZeroShot-Multilingual")
+        self.assertEqual(parsed["languages"], ["en-US", "es-US", "fr-FR"])
+        female = [v for v in parsed["voices"] if v["name"] == "Female"]
+        male = [v for v in parsed["voices"] if v["name"] == "Male"]
+        self.assertEqual(len(female), 3)
+        self.assertEqual(len(male), 3)
+        self.assertTrue(all(v["id"] == "Magpie-ZeroShot-Multilingual.Female" for v in female))
+        self.assertTrue(all(v["id"] == "Magpie-ZeroShot-Multilingual.Male" for v in male))
+        self.assertEqual({v["language"] for v in female}, {"en-US", "es-US", "fr-FR"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_parse_tts_config.py
+++ b/tests/unit/test_parse_tts_config.py
@@ -27,8 +27,8 @@ class ParseTtsConfigTests(unittest.TestCase):
         self.assertEqual(
             parsed["voices"],
             [
-                {"id": "Magpie-Multilingual.EN-US.Aria", "name": "Aria", "language": "EN-US"},
-                {"id": "Magpie-Multilingual.ES-US.Isabela", "name": "Isabela", "language": "ES-US"},
+                {"id": "Magpie-Multilingual.EN-US.Aria", "name": "Aria", "language": "en-US"},
+                {"id": "Magpie-Multilingual.ES-US.Isabela", "name": "Isabela", "language": "es-US"},
             ],
         )
 

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -43,6 +43,7 @@ tts:
     model: magpie-tts-multilingual
     voice_id: Magpie-Multilingual.EN-US.Aria
     synthesis_mode: stitched
+    zero_shot_audio_prompt_file: /data/prompts/clone.wav
 """,
                 encoding="utf-8",
             )
@@ -91,6 +92,7 @@ tts:
             self.assertEqual(config["tts_model"], "magpie-tts-multilingual")
             self.assertEqual(config["tts_voice_id"], "client-voice")
             self.assertEqual(config["tts_synthesis_mode"], "stitched")
+            self.assertEqual(config["tts_zero_shot_audio_prompt_file"], "/data/prompts/clone.wav")
 
     def test_hydrates_raw_catalog_key_for_direct_clients(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -227,7 +229,11 @@ llm:
         self_hosted_ids = {entry["id"] for entry in self_hosted}
         self.assertEqual(
             self_hosted_ids,
-            {"self-hosted:magpie-multilingual-tts", "self-hosted:chatterbox-multilingual-tts"},
+            {
+                "self-hosted:magpie-multilingual-tts",
+                "self-hosted:chatterbox-multilingual-tts",
+                "self-hosted:magpie-zeroshot-tts",
+            },
         )
         for entry in self_hosted:
             self.assertEqual(entry["server"], "localhost:50151")

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import examples_registry
 import utils
-from utils import build_services_api_response, hydrate_config_from_catalog, load_service_entry
+from utils import build_services_api_response, filter_session_config, hydrate_config_from_catalog, load_service_entry
 
 
 class ServiceCatalogHydrationTests(unittest.TestCase):
@@ -93,6 +93,61 @@ tts:
             self.assertEqual(config["tts_voice_id"], "client-voice")
             self.assertEqual(config["tts_synthesis_mode"], "stitched")
             self.assertEqual(config["tts_zero_shot_audio_prompt_file"], "/data/prompts/clone.wav")
+
+    def test_zero_shot_prompt_file_is_catalog_only_not_client_body(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cloud_path = Path(tmpdir) / "services.cloud.yaml"
+            cloud_path.write_text(
+                dedent(
+                    """\
+                    tts:
+                      magpie:
+                        name: Magpie
+                        server: catalog-tts:443
+                        function_id: catalog-tts-function
+                        model: magpie-tts-zeroshot
+                        voice_id: Magpie-ZeroShot-Multilingual.Female
+                        zero_shot_audio_prompt_file: /data/prompts/clone.wav
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "SERVICES_CLOUD_PATH": str(cloud_path),
+                    "SERVICES_LOCAL_PATH": str(Path(tmpdir) / "missing-services.local.yaml"),
+                },
+            ):
+                filtered = filter_session_config(
+                    {
+                        "tts_id": "cloud-nim:magpie",
+                        "tts_zero_shot_audio_prompt_file": "/evil/client/path.wav",
+                    }
+                )
+
+            self.assertEqual(filtered["tts_zero_shot_audio_prompt_file"], "/data/prompts/clone.wav")
+
+    def test_zero_shot_prompt_file_dropped_without_catalog_tts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cloud_path = Path(tmpdir) / "services.cloud.yaml"
+            cloud_path.write_text("tts: {}\n", encoding="utf-8")
+
+            with patch.dict(
+                os.environ,
+                {
+                    "SERVICES_CLOUD_PATH": str(cloud_path),
+                    "SERVICES_LOCAL_PATH": str(Path(tmpdir) / "missing-services.local.yaml"),
+                },
+            ):
+                for tts_id in ("", "custom-tts"):
+                    with self.subTest(tts_id=tts_id):
+                        body = {"tts_zero_shot_audio_prompt_file": "/evil/client/path.wav"}
+                        if tts_id:
+                            body["tts_id"] = tts_id
+                        filtered = filter_session_config(body)
+                        self.assertNotIn("tts_zero_shot_audio_prompt_file", filtered)
 
     def test_hydrates_raw_catalog_key_for_direct_clients(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
- Add Magpie TTS Zeroshot as a local-only, opt-in catalog TTS (workstation + dgxspark), with Compose profile `magpie-zeroshot-tts` and shared Magpie ports (`50151` / `9000`).
- Wire optional `zero_shot_audio_prompt_file` through catalog hydration into `NvidiaTTSService` for voice cloning (no env var).
- Align default voices (`Magpie-ZeroShot-Multilingual.Female` / `.Male`) and `batch_size=8` profile notes with the Zeroshot NIM, and fix TTS config parsing so locale-shared subvoices appear in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Magpie TTS Zeroshot** as an opt-in, local-only streaming option.
  * Enabled per-run zero-shot voice prompting with catalog-provided defaults.
* **Documentation**
  * Updated deployment, voice, locale, hardware, and shared-port guidance.
  * Added Zeroshot entries to example local service catalogs.
* **Bug Fixes**
  * Improved Zeroshot voice and locale parsing, readiness checks, and endpoint routing.
  * Enforced catalog-only handling for zero-shot prompt settings.
* **Tests**
  * Added coverage for Zeroshot parsing, prompt hydration, and configuration enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->