### PR TITLE
Update Magpie TTS image to 1.9.0

### DIFF
--- a/docker/docker-compose.magpie-tts.yaml
+++ b/docker/docker-compose.magpie-tts.yaml
@@ -1,5 +1,5 @@
 x-tts-service: &tts-service-base
-    image: nvcr.io/nim/nvidia/magpie-tts-multilingual:1.8.0
+    image: nvcr.io/nim/nvidia/magpie-tts-multilingual:1.9.0
     user: "0:0"
     ports:
       - "50151:50051"

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -17,17 +17,17 @@ Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Ch
 
 ### Supported languages
 
-The client discovers the active TTS service's voices and language codes at runtime. Use this table as a model reference; exact availability can differ by endpoint, deployment profile, or selected NIM image.
+The client discovers the active TTS service's available voices and language codes at runtime. Treat this table as model-level guidance, because exact availability can vary by endpoint, deployment profile, and selected NIM image.
 
 | Model | Supported languages |
 | --- | --- |
-| [Magpie TTS Multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#magpie-tts-multilingual-supported-languages) | English (`en-US`) · Spanish (`es-US`) · French (`fr-FR`) · German (`de-DE`) · Italian (`it-IT`) · Vietnamese (`vi-VN`) · Mandarin (`zh-CN`) · Hindi (`hi-IN`) · Japanese (`ja-JP`) · Modern Standard Arabic (`ar-AR`) · Korean (`ko-KR`) · Brazilian Portuguese (`pt-BR`) |
-| [Chatterbox TTS Multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#chatterbox-tts-multilingual-supported-languages) | Arabic (`ar-SA`) · Danish (`da-DK`) · German (`de-DE`) · Greek (`el-GR`) · English (`en-US`) · Spanish (`es-ES`) · Finnish (`fi-FI`) · French (`fr-FR`) · Hebrew (`he-IL`) · Hindi (`hi-IN`) · Italian (`it-IT`) · Japanese (`ja-JP`) · Korean (`ko-KR`) · Malay (`ms-MY`) · Dutch (`nl-NL`) · Norwegian (`nb-NO`) · Polish (`pl-PL`) · Brazilian Portuguese (`pt-BR`) · Russian (`ru-RU`) · Swedish (`sv-SE`) · Swahili (`sw-KE`) · Turkish (`tr-TR`) · Mandarin (`zh-CN`) |
+| [Magpie TTS Multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#magpie-tts-multilingual) | English (`en-US`) · Spanish (`es-US`) · French (`fr-FR`) · German (`de-DE`) · Italian (`it-IT`) · Vietnamese (`vi-VN`) · Mandarin (`zh-CN`) · Hindi (`hi-IN`) · Japanese (`ja-JP`) · Modern Standard Arabic (`ar-AR`) · Korean (`ko-KR`) · Brazilian Portuguese (`pt-BR`) |
+| [Chatterbox TTS Multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#chatterbox-tts-multilingual) | Arabic (`ar-SA`) · Danish (`da-DK`) · German (`de-DE`) · Greek (`el-GR`) · English (`en-US`) · Spanish (`es-ES`) · Finnish (`fi-FI`) · French (`fr-FR`) · Hebrew (`he-IL`) · Hindi (`hi-IN`) · Italian (`it-IT`) · Japanese (`ja-JP`) · Korean (`ko-KR`) · Malay (`ms-MY`) · Dutch (`nl-NL`) · Norwegian (`nb-NO`) · Polish (`pl-PL`) · Brazilian Portuguese (`pt-BR`) · Russian (`ru-RU`) · Swedish (`sv-SE`) · Swahili (`sw-KE`) · Turkish (`tr-TR`) · Mandarin (`zh-CN`) |
 
 For NVIDIA's current model and deployment support details, see the [TTS support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html).
 
 > The active default per slot is set in [`examples_registry.yaml`](../../examples_registry.yaml) (`defaults`).
-
+>
 > **Streaming only.** The real-time pipeline needs a **streaming** TTS model. The streaming-capable TTS NIMs are **Magpie TTS Multilingual**, **Magpie TTS Zeroshot**, and **Chatterbox TTS Multilingual**. Check the [Pipecat NVIDIA TTS service](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/nvidia/tts.py) for supported request fields and model-specific options. This blueprint ships Magpie TTS Multilingual as the default local TTS sidecar.
 
 ## Hardware requirements and deployment configs

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -15,9 +15,20 @@ TTS services are declared per example in `services.cloud.yaml` (remote / NVCF) a
 
 Voice IDs follow each model's naming (e.g. `Magpie-Multilingual.EN-US.Aria`, `Chatterbox-Multilingual.en-US.Male`). The available voices and emotions depend on the deployed NIM. See [available voices and emotions](https://docs.nvidia.com/nim/speech/latest/tts/voices.html).
 
+### Supported languages
+
+The client discovers the active TTS service's voices and language codes at runtime. Use this table as a model reference; exact availability can differ by endpoint, deployment profile, or selected NIM image.
+
+| Model | Supported languages |
+| --- | --- |
+| [Magpie TTS Multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#magpie-tts-multilingual-supported-languages) | English (`en-US`) · Spanish (`es-US`) · French (`fr-FR`) · German (`de-DE`) · Italian (`it-IT`) · Vietnamese (`vi-VN`) · Mandarin (`zh-CN`) · Hindi (`hi-IN`) · Japanese (`ja-JP`) · Modern Standard Arabic (`ar-AR`) · Korean (`ko-KR`) · Brazilian Portuguese (`pt-BR`) |
+| [Chatterbox TTS Multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#chatterbox-tts-multilingual-supported-languages) | Arabic (`ar-SA`) · Danish (`da-DK`) · German (`de-DE`) · Greek (`el-GR`) · English (`en-US`) · Spanish (`es-ES`) · Finnish (`fi-FI`) · French (`fr-FR`) · Hebrew (`he-IL`) · Hindi (`hi-IN`) · Italian (`it-IT`) · Japanese (`ja-JP`) · Korean (`ko-KR`) · Malay (`ms-MY`) · Dutch (`nl-NL`) · Norwegian (`nb-NO`) · Polish (`pl-PL`) · Brazilian Portuguese (`pt-BR`) · Russian (`ru-RU`) · Swedish (`sv-SE`) · Swahili (`sw-KE`) · Turkish (`tr-TR`) · Mandarin (`zh-CN`) |
+
+For NVIDIA's current model and deployment support details, see the [TTS support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html).
+
 > The active default per slot is set in [`examples_registry.yaml`](../../examples_registry.yaml) (`defaults`).
 
-> **Streaming only.** The real-time pipeline needs a **streaming** TTS model. The streaming-capable TTS NIMs are **Magpie TTS Multilingual**, **Magpie TTS Zeroshot**, and **Chatterbox TTS Multilingual**. All three can be enabled with the latest Pipecat (**> 1.4.0**). Check the [Pipecat NVIDIA TTS service](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/nvidia/tts.py) for details. This blueprint pins `pipecat-ai==1.3.0` and ships Magpie TTS Multilingual.
+> **Streaming only.** The real-time pipeline needs a **streaming** TTS model. The streaming-capable TTS NIMs are **Magpie TTS Multilingual**, **Magpie TTS Zeroshot**, and **Chatterbox TTS Multilingual**. Check the [Pipecat NVIDIA TTS service](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/nvidia/tts.py) for supported request fields and model-specific options. This blueprint ships Magpie TTS Multilingual as the default local TTS sidecar.
 
 ## Hardware requirements and deployment configs
 
@@ -146,7 +157,7 @@ tts = NvidiaTTSService(
 
 ### Voice cloning / zero-shot
 
-Magpie TTS Zeroshot clones a voice from a short reference clip. See [voice cloning](https://docs.nvidia.com/nim/speech/latest/tts/voice-cloning.html). Pipecat's `NvidiaTTSService` does not expose zero-shot voice cloning in releases **≤ 1.4.0** (this repo pins `pipecat-ai==1.3.0`). To use it, upgrade to the latest Pipecat release or run from its `main` branch.
+Magpie TTS Zeroshot clones a voice from a short reference clip. See [voice cloning](https://docs.nvidia.com/nim/speech/latest/tts/voice-cloning.html). Verify the current [Pipecat NVIDIA TTS service](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/nvidia/tts.py) request fields before wiring zero-shot voice cloning into a pipeline.
 
 ## Reference
 

--- a/src/examples/multilingual/README.md
+++ b/src/examples/multilingual/README.md
@@ -55,7 +55,7 @@ After deploying, validate the session language with the steps in [Testing](#test
 
 On-prem recipes default to **Nemotron ASR Streaming Multilingual** (`nemotron-asr-streaming-multilingual`) via `examples_registry.yaml` and `services.local.yaml`. The `multilingual-assistant/workstation` and `/dgx-spark` recipe profiles start that sidecar locally. There is no NVCF endpoint for it, so the cloud recipe falls back to **Parakeet 1.1B RNNT Multilingual** (`parakeet-rnnt`), the only multilingual ASR available on NVCF.
 
-TTS voices and supported language codes are discovered at runtime by prewarming the configured TTS service, and the UI language selector is populated from the languages shared by the ASR and TTS services. The selected session language is injected into the prompt and pins the ASR and the TTS voice for the whole connection.
+TTS voices and supported language codes are discovered at runtime by prewarming the configured TTS service, and the UI language selector is populated from the languages shared by the ASR and TTS services. The selected session language is injected into the prompt and pins the ASR and the TTS voice for the whole connection. For Magpie and Chatterbox TTS language coverage, see [Configure TTS](../../../docs/how-to/configure-tts.md#supported-languages).
 
 | Path | Role |
 | --- | --- |


### PR DESCRIPTION
## Summary
- Pins Magpie TTS Multilingual NIM image to 1.9.0
- Adds supported-language documentation for Magpie and Chatterbox TTS

## Validation
- git diff --check
- docker compose -f docker/docker-compose.magpie-tts.yaml config
- workstation profile local deployment with multilingual example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Magpie multilingual TTS service container to version **1.9.0** (from 1.8.0).

* **Documentation**
  * Expanded “Supported languages” with explicit per-model language codes and noted that language availability can vary by endpoint/profile/image.
  * Revised “streaming only” guidance to remove the prior Pipecat version constraint while keeping the streaming-capable model requirement.
  * Updated “voice cloning/zero-shot” guidance to instruct verification of current NVIDIA TTS request fields.
  * Added a link to language coverage information for Magpie and Chatterbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->