### PR TITLE
ci(evals): add service-backed Pipecat eval workflow

### DIFF
--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -117,8 +117,11 @@ jobs:
           fi
 
           if ! curl -fsS http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+            rm -f "$RUNNER_TEMP/ollama.pid" "$RUNNER_TEMP/ollama.starttime"
             nohup ollama serve > "$RUNNER_TEMP/ollama.log" 2>&1 &
-            echo "$!" > "$RUNNER_TEMP/ollama.pid"
+            pid="$!"
+            echo "$pid" > "$RUNNER_TEMP/ollama.pid"
+            awk '{print $22}' "/proc/$pid/stat" > "$RUNNER_TEMP/ollama.starttime"
           fi
 
           for attempt in {1..60}; do
@@ -155,15 +158,20 @@ jobs:
           fi
 
           mkdir -p "$RUNNER_TEMP/booking-db"
+          rm -f "$RUNNER_TEMP/booking-server.pid" "$RUNNER_TEMP/booking-server.starttime"
           BOOKING_DB_PATH="$RUNNER_TEMP/booking-db/bookings.db" \
             BOOKING_HOST=127.0.0.1 \
             BOOKING_PORT=8001 \
             nohup uv run --group eval python -m examples.frontend_backend_agent.airline.database.server \
             > "$RUNNER_TEMP/booking-server.log" 2>&1 &
-          echo "$!" > "$RUNNER_TEMP/booking-server.pid"
+          pid="$!"
+          echo "$pid" > "$RUNNER_TEMP/booking-server.pid"
+          awk '{print $22}' "/proc/$pid/stat" > "$RUNNER_TEMP/booking-server.starttime"
 
           for attempt in {1..60}; do
-            if ! kill -0 "$(cat "$RUNNER_TEMP/booking-server.pid")" 2>/dev/null; then
+            current_starttime="$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true)"
+            expected_starttime="$(cat "$RUNNER_TEMP/booking-server.starttime")"
+            if [ "$current_starttime" != "$expected_starttime" ]; then
               cat "$RUNNER_TEMP/booking-server.log" || true
               exit 1
             fi
@@ -211,43 +219,69 @@ jobs:
       - name: Stop Ollama judge
         if: always()
         run: |
-          if [ ! -f "$RUNNER_TEMP/ollama.pid" ]; then
+          pid_file="$RUNNER_TEMP/ollama.pid"
+          starttime_file="$RUNNER_TEMP/ollama.starttime"
+
+          if [ ! -f "$pid_file" ] || [ ! -f "$starttime_file" ]; then
+            rm -f "$pid_file" "$starttime_file"
             exit 0
           fi
 
-          pid="$(cat "$RUNNER_TEMP/ollama.pid")"
-          if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
-            exit 0
-          fi
+          pid="$(cat "$pid_file")"
+          expected_starttime="$(cat "$starttime_file")"
+          rm -f "$pid_file" "$starttime_file"
+
+          is_owned_process() {
+            [ -n "$pid" ] || return 1
+            current_starttime="$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true)"
+            [ "$current_starttime" = "$expected_starttime" ]
+          }
+
+          is_owned_process || exit 0
 
           kill "$pid" || true
           for attempt in {1..10}; do
-            if ! kill -0 "$pid" 2>/dev/null; then
+            if ! is_owned_process; then
               exit 0
             fi
             sleep 1
           done
 
-          kill -9 "$pid" || true
+          if is_owned_process; then
+            kill -9 "$pid" || true
+          fi
 
       - name: Stop booking backend
         if: always()
         run: |
-          if [ ! -f "$RUNNER_TEMP/booking-server.pid" ]; then
+          pid_file="$RUNNER_TEMP/booking-server.pid"
+          starttime_file="$RUNNER_TEMP/booking-server.starttime"
+
+          if [ ! -f "$pid_file" ] || [ ! -f "$starttime_file" ]; then
+            rm -f "$pid_file" "$starttime_file"
             exit 0
           fi
 
-          pid="$(cat "$RUNNER_TEMP/booking-server.pid")"
-          if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
-            exit 0
-          fi
+          pid="$(cat "$pid_file")"
+          expected_starttime="$(cat "$starttime_file")"
+          rm -f "$pid_file" "$starttime_file"
+
+          is_owned_process() {
+            [ -n "$pid" ] || return 1
+            current_starttime="$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true)"
+            [ "$current_starttime" = "$expected_starttime" ]
+          }
+
+          is_owned_process || exit 0
 
           kill "$pid" || true
           for attempt in {1..10}; do
-            if ! kill -0 "$pid" 2>/dev/null; then
+            if ! is_owned_process; then
               exit 0
             fi
             sleep 1
           done
 
-          kill -9 "$pid" || true
+          if is_owned_process; then
+            kill -9 "$pid" || true
+          fi

--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -118,6 +118,7 @@ jobs:
 
           if ! curl -fsS http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
             nohup ollama serve > "$RUNNER_TEMP/ollama.log" 2>&1 &
+            echo "$!" > "$RUNNER_TEMP/ollama.pid"
           fi
 
           for attempt in {1..60}; do
@@ -206,6 +207,28 @@ jobs:
             eval-runs/
             ${{ runner.temp }}/ollama.log
             ${{ runner.temp }}/booking-server.log
+
+      - name: Stop Ollama judge
+        if: always()
+        run: |
+          if [ ! -f "$RUNNER_TEMP/ollama.pid" ]; then
+            exit 0
+          fi
+
+          pid="$(cat "$RUNNER_TEMP/ollama.pid")"
+          if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+            exit 0
+          fi
+
+          kill "$pid" || true
+          for attempt in {1..10}; do
+            if ! kill -0 "$pid" 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          kill -9 "$pid" || true
 
       - name: Stop booking backend
         if: always()

--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Service-backed Pipecat evals. These use NVIDIA cloud ASR/LLM/TTS services,
+# a local Ollama judge, and the local frontend-backend booking server.
+
+name: Pipecat Service Evals
+
+on:
+  workflow_dispatch:
+    inputs:
+      manifest:
+        description: "Pipecat eval manifest to run"
+        required: true
+        default: "tests/pipecat_evals/service/cloud_tts_manifest.yaml"
+      scenario:
+        description: "Optional single scenario name"
+        required: false
+        default: ""
+      timeout_seconds:
+        description: "Per-scenario Pipecat timeout in seconds"
+        required: true
+        default: "360"
+      retries:
+        description: "Retries per scenario"
+        required: true
+        default: "2"
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pipecat-service-evals:
+    name: Pipecat service evals
+    runs-on: arc-runners-org-nvidia-ai-bp-2-gpu
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 180
+
+    env:
+      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      PYTHONPATH: src
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --group eval
+
+      - name: Validate NVIDIA API key
+        run: |
+          if [ -z "$NVIDIA_API_KEY" ]; then
+            echo "NVIDIA_API_KEY repository secret is required for service-backed Pipecat evals."
+            exit 1
+          fi
+
+      - name: Inspect runner
+        run: |
+          uname -a
+          python --version
+          uv --version
+          nvidia-smi || true
+
+      - name: Start Ollama judge
+        env:
+          OLLAMA_MODEL: gemma2:9b
+        run: |
+          if ! command -v ollama >/dev/null 2>&1; then
+            curl -fsSL https://ollama.com/install.sh | sh
+          fi
+
+          if ! curl -fsS http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+            nohup ollama serve > "$RUNNER_TEMP/ollama.log" 2>&1 &
+          fi
+
+          for attempt in {1..60}; do
+            if curl -fsS http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              cat "$RUNNER_TEMP/ollama.log" || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+          ollama pull "$OLLAMA_MODEL"
+
+      - name: Start booking backend
+        run: |
+          if curl -fsS http://127.0.0.1:8001/health >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          mkdir -p "$RUNNER_TEMP/booking-db"
+          BOOKING_DB_PATH="$RUNNER_TEMP/booking-db/bookings.db" \
+            BOOKING_HOST=127.0.0.1 \
+            BOOKING_PORT=8001 \
+            uv run --group eval python -m examples.frontend_backend_agent.airline.database.server \
+            > "$RUNNER_TEMP/booking-server.log" 2>&1 &
+
+          for attempt in {1..60}; do
+            if curl -fsS http://127.0.0.1:8001/health >/dev/null 2>&1; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              cat "$RUNNER_TEMP/booking-server.log" || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run Pipecat service evals
+        env:
+          SERVICE_EVAL_MANIFEST: ${{ github.event.inputs.manifest || 'tests/pipecat_evals/service/cloud_tts_manifest.yaml' }}
+          SERVICE_EVAL_SCENARIO: ${{ github.event.inputs.scenario || '' }}
+          SERVICE_EVAL_TIMEOUT_SECONDS: ${{ github.event.inputs.timeout_seconds || '360' }}
+          SERVICE_EVAL_RETRIES: ${{ github.event.inputs.retries || '2' }}
+        run: |
+          args=(
+            --manifest "$SERVICE_EVAL_MANIFEST"
+            --timeout "$SERVICE_EVAL_TIMEOUT_SECONDS"
+            --retries "$SERVICE_EVAL_RETRIES"
+          )
+
+          if [ -n "$SERVICE_EVAL_SCENARIO" ]; then
+            args+=(--scenario "$SERVICE_EVAL_SCENARIO")
+          fi
+
+          uv run --group eval python tests/pipecat_evals/service/run_cloud_tts_evals.py "${args[@]}"
+
+      - name: Upload eval logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipecat-service-eval-logs
+          path: |
+            eval-runs/
+            ${{ runner.temp }}/ollama.log
+            ${{ runner.temp }}/booking-server.log

--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   pipecat-service-evals:
     name: Pipecat service evals
-    runs-on: arc-runners-org-nvidia-ai-bp-2-gpu
+    runs-on: arc-runners-org-nvidia-ai-bp-1-gpu
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 180
 

--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -45,27 +45,28 @@ jobs:
     timeout-minutes: 180
 
     env:
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
       PYTHONPATH: src
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --group eval
+        run: uv sync --locked --group eval
 
       - name: Validate NVIDIA API key
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           if [ -z "$NVIDIA_API_KEY" ]; then
             echo "NVIDIA_API_KEY repository secret is required for service-backed Pipecat evals."
@@ -90,12 +91,15 @@ jobs:
             exit 1
           fi
 
-          if command -v sudo >/dev/null 2>&1; then
+          if command -v sudo >/dev/null 2>&1 && sudo -n true; then
             sudo apt-get update
             sudo apt-get install -y zstd
-          else
+          elif [ "$(id -u)" -eq 0 ]; then
             apt-get update
             apt-get install -y zstd
+          else
+            echo "zstd is required to install Ollama. Install zstd in the runner image or grant passwordless sudo."
+            exit 1
           fi
 
       - name: Start Ollama judge
@@ -132,17 +136,37 @@ jobs:
       - name: Start booking backend
         run: |
           if curl -fsS http://127.0.0.1:8001/health >/dev/null 2>&1; then
-            exit 0
+            echo "A booking backend is already serving on localhost:8001; refusing to reuse a stale service."
+            exit 1
+          fi
+
+          if python - <<'PY'
+          import socket
+          import sys
+
+          with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+              sock.settimeout(1)
+              sys.exit(0 if sock.connect_ex(("127.0.0.1", 8001)) == 0 else 1)
+          PY
+          then
+            echo "Port 8001 is already in use before this workflow started the booking backend."
+            exit 1
           fi
 
           mkdir -p "$RUNNER_TEMP/booking-db"
           BOOKING_DB_PATH="$RUNNER_TEMP/booking-db/bookings.db" \
             BOOKING_HOST=127.0.0.1 \
             BOOKING_PORT=8001 \
-            uv run --group eval python -m examples.frontend_backend_agent.airline.database.server \
+            nohup uv run --group eval python -m examples.frontend_backend_agent.airline.database.server \
             > "$RUNNER_TEMP/booking-server.log" 2>&1 &
+          echo "$!" > "$RUNNER_TEMP/booking-server.pid"
 
           for attempt in {1..60}; do
+            if ! kill -0 "$(cat "$RUNNER_TEMP/booking-server.pid")" 2>/dev/null; then
+              cat "$RUNNER_TEMP/booking-server.log" || true
+              exit 1
+            fi
+
             if curl -fsS http://127.0.0.1:8001/health >/dev/null 2>&1; then
               exit 0
             fi
@@ -159,6 +183,7 @@ jobs:
           SERVICE_EVAL_SCENARIO: ${{ github.event.inputs.scenario || '' }}
           SERVICE_EVAL_TIMEOUT_SECONDS: ${{ github.event.inputs.timeout_seconds || '360' }}
           SERVICE_EVAL_RETRIES: ${{ github.event.inputs.retries || '2' }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           args=(
             --manifest "$SERVICE_EVAL_MANIFEST"
@@ -174,10 +199,32 @@ jobs:
 
       - name: Upload eval logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: pipecat-service-eval-logs
           path: |
             eval-runs/
             ${{ runner.temp }}/ollama.log
             ${{ runner.temp }}/booking-server.log
+
+      - name: Stop booking backend
+        if: always()
+        run: |
+          if [ ! -f "$RUNNER_TEMP/booking-server.pid" ]; then
+            exit 0
+          fi
+
+          pid="$(cat "$RUNNER_TEMP/booking-server.pid")"
+          if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+            exit 0
+          fi
+
+          kill "$pid" || true
+          for attempt in {1..10}; do
+            if ! kill -0 "$pid" 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          kill -9 "$pid" || true

--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -79,6 +79,25 @@ jobs:
           uv --version
           nvidia-smi || true
 
+      - name: Install Ollama prerequisites
+        run: |
+          if command -v zstd >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "zstd is required to install Ollama, and apt-get is not available."
+            exit 1
+          fi
+
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y zstd
+          else
+            apt-get update
+            apt-get install -y zstd
+          fi
+
       - name: Start Ollama judge
         env:
           OLLAMA_MODEL: gemma2:9b

--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -103,7 +103,13 @@ jobs:
           OLLAMA_MODEL: gemma2:9b
         run: |
           if ! command -v ollama >/dev/null 2>&1; then
-            curl -fsSL https://ollama.com/install.sh | sh
+            if ! curl -fsSL https://ollama.com/install.sh | sh; then
+              if ! command -v ollama >/dev/null 2>&1; then
+                echo "Ollama installer failed before installing the ollama binary."
+                exit 1
+              fi
+              echo "Ollama installer exited non-zero after installing the binary; continuing with explicit startup check."
+            fi
           fi
 
           if ! curl -fsS http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then

--- a/.github/workflows/pipecat-service-evals.yml
+++ b/.github/workflows/pipecat-service-evals.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Install dependencies
         run: uv sync --group eval
 

--- a/tests/pipecat_evals/service/scenarios/frontend_backend_unsupported_nonflight.yaml
+++ b/tests/pipecat_evals/service/scenarios/frontend_backend_unsupported_nonflight.yaml
@@ -13,5 +13,5 @@ turns:
   - user: "Can you order a pizza for me?"
     expect:
       - event: response
-        eval: "the reply says this assistant supports flight searches, new bookings, cancellation of pending flight tasks, or PNR status, and does not offer to order pizza"
+        eval: "the reply politely declines or says it cannot help with ordering pizza. It must not say it can order pizza, must not offer to place a pizza order, and must not ask for pizza order details. It may optionally redirect to flight or airline help."
         within_ms: 90000


### PR DESCRIPTION
Adds a GitHub Actions workflow to run service-backed Pipecat evals on the org self-hosted ARC GPU runner.

Changes:

Adds .github/workflows/pipecat-service-evals.yml
Runs on main/develop pushes, same-repo PRs to main/develop, and manual workflow_dispatch
Targets arc-runners-org-nvidia-ai-bp-2-gpu
Requires NVIDIA_API_KEY from repository secrets
Starts Ollama with gemma2:9b for judge-backed evals
Starts the frontend-backend booking server on localhost:8001
Runs tests/pipecat_evals/service/cloud_tts_manifest.yaml by default
Uploads eval-runs, Ollama logs, and booking server logs as workflow artifacts
Testing

rtk git diff --check
rtk uv run --project . --group eval python -c "import yaml; yaml.safe_load(open('.github/workflows/pipecat-service-evals.yml', encoding='utf-8'));
print('workflow yaml parsed')"
rtk uv run --project . --group dev ruff format --check .
rtk uv run --project . --group dev ruff check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GPU-backed evaluation workflow for Pipecat services using NVIDIA cloud services and a local evaluation judge.
  * Supports manual runs with configurable manifests, optional scenarios, timeouts, and retries, as well as pushes and pull requests to supported branches.
  * Automatically validates credentials, starts and health-checks required services, uploads evaluation results and logs, and cleans up services after each run.

* **Bug Fixes**
  * Updated unsupported non-flight scenario validation to require a polite refusal without requesting or providing pizza-order details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->