### PR TITLE
ci(evals): add service-backed Pipecat eval workflow

### DIFF
--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Service-backed Pipecat evals. These use NVIDIA cloud ASR/LLM/TTS services,
+# a local Ollama judge, and the local frontend-backend booking server.
+
+name: Pipecat Service Evals
+
+on:
+  workflow_dispatch:
+    inputs:
+      manifest:
+        description: "Pipecat eval manifest to run"
+        required: true
+        default: "tests/pipecat_evals/service/cloud_tts_manifest.yaml"
+      scenario:
+        description: "Optional single scenario name"
+        required: false
+        default: ""
+      timeout_seconds:
+        description: "Per-scenario Pipecat timeout in seconds"
+        required: true
+        default: "360"
+      retries:
+        description: "Retries per scenario"
+        required: true
+        default: "2"
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pipecat-service-evals:
+    name: Pipecat service evals
+    runs-on: arc-runners-org-nvidia-ai-bp-2-gpu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 180
+
+    env:
+      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      PYTHONPATH: src
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --group eval
+
+      - name: Validate NVIDIA API key
+        run: |
+          if [ -z "$NVIDIA_API_KEY" ]; then
+            echo "NVIDIA_API_KEY repository secret is required for service-backed Pipecat evals."
+            exit 1
+          fi
+
+      - name: Inspect runner
+        run: |
+          uname -a
+          python --version
+          uv --version
+          nvidia-smi || true
+
+      - name: Start Ollama judge
+        env:
+          OLLAMA_MODEL: gemma2:9b
+        run: |
+          if ! command -v ollama >/dev/null 2>&1; then
+            curl -fsSL https://ollama.com/install.sh | sh
+          fi
+
+          if ! curl -fsS http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+            nohup ollama serve > "$RUNNER_TEMP/ollama.log" 2>&1 &
+          fi
+
+          for attempt in {1..60}; do
+            if curl -fsS http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              cat "$RUNNER_TEMP/ollama.log" || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+          ollama pull "$OLLAMA_MODEL"
+
+      - name: Start booking backend
+        run: |
+          if curl -fsS http://127.0.0.1:8001/health >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          mkdir -p "$RUNNER_TEMP/booking-db"
+          BOOKING_DB_PATH="$RUNNER_TEMP/booking-db/bookings.db" \
+            BOOKING_HOST=127.0.0.1 \
+            BOOKING_PORT=8001 \
+            uv run --group eval python -m examples.frontend_backend_agent.airline.database.server \
+            > "$RUNNER_TEMP/booking-server.log" 2>&1 &
+
+          for attempt in {1..60}; do
+            if curl -fsS http://127.0.0.1:8001/health >/dev/null 2>&1; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              cat "$RUNNER_TEMP/booking-server.log" || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run Pipecat service evals
+        env:
+          SERVICE_EVAL_MANIFEST: ${{ github.event.inputs.manifest || 'tests/pipecat_evals/service/cloud_tts_manifest.yaml' }}
+          SERVICE_EVAL_SCENARIO: ${{ github.event.inputs.scenario || '' }}
+          SERVICE_EVAL_TIMEOUT_SECONDS: ${{ github.event.inputs.timeout_seconds || '360' }}
+          SERVICE_EVAL_RETRIES: ${{ github.event.inputs.retries || '2' }}
+        run: |
+          args=(
+            --manifest "$SERVICE_EVAL_MANIFEST"
+            --timeout "$SERVICE_EVAL_TIMEOUT_SECONDS"
+            --retries "$SERVICE_EVAL_RETRIES"
+          )
+
+          if [ -n "$SERVICE_EVAL_SCENARIO" ]; then
+            args+=(--scenario "$SERVICE_EVAL_SCENARIO")
+          fi
+
+          uv run --group eval python tests/pipecat_evals/service/run_cloud_tts_evals.py "${args[@]}"
+
+      - name: Upload eval logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipecat-service-eval-logs
+          path: |
+            eval-runs/
+            ${{ runner.temp }}/ollama.log
+            ${{ runner.temp }}/booking-server.log


### PR DESCRIPTION
  Adds a GitHub Actions workflow to run service-backed Pipecat evals on the org self-hosted ARC GPU runner.

  **Changes:**

-   Adds .github/workflows/pipecat-service-evals.yml
-   Runs on main/develop pushes, same-repo PRs to main/develop, and manual workflow_dispatch
-   Targets arc-runners-org-nvidia-ai-bp-2-gpu
-   Requires NVIDIA_API_KEY from repository secrets
-   Starts Ollama with gemma2:9b for judge-backed evals
-   Starts the frontend-backend booking server on localhost:8001
-   Runs tests/pipecat_evals/service/cloud_tts_manifest.yaml by default
-   Uploads eval-runs, Ollama logs, and booking server logs as workflow artifacts

  **Testing**

-   rtk git diff --check
-   rtk uv run --project . --group eval python -c "import yaml; yaml.safe_load(open('.github/workflows/pipecat-service-evals.yml', encoding='utf-8'));
-   print('workflow yaml parsed')"
-   rtk uv run --project . --group dev ruff format --check .
-   rtk uv run --project . --group dev ruff check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow for running Pipecat service evaluation tests.
  * Supports manual runs with configurable test manifests, scenarios, timeouts, and retries.
  * Automatically starts and validates required local services before testing.
  * Preserves evaluation output and service logs as downloadable artifacts.
  * Runs automatically for changes to the main development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->