### PR TITLE
fix(tts): pin generic zeroshot TTS to en-US via catalog language_code

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -120,6 +120,7 @@ export interface SimpleService {
   model?: string;
   voiceId?: string;
   functionId?: string;
+  languageCode?: string;
   builtIn: boolean;
   source?: BuiltInServiceSource;
 }
@@ -151,6 +152,7 @@ export function useDefaultTTS(pipelineMode = "") {
         model: e.model ? String(e.model) : undefined,
         voiceId: e.voice_id ? String(e.voice_id) : undefined,
         functionId: e.function_id ? String(e.function_id) : undefined,
+        languageCode: e.language_code ? String(e.language_code) : undefined,
         builtIn: true,
         source: normalizeServiceSource(e.source),
       })),

--- a/client/src/components/VoiceSettings.tsx
+++ b/client/src/components/VoiceSettings.tsx
@@ -83,18 +83,28 @@ export function VoiceSettings() {
 
   const defaultVoice = useMemo(() => {
     if (!ttsConfig?.voices?.length) return null;
+    // Zero-shot models reuse one voice id across every locale, so an id lookup alone
+    // can land on an arbitrary language. Disambiguate with the catalog language when
+    // the entry declares one; otherwise keep the plain id match.
+    const catalogLang = (selectedTTS?.languageCode || "").toUpperCase();
+    const byId = (voiceId: string) => {
+      const matches = ttsConfig.voices.filter((voice) => voice.id === voiceId);
+      if (matches.length === 0) return null;
+      if (!catalogLang) return matches[0];
+      return matches.find((voice) => voice.language.toUpperCase() === catalogLang) || matches[0];
+    };
     const selectedServiceVoice = selectedTTS?.voiceId || "";
     if (selectedServiceVoice) {
-      const match = ttsConfig.voices.find((voice) => voice.id === selectedServiceVoice);
+      const match = byId(selectedServiceVoice);
       if (match) return match;
     }
     if (ttsConfig.defaultVoiceId) {
-      const match = ttsConfig.voices.find((voice) => voice.id === ttsConfig.defaultVoiceId);
+      const match = byId(ttsConfig.defaultVoiceId);
       if (match) return match;
     }
     const enVoice = ttsConfig.voices.find((voice) => voice.language.toUpperCase() === "EN-US");
     return enVoice || ttsConfig.voices[0];
-  }, [ttsConfig, selectedTTS?.voiceId]);
+  }, [ttsConfig, selectedTTS?.voiceId, selectedTTS?.languageCode]);
 
   const hasActiveOverride = voiceOverride.serviceId === (selectedTTS?.id ?? "");
   const activeLang = (hasActiveOverride ? voiceOverride.language : "") || (defaultVoice?.language.replace("_", "-") ?? "");

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -102,6 +102,7 @@ tts:
     voice_id: "Chatterbox-Multilingual.en-US.Male"
     model: "chatterbox-tts-multilingual"
     function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
+    synthesis_mode: per_sentence
 
   # Local only (services.local.yaml workstation / dgxspark). No cloud function_id.
   magpie-zeroshot-tts:
@@ -126,7 +127,7 @@ Pipecat's `NvidiaTTSService` supports two synthesis modes via the catalog field 
 | `stitched` | Reuse one Magpie `SynthesizeOnline` stream across sentences in a reply (smoother multi-sentence audio). Use this for Magpie multilingual / zero-shot ≥ v1.7.0. |
 | `per_sentence` | Open a fresh synthesis call per sentence. Safe for models without cross-sentence stitching. |
 
-Set `synthesis_mode` on the catalog entry (hydrated as `tts_synthesis_mode`). Magpie ships with `stitched`. Omit the field on other models to leave Pipecat's default (`per_sentence`).
+Set `synthesis_mode` on the catalog entry (hydrated as `tts_synthesis_mode`). Magpie multilingual and Magpie zeroshot ship with `stitched`; Chatterbox ships with `per_sentence`. Always set the field explicitly so a UI/backend TTS switch cannot inherit another model's mode via the registry-default fallback in the pipeline.
 
 ### Pronunciation (IPA)
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -112,6 +112,7 @@ tts:
     model: "magpie-tts-zeroshot"
     function_id: ""
     synthesis_mode: stitched
+    language_code: en-US
     # optional voice cloning:
     # zero_shot_audio_prompt_file: "/path/to/prompt.wav"
 ```

--- a/src/examples/frontend_backend_agent/services.cloud.yaml
+++ b/src/examples/frontend_backend_agent/services.cloud.yaml
@@ -37,6 +37,7 @@ tts:
     voice_id: "Chatterbox-Multilingual.en-US.Male"
     model: "chatterbox-tts-multilingual"
     function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
+    synthesis_mode: per_sentence
 
 asr:
   nemotron-asr-streaming-english:

--- a/src/examples/frontend_backend_agent/services.local.yaml
+++ b/src/examples/frontend_backend_agent/services.local.yaml
@@ -35,6 +35,7 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"
@@ -88,6 +89,7 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -143,11 +143,16 @@ async def bot(runner_args: RunnerArguments) -> None:
     tts_zero_shot_audio_prompt_file = body.get("tts_zero_shot_audio_prompt_file", "") or default_tts.get(
         "zero_shot_audio_prompt_file", ""
     )
+    tts_language_code = body.get("tts_language_code", "") or default_tts.get("language_code", "")
+    if tts_language_code:
+        tts_language_code = normalize_lang_code(tts_language_code)
     custom_dictionary = load_ipa_dictionary()
 
     tts_settings_kwargs: dict = {"voice": tts_voice}
     if tts_synthesis_mode:
         tts_settings_kwargs["synthesis_mode"] = tts_synthesis_mode
+    if tts_language_code:
+        tts_settings_kwargs["language"] = tts_language_code
     tts_kwargs: dict = {
         "api_key": os.getenv("NVIDIA_API_KEY"),
         "server": tts_server,
@@ -169,6 +174,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         f"TTS: server={tts_server}, ssl={tts_ssl}, voice={tts_voice}, "
         f"model={tts_model or '(pipecat default)'}, function_id={tts_function_id or '(pipecat default)'}, "
         f"synthesis_mode={tts_synthesis_mode or '(pipecat default)'}, "
+        f"language={tts_language_code or '(pipecat default)'}, "
         f"zero_shot_audio_prompt_file={tts_zero_shot_audio_prompt_file or '(none)'}, "
         f"text_filters=[NemotronSpeechTextFilter]"
     )

--- a/src/examples/generic/services.cloud.yaml
+++ b/src/examples/generic/services.cloud.yaml
@@ -49,6 +49,7 @@ tts:
     voice_id: "Chatterbox-Multilingual.en-US.Male"
     model: "chatterbox-tts-multilingual"
     function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
+    synthesis_mode: per_sentence
 
 # ── ASR Services (Cascaded pipeline) ──
 asr:

--- a/src/examples/generic/services.local.yaml
+++ b/src/examples/generic/services.local.yaml
@@ -49,6 +49,7 @@ workstation:
       model: "magpie-tts-zeroshot"
       function_id: ""
       synthesis_mode: stitched
+      language_code: en-US
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"
@@ -101,6 +102,7 @@ dgxspark:
       model: "magpie-tts-zeroshot"
       function_id: ""
       synthesis_mode: stitched
+      language_code: en-US
   asr:
     nemotron-asr-streaming-english:
       name: "Nemotron ASR Streaming English"

--- a/src/examples/generic/services.local.yaml
+++ b/src/examples/generic/services.local.yaml
@@ -42,6 +42,7 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"
@@ -95,6 +96,7 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"

--- a/src/examples/multilingual/services.cloud.yaml
+++ b/src/examples/multilingual/services.cloud.yaml
@@ -49,6 +49,7 @@ tts:
     voice_id: "Chatterbox-Multilingual.en-US.Male"
     model: "chatterbox-tts-multilingual"
     function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
+    synthesis_mode: per_sentence
 
 # ── ASR Services (Cascaded pipeline) ──
 asr:

--- a/src/examples/multilingual/services.local.yaml
+++ b/src/examples/multilingual/services.local.yaml
@@ -24,6 +24,7 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"
@@ -66,6 +67,7 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"

--- a/src/examples/omni_assistant/services.cloud.yaml
+++ b/src/examples/omni_assistant/services.cloud.yaml
@@ -23,3 +23,4 @@ tts:
     voice_id: "Chatterbox-Multilingual.en-US.Male"
     model: "chatterbox-tts-multilingual"
     function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
+    synthesis_mode: per_sentence

--- a/src/examples/omni_assistant/services.local.yaml
+++ b/src/examples/omni_assistant/services.local.yaml
@@ -31,6 +31,7 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"
@@ -61,6 +62,7 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"

--- a/src/examples/omni_assistant_subagents/services.cloud.yaml
+++ b/src/examples/omni_assistant_subagents/services.cloud.yaml
@@ -23,3 +23,4 @@ tts:
     voice_id: "Chatterbox-Multilingual.en-US.Male"
     model: "chatterbox-tts-multilingual"
     function_id: "ddacc747-1269-4fab-bfd9-8f593dead106"
+    synthesis_mode: per_sentence

--- a/src/examples/omni_assistant_subagents/services.local.yaml
+++ b/src/examples/omni_assistant_subagents/services.local.yaml
@@ -22,6 +22,7 @@ workstation:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"
@@ -52,6 +53,7 @@ dgxspark:
       voice_id: "Chatterbox-Multilingual.en-US.Male"
       model: "chatterbox-tts-multilingual"
       function_id: ""
+      synthesis_mode: per_sentence
     magpie-zeroshot-tts:
       name: "Magpie TTS Zeroshot"
       server: "magpie-zeroshot-tts-service:50051"

--- a/src/utils.py
+++ b/src/utils.py
@@ -582,6 +582,14 @@ def filter_session_config(data: dict) -> dict:
         filtered = {k: v for k, v in filtered.items() if k in allowed}
     # Defense in depth: never trust a client path even if it bypasses the allowlists.
     filtered.pop("tts_zero_shot_audio_prompt_file", None)
+    # Custom (non-catalog) selections skip hydration, so the raw client value would
+    # reach ``normalize_lang_code`` in the pipeline. Keep only usable strings.
+    raw_tts_language_code = filtered.get("tts_language_code")
+    if raw_tts_language_code is not None:
+        if isinstance(raw_tts_language_code, str) and raw_tts_language_code.strip():
+            filtered["tts_language_code"] = raw_tts_language_code.strip()
+        else:
+            filtered.pop("tts_language_code", None)
     hydrate_config_from_catalog(filtered)
     return filtered
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -52,6 +52,7 @@ _SLOT_CONFIG_KEYS: dict[str, frozenset[str]] = {
             "tts_function_id",
             "tts_model",
             "tts_synthesis_mode",
+            "tts_language_code",
         }
     ),
 }
@@ -481,6 +482,7 @@ SESSION_CONFIG_KEYS: frozenset[str] = frozenset(
         "tts_function_id",
         "tts_model",
         "tts_synthesis_mode",
+        "tts_language_code",
     }
 )
 
@@ -528,13 +530,14 @@ _CATALOG_HYDRATION: tuple[tuple[str, str, dict[str, str]], ...] = (
             "model": "tts_model",
             "voice_id": "tts_voice_id",
             "synthesis_mode": "tts_synthesis_mode",
+            "language_code": "tts_language_code",
             "zero_shot_audio_prompt_file": "tts_zero_shot_audio_prompt_file",
         },
     ),
 )
 
 # Body fields the client may set explicitly; catalog hydration must not overwrite them.
-_CLIENT_OVERRIDABLE_BODY_FIELDS = frozenset({"asr_language_code", "tts_voice_id"})
+_CLIENT_OVERRIDABLE_BODY_FIELDS = frozenset({"asr_language_code", "tts_language_code", "tts_voice_id"})
 
 
 def hydrate_config_from_catalog(config: dict) -> None:

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -43,6 +43,7 @@ tts:
     model: magpie-tts-multilingual
     voice_id: Magpie-Multilingual.EN-US.Aria
     synthesis_mode: stitched
+    language_code: en-US
     zero_shot_audio_prompt_file: /data/prompts/clone.wav
 """,
                 encoding="utf-8",
@@ -92,7 +93,39 @@ tts:
             self.assertEqual(config["tts_model"], "magpie-tts-multilingual")
             self.assertEqual(config["tts_voice_id"], "client-voice")
             self.assertEqual(config["tts_synthesis_mode"], "stitched")
+            self.assertEqual(config["tts_language_code"], "en-US")
             self.assertEqual(config["tts_zero_shot_audio_prompt_file"], "/data/prompts/clone.wav")
+
+    def test_tts_language_code_client_override_wins_over_catalog(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cloud_path = Path(tmpdir) / "services.cloud.yaml"
+            cloud_path.write_text(
+                dedent(
+                    """\
+                    tts:
+                      magpie:
+                        name: Magpie
+                        server: catalog-tts:443
+                        model: magpie-tts-zeroshot
+                        voice_id: Magpie-ZeroShot-Multilingual.Female
+                        language_code: en-US
+                    """
+                ),
+                encoding="utf-8",
+            )
+            config = {
+                "tts_id": "cloud-nim:magpie",
+                "tts_language_code": "es-US",
+            }
+            with patch.dict(
+                os.environ,
+                {
+                    "SERVICES_CLOUD_PATH": str(cloud_path),
+                    "SERVICES_LOCAL_PATH": str(Path(tmpdir) / "missing-services.local.yaml"),
+                },
+            ):
+                hydrate_config_from_catalog(config)
+            self.assertEqual(config["tts_language_code"], "es-US")
 
     def test_zero_shot_prompt_file_is_catalog_only_not_client_body(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -127,6 +127,26 @@ tts:
                 hydrate_config_from_catalog(config)
             self.assertEqual(config["tts_language_code"], "es-US")
 
+    def test_custom_tts_language_code_keeps_only_usable_strings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cloud_path = Path(tmpdir) / "services.cloud.yaml"
+            cloud_path.write_text("tts: {}\n", encoding="utf-8")
+            with patch.dict(
+                os.environ,
+                {
+                    "SERVICES_CLOUD_PATH": str(cloud_path),
+                    "SERVICES_LOCAL_PATH": str(Path(tmpdir) / "missing-services.local.yaml"),
+                },
+            ):
+                # Custom selections skip hydration, so the raw client value survives.
+                for value in ({"evil": 1}, ["en-US"], True, "   "):
+                    with self.subTest(value=value):
+                        filtered = filter_session_config({"tts_id": "custom-tts", "tts_language_code": value})
+                        self.assertNotIn("tts_language_code", filtered)
+
+                filtered = filter_session_config({"tts_id": "custom-tts", "tts_language_code": " en-US "})
+                self.assertEqual(filtered["tts_language_code"], "en-US")
+
     def test_zero_shot_prompt_file_is_catalog_only_not_client_body(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cloud_path = Path(tmpdir) / "services.cloud.yaml"

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -96,6 +96,46 @@ tts:
             self.assertEqual(config["tts_language_code"], "en-US")
             self.assertEqual(config["tts_zero_shot_audio_prompt_file"], "/data/prompts/clone.wav")
 
+    def test_chatterbox_hydrates_per_sentence_even_with_sticky_stitched(self) -> None:
+        """UI TTS switches must not keep Magpie's stitched mode on Chatterbox."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cloud_path = Path(tmpdir) / "services.cloud.yaml"
+            cloud_path.write_text(
+                dedent(
+                    """\
+                    tts:
+                      magpie:
+                        name: Magpie
+                        server: catalog-tts:443
+                        model: magpie-tts-multilingual
+                        voice_id: Magpie-Multilingual.EN-US.Aria
+                        synthesis_mode: stitched
+                      chatterbox:
+                        name: Chatterbox
+                        server: catalog-tts:443
+                        model: chatterbox-tts-multilingual
+                        voice_id: Chatterbox-Multilingual.en-US.Male
+                        synthesis_mode: per_sentence
+                    """
+                ),
+                encoding="utf-8",
+            )
+            config = {
+                "tts_id": "cloud-nim:chatterbox",
+                # Leftover from a prior Magpie selection / registry-default body.
+                "tts_synthesis_mode": "stitched",
+            }
+            with patch.dict(
+                os.environ,
+                {
+                    "SERVICES_CLOUD_PATH": str(cloud_path),
+                    "SERVICES_LOCAL_PATH": str(Path(tmpdir) / "missing-services.local.yaml"),
+                },
+            ):
+                hydrate_config_from_catalog(config)
+            self.assertEqual(config["tts_model"], "chatterbox-tts-multilingual")
+            self.assertEqual(config["tts_synthesis_mode"], "per_sentence")
+
     def test_tts_language_code_client_override_wins_over_catalog(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             cloud_path = Path(tmpdir) / "services.cloud.yaml"


### PR DESCRIPTION
## Summary

The Generic Assistant left the TTS language unset, relying on Pipecat's built-in `en-US` default. That worked for Magpie Multilingual because its voice ids encode the locale (`Magpie-Multilingual.EN-US.Aria`). Magpie Zeroshot reuses one voice id across every locale (`Magpie-ZeroShot-Multilingual.Female` is valid for all 12 languages), so nothing pinned the language and the UI resolved the voice to whichever locale sorted first — `ar-AR`. A mid-session voice switch then sent `language: ar-AR` to the service.

- Declare `language_code: en-US` on the generic `magpie-zeroshot-tts` catalog entry (workstation + dgxspark)
- Hydrate catalog `language_code` into `tts_language_code`, mirroring the existing `asr_language_code` handling, and apply it in the generic pipeline's `NvidiaTTSSettings`
- Disambiguate locale-shared voice ids in the client voice selector using the catalog language, leaving locale-scoped voice ids on the existing id match

The Multilingual Assistant is intentionally untouched: it owns language through its `session_languages` capability and `fixed_session_language`, and never reads `tts_language_code`. Its zeroshot catalog entry deliberately has no `language_code` so the user's session language stays authoritative.

## Test plan

- [x] `ruff check .` and `ruff format --check .`
- [x] `pytest tests/unit` (333 passed), including new catalog hydration and client-override coverage
- [x] Pipecat eval smoke
- [x] `npm --prefix client run lint` and `npm --prefix client run build`
- [x] Manual: Generic Assistant against a self-hosted Magpie Zeroshot NIM with cloud ASR/LLM — pipeline logs `language=en-US`, and the UI language reads `en-US` instead of `ar-AR`
- [ ] Manual: Multilingual Assistant with zeroshot selected still follows the chosen session language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added language-aware text-to-speech configuration for more accurate voice selection when catalogs contain duplicate voice IDs.
  - TTS language settings can now be provided through session configuration and preserved when explicitly specified.
  - Default example configurations now include English (US) language settings for supported TTS services.

- **Bug Fixes**
  - Improved default voice resolution by prioritizing the selected catalog language while retaining a reliable fallback.
  - Configured Chatterbox multilingual TTS to synthesize speech per sentence across supported examples.

- **Documentation**
  - Clarified required synthesis modes for supported TTS catalog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->