### PR TITLE
Resolve eval attachment paths from runner-body location

### DIFF
--- a/src/eval_bot.py
+++ b/src/eval_bot.py
@@ -54,7 +54,11 @@ def _prepare_body(body: dict, example: dict, runner_args: RunnerArguments) -> di
     return prepared
 
 
-def _preload_eval_attachment(body: dict, session_id: str) -> None:
+def _preload_eval_attachment(
+    body: dict,
+    session_id: str,
+    runner_args: RunnerArguments | None = None,
+) -> None:
     """Store one eval-supplied attachment so upload-backed examples can see it."""
     attachment = body.get(_EVAL_ATTACHMENT_KEY)
     if not attachment:
@@ -69,7 +73,10 @@ def _preload_eval_attachment(body: dict, session_id: str) -> None:
         raise ValueError(f"{_EVAL_ATTACHMENT_KEY}.path is required")
     path = Path(raw_path).expanduser()
     if not path.is_absolute():
-        path = _PROJECT_ROOT / path
+        cli_args = getattr(runner_args, "cli_args", None)
+        runner_body = getattr(cli_args, "runner_body", None)
+        base_dir = Path(runner_body).expanduser().resolve().parent if runner_body else Path.cwd()
+        path = base_dir / path
     path = path.resolve()
     fixture_root = _EVAL_ATTACHMENT_FIXTURE_ROOT.resolve()
     try:
@@ -102,7 +109,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     example = _select_example(body)
     _bind_example_context(example)
     runner_args.body = _prepare_body(body, example, runner_args)
-    _preload_eval_attachment(body, str(runner_args.body.get("session_id") or ""))
+    _preload_eval_attachment(body, str(runner_args.body.get("session_id") or ""), runner_args)
     bot_fn = examples_registry.resolve_bot(example)
     await bot_fn(runner_args)
 

--- a/tests/pipecat_evals/ci/smoke.py
+++ b/tests/pipecat_evals/ci/smoke.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from argparse import Namespace
 from pathlib import Path
 
 from pipecat.evals.transport import EvalTransport
@@ -36,11 +37,12 @@ def _check_eval_bot_uploaded_attachment_body() -> None:
     body_path = ROOT / "tests/pipecat_evals/service/runner_bodies/omni_uploaded_image.json"
     body = json.loads(body_path.read_text(encoding="utf-8"))
     args = EvalRunnerArguments(body=body, session_id=str(body.get("session_id") or ""))
+    args.cli_args = Namespace(runner_body=str(body_path))
     example = eval_bot._select_example(body)
     prepared = eval_bot._prepare_body(body, example, args)
 
     try:
-        eval_bot._preload_eval_attachment(body, prepared["session_id"])
+        eval_bot._preload_eval_attachment(body, prepared["session_id"], args)
         attachment = latest_attachment(prepared["session_id"])
         if attachment is None:
             raise AssertionError("eval attachment was not stored")

--- a/tests/pipecat_evals/service/runner_bodies/omni_uploaded_image.json
+++ b/tests/pipecat_evals/service/runner_bodies/omni_uploaded_image.json
@@ -6,7 +6,7 @@
   "tts_voice_id": "Magpie-Multilingual.EN-US.Aria",
   "session_id": "eval-omni-uploaded-image",
   "eval_attachment": {
-    "path": "src/examples/omni_assistant/images/omni-assistant-architecture.png",
+    "path": "../../../../src/examples/omni_assistant/images/omni-assistant-architecture.png",
     "kind": "image",
     "content_type": "image/png",
     "name": "omni-assistant-architecture.png"

--- a/tests/unit/test_eval_bot.py
+++ b/tests/unit/test_eval_bot.py
@@ -4,8 +4,12 @@
 # ruff: noqa: D100, D101, D102
 
 import unittest
+from argparse import Namespace
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
+
+from pipecat.runner.types import EvalRunnerArguments
 
 import eval_bot
 
@@ -34,6 +38,37 @@ class EvalBotAttachmentTests(unittest.TestCase):
         self.assertEqual(kwargs["name"], fixture.name)
         self.assertEqual(kwargs["content_type"], "image/png")
         self.assertEqual(kwargs["data"], fixture.read_bytes())
+
+    def test_preload_eval_attachment_resolves_relative_path_from_runner_body_parent(self) -> None:
+        fixture = eval_bot._EVAL_ATTACHMENT_FIXTURE_ROOT / "omni-assistant-architecture.png"
+        runner_args = EvalRunnerArguments()
+        runner_args.cli_args = Namespace(runner_body=str(fixture.parent / "manual-body.json"))
+
+        with (
+            TemporaryDirectory() as other_cwd,
+            patch("eval_bot.Path.cwd", return_value=Path(other_cwd)),
+            patch("eval_bot.store_attachment") as store_attachment,
+        ):
+            eval_bot._preload_eval_attachment(
+                self._body_for_path(fixture.name),
+                "eval-session",
+                runner_args,
+            )
+
+        store_attachment.assert_called_once()
+        self.assertEqual(store_attachment.call_args.kwargs["data"], fixture.read_bytes())
+
+    def test_preload_eval_attachment_resolves_relative_path_from_cwd_without_runner_body(self) -> None:
+        fixture = eval_bot._EVAL_ATTACHMENT_FIXTURE_ROOT / "omni-assistant-architecture.png"
+
+        with (
+            patch("eval_bot.Path.cwd", return_value=fixture.parent),
+            patch("eval_bot.store_attachment") as store_attachment,
+        ):
+            eval_bot._preload_eval_attachment(self._body_for_path(fixture.name), "eval-session")
+
+        store_attachment.assert_called_once()
+        self.assertEqual(store_attachment.call_args.kwargs["data"], fixture.read_bytes())
 
     def test_preload_eval_attachment_rejects_path_outside_fixture_root(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be under"):


### PR DESCRIPTION
Resolve relative eval attachment paths from the runner-body file’s parent directory, allowing manual eval launches to work independently of the current working directory.

  **Changes:**

-   Use runner_args.cli_args.runner_body to determine the base directory for relative attachment paths.
-   Fall back to Path.cwd() when runner-body metadata is unavailable.
-   Preserve fixture-root confinement, regular-file validation, maximum-size validation, and absolute-path handling.
-   Update the uploaded-image runner body to use a runner-body-relative attachment path.
-   Add regression coverage for runner-body resolution from a different working directory and legacy cwd fallback.
-   Update the eval smoke harness to provide runner-body CLI metadata.

  **Testing**

-   rtk uv run --project . --group dev pytest tests/unit/test_eval_bot.py -v — 6 passed
-   rtk uv run --project . --group dev pytest tests/unit -v — 225 passed, 6 subtests passed
-   rtk env PYTHONPATH=src uv run --project . --group eval python tests/pipecat_evals/ci/smoke.py — passed
-   rtk env PYTHONPATH=src uv run --project . --group eval python -m pipecat.evals suite tests/pipecat_evals/ci/manifest.yaml --timeout 5 --name ci — 2/2 passed
-   rtk uv run --project . --group dev ruff format --check . — passed
-   rtk uv run --project . --group dev ruff check . — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uploaded attachment handling so relative file paths resolve correctly based on the active evaluation runner.
  * Added a fallback to the current working directory when runner path information is unavailable.
* **Tests**
  * Expanded coverage for attachment resolution in runner and standalone scenarios.
  * Updated smoke-test configuration and attachment fixture paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->