### PR TITLE
Add repository-tailored documentation agent guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Summary
+
+<!-- Describe what changes and why. Include before-and-after behavior when it applies. -->
+
+## Related Issue
+
+<!-- Add Fixes #NNN or Closes #NNN. Remove this section when no issue applies. -->
+
+## Changes
+
+<!-- List the concrete implementation and documentation changes. -->
+
+## Type of Change
+
+- [ ] Code change (feature, bug fix, or refactor)
+- [ ] Code change with doc updates
+- [ ] Doc only (prose changes, no code sample modifications)
+- [ ] Doc only (includes code sample changes)
+
+## Quality Gates
+
+- [ ] Tests added or updated for changed behavior
+- [ ] Existing tests cover changed behavior — justification:
+- [ ] Tests not applicable — justification:
+- [ ] Docs updated for user-facing behavior changes
+- [ ] Docs not applicable — justification:
+
+## Documentation Writer Review
+
+<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each field. For Evidence, list changed documentation paths or explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata. Rerun the review and refresh the metadata after any new commit. This receipt is advisory. -->
+
+- [ ] Documentation writer reviewed the completed changes
+- Result: `docs-updated` | `no-docs-needed` | `blocked`
+- Evidence:
+- Agent:
+<!-- docs-review-head-sha: -->
+<!-- docs-review-agents-blob-sha: -->
+
+## Verification
+
+- [ ] Applicable lint, test, and build checks passed
+- [ ] Documentation validation passed for changed documentation
+- [ ] No secrets, API keys, or credentials are committed

--- a/.github/workflows/docs-review-receipt.yml
+++ b/.github/workflows/docs-review-receipt.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: CI / Documentation Writer Review
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  docs-review-receipt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Collect receipt inputs
+        id: receipt-inputs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed_files="$RUNNER_TEMP/docs-review-changed-files.txt"
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$changed_files"
+          agents_blob="$(git rev-parse "${HEAD_SHA}:AGENTS.md")"
+          echo "changed_files=$changed_files" >> "$GITHUB_OUTPUT"
+          echo "agents_blob=$agents_blob" >> "$GITHUB_OUTPUT"
+
+      - name: Check documentation writer review receipt
+        continue-on-error: true
+        env:
+          AGENTS_BLOB: ${{ steps.receipt-inputs.outputs.agents_blob }}
+          CHANGED_FILES: ${{ steps.receipt-inputs.outputs.changed_files }}
+        run: >-
+          python scripts/docs-review-receipt.py check
+          --event "$GITHUB_EVENT_PATH"
+          --changed-files "$CHANGED_FILES"
+          --agents-blob "$AGENTS_BLOB"
+          --mode advisory

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ docs/how-to/evaluate-thinker-talker-airline.md
 eval/
 tests/test_voice_agent_eval.py
 .ipynb_checkpoints/
+
+# Local contributor documentation routing status
+.dori_user_status

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,3 @@ docs/how-to/evaluate-thinker-talker-airline.md
 eval/
 tests/test_voice_agent_eval.py
 .ipynb_checkpoints/
-
-# Local contributor documentation routing status
-.dori_user_status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,32 @@ If the host cannot run subagents, the primary task must read `docs/AGENTS.md`,
 complete the documentation work, and run the same validation. Do not omit
 required documentation because parallel execution is unavailable.
 
+### Documentation Writer Review Receipt
+
+Every pull request that changes code or documentation must include one
+`## Documentation Writer Review` section from
+`.github/PULL_REQUEST_TEMPLATE.md`. Complete the review after the changes and
+applicable validation are finished.
+
+- Check the review-completion box and keep exactly one result:
+  `docs-updated`, `no-docs-needed`, or `blocked`.
+- Name the changed documentation in **Evidence**, or explain why documentation
+  is not needed or why the review is blocked.
+- Record the agent product and surface that performed the review.
+- After committing the reviewed changes, fill the hidden head and guidance
+  fields with `git rev-parse --short HEAD` and
+  `git rev-parse --short HEAD:AGENTS.md`.
+- Any later commit makes the receipt stale. Rerun the documentation review and
+  refresh both hidden fields.
+
+The `CI / Documentation Writer Review` workflow checks the receipt in advisory
+mode. Use the following command to measure adoption. The report also supports
+`json` and `csv` formats.
+
+```bash
+python scripts/docs-review-receipt.py report --since <YYYY-MM-DD> --format summary
+```
+
 ### NVIDIA DORI Routing
 
 Select the documentation path from current host capabilities.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,28 +113,3 @@ mode. Use the following command to measure adoption. The report also supports
 ```bash
 python scripts/docs-review-receipt.py report --since <YYYY-MM-DD> --format summary
 ```
-
-### NVIDIA DORI Routing
-
-Select the documentation path from current host capabilities.
-Do not ask the user to classify themselves or store repository-scoped identity
-state during a normal documentation task.
-
-1. Check whether the current agent exposes `dori_handle` or `dori_route` and
-   `dori_collections`.
-   If the user explicitly asks not to use DORI, use the
-   [Writing Style Guide](docs/AGENTS.md#writing-style-guide) instead.
-2. When those tools are available, list the installed collections.
-   - If a collection source exactly matches `gitlab:tech-docs/skill-library`, use DORI for
-     task routing.
-   - If the collection is missing, inaccessible, or cannot be verified,
-     continue with the
-     [Writing Style Guide](docs/AGENTS.md#writing-style-guide).
-3. When the DORI tools are unavailable, continue with the Writing Style Guide.
-   Do not inspect a shell-visible CLI, install software, or configure the host
-   during a normal documentation task.
-4. Use [NVIDIA DORI Setup](docs/DORI_SETUP.md) only when the user explicitly
-   asks to install or configure DORI.
-
-Capability detection does not approve installation or host configuration.
-DORI unavailability must not block documentation work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# Nemotron Voice Agent Repository Guidance
+
+## Product Scope
+
+Nemotron Voice Agent is an end-to-end voice-agent blueprint built on Pipecat.
+It combines NVIDIA NIM services for automatic speech recognition (ASR), large
+language model (LLM) inference, and text-to-speech (TTS) synthesis. Preserve
+the repository's supported cloud, workstation, DGX Spark, and Jetson Thor
+deployment profiles when changing shared behavior.
+
+## Sources of Truth
+
+- Use `pyproject.toml` and `uv.lock` for Python versions and dependencies.
+- Use `client/package.json` and `client/package-lock.json` for client
+  dependencies and scripts.
+- Use `examples_registry.yaml` for registered examples, transports, and
+  per-example defaults.
+- Use each `src/examples/<example>/pipeline.py`, `prompts.yaml`,
+  `services.cloud.yaml`, and `services.local.yaml` for example behavior and
+  configuration. Shared runtime behavior lives in `src/examples/shared/`,
+  `src/server.py`, and the other root modules in `src/`.
+- Use `docker-compose.yml` and the files in `docker/` for Compose profiles,
+  service names, container images, ports, and hardware-specific deployment
+  behavior.
+- Use `README.md`, the example READMEs, and `docs/` for user-facing behavior.
+  When prose and implementation disagree, verify the implementation and update
+  the affected documentation in the same change.
+
+## Repository Workflows
+
+- Run repository commands from the repository root.
+- Preserve an existing `.env`. Never commit credentials, generated runtime
+  state, benchmark results, caches, or local model data.
+- Select exactly one recipe profile for a Docker Compose deployment. Cloud
+  profiles use `<example>`; local profiles use `<example>/<hardware>`.
+  Observability profiles such as `tracing` and `turn` are overlays.
+- Load `skills/deploy/SKILL.md` for deployment or startup troubleshooting.
+- Load `skills/configure-pipeline/SKILL.md` for changes to `.env`,
+  `examples_registry.yaml`, prompts, service catalogs, transports, tracing, or
+  audio settings.
+- Load `skills/upgrade-pipecat/SKILL.md` before changing Pipecat server or
+  client dependency versions or migrating Pipecat APIs.
+- Preserve unrelated configuration keys, comments, examples, and deployment
+  profiles. Do not infer hardware, credentials, or private-service access.
+
+## Validation
+
+Run checks that match the changed surfaces. The GitHub Actions workflow uses
+these commands:
+
+```bash
+uvx ruff@0.15.6 check .
+uvx ruff@0.15.6 format --check .
+uv sync --dev
+uv run pytest tests/ -v
+npm --prefix client ci
+npm --prefix client run lint
+npm --prefix client run build
+```
+
+For documentation-only changes, run the configured pre-commit hooks on the
+changed files:
+
+```bash
+uv run --project . --group dev pre-commit run --files <changed-files>
+```
+
+Inspect relative links and referenced paths. This repository does not configure
+a dedicated documentation renderer or Markdown link checker. Report any
+validation that requires unavailable GPUs, services, credentials, or deployment
+hardware instead of claiming it passed.
+
+## Documentation
+
+Before completing a change, determine whether it affects a user-visible
+surface. These surfaces include public APIs, configuration, Compose profiles,
+service catalogs, prompts, the browser client, workflows, defaults, errors,
+deployment behavior, and other product behavior.
+
+When a change affects users and the host supports subagents, start a
+documentation subagent in parallel while the primary implementation continues.
+Direct the subagent to read `docs/AGENTS.md`, provide the changed source files
+and identified user impact, and require it to update the affected documentation
+and run the documented validation. Reconcile the documentation changes and
+validation evidence before completing the change.
+
+If the host cannot run subagents, the primary task must read `docs/AGENTS.md`,
+complete the documentation work, and run the same validation. Do not omit
+required documentation because parallel execution is unavailable.
+
+### NVIDIA DORI Routing
+
+Select the documentation path from current host capabilities.
+Do not ask the user to classify themselves or store repository-scoped identity
+state during a normal documentation task.
+
+1. Check whether the current agent exposes `dori_handle` or `dori_route` and
+   `dori_collections`.
+   If the user explicitly asks not to use DORI, use the
+   [Writing Style Guide](docs/AGENTS.md#writing-style-guide) instead.
+2. When those tools are available, list the installed collections.
+   - If a collection source exactly matches `gitlab:tech-docs/skill-library`, use DORI for
+     task routing.
+   - If the collection is missing, inaccessible, or cannot be verified,
+     continue with the
+     [Writing Style Guide](docs/AGENTS.md#writing-style-guide).
+3. When the DORI tools are unavailable, continue with the Writing Style Guide.
+   Do not inspect a shell-visible CLI, install software, or configure the host
+   during a normal documentation task.
+4. Use [NVIDIA DORI Setup](docs/DORI_SETUP.md) only when the user explicitly
+   asks to install or configure DORI.
+
+Capability detection does not approve installation or host configuration.
+DORI unavailability must not block documentation work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,49 @@
 
 Use the following guidelines to contribute to this project.
 
-
 ## Pull Requests
-Developer workflow for code contributions is as follows:
 
-1. Developers must create a [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) of this repository for the upstreaming.
-2. Git clone the forked repository and push changes to the personal fork.
-3. Developers must run changes locally to make sure formatting and linting checks pass.
-4. Once the code changes are staged on the fork and ready for review, a Pull Request (PR) can be requested to merge the changes from a branch of the fork into a selected branch of upstream.
-5. If you are contributing for the first time, Download [Contribution License Agreement(CLA)](CLA.md) and share a signed CLA.
-6. Since there is no CI/CD process in place yet, the PR will be accepted and the corresponding issue closed only after adequate testing has been completed, manually, by the developer and/or repository owners reviewing the code.
+Use the following workflow for code and documentation contributions:
+
+1. Create a [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)
+   of this repository.
+2. Clone your fork and create a branch for the change.
+3. Run the applicable formatting, linting, test, client-build, and documentation
+   checks locally.
+4. Complete the pull request template, including one **Type of Change** choice
+   and the documentation writer review receipt.
+5. Push the branch to your fork and open a pull request against the appropriate
+   upstream branch.
+6. If you are contributing for the first time, download the
+   [Contribution License Agreement](CLA.md) and share a signed copy.
+
+## Documentation Writer Review Receipt
+
+Pull requests that change code or documentation must record a documentation
+review after the changes and applicable validation are complete. In the pull
+request description:
+
+1. Check **Documentation writer reviewed the completed changes**.
+2. Keep one result: `docs-updated`, `no-docs-needed`, or `blocked`.
+3. Add the changed documentation paths or a concise rationale to **Evidence**.
+4. Record the agent product and surface that performed the review.
+5. After committing the reviewed changes, populate the hidden metadata with:
+
+   ```bash
+   git rev-parse --short HEAD
+   git rev-parse --short HEAD:AGENTS.md
+   ```
+
+Rerun the review and refresh both values after any later commit. The
+`CI / Documentation Writer Review` workflow reports missing, invalid, or stale
+receipts in advisory mode.
+
+Maintainers can measure adoption with the following command. Replace the date
+with the start of the reporting window:
+
+```bash
+python scripts/docs-review-receipt.py report --since 2026-08-01 --format summary
+```
+
+The report uses the authenticated GitHub CLI session and also supports `json`
+and `csv` output.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -129,6 +129,10 @@ Markdown link checker. For documentation-only changes:
 4. Record any validation that requires unavailable credentials, NVIDIA
    services, GPUs, or deployment hardware as a gap.
 
+Return the review result, changed documentation paths or rationale, validation
+evidence, and agent surface to the primary task for the pull request's
+Documentation Writer Review receipt.
+
 When documentation accompanies code, configuration, Compose, or client
 changes, also run the applicable validation commands from the root
 `AGENTS.md`.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -59,10 +59,6 @@ notes that you create or edit.
 
 ## NVIDIA DORI Routing
 
-Select the documentation path from current host capabilities.
-Do not ask the user to classify themselves or store repository-scoped identity
-state during a normal documentation task.
-
 1. Check whether the current agent exposes `dori_handle` or `dori_route` and
    `dori_collections`.
    If the user explicitly asks not to use DORI, use the
@@ -75,8 +71,13 @@ state during a normal documentation task.
 3. When the DORI tools are unavailable, continue with the Writing Style Guide.
    Do not inspect a shell-visible CLI, install software, or configure the host
    during a normal documentation task.
-4. Use [NVIDIA DORI Setup](DORI_SETUP.md) only when the user explicitly asks to
-   install or configure DORI.
+4. If DORI or the verified Skill Library is unavailable and the user has access
+   to `gitlab-master.nvidia.com`, print a brief recommendation to install DORI
+   and refer to [NVIDIA DORI Setup](DORI_SETUP.md). Continue the documentation
+   task with the Writing Style Guide. Do not pause or block work for
+   installation.
+5. Run NVIDIA DORI Setup only when the user explicitly asks to install or
+   configure DORI.
 
 Capability detection does not approve installation or host configuration.
 DORI unavailability must not block documentation work.
@@ -97,8 +98,8 @@ the developer opens the pull or merge request.
    work in the primary task.
 
 If the verified Skill Library is unavailable, inaccessible, or fails, skip DORI.
-Do not attempt routing, prompt for setup, or ask for or persist a user
-classification. Continue using the Writing Style Guide above.
+Do not attempt routing or start setup automatically. Continue using the Writing
+Style Guide above.
 
 ## Documentation Structure
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -57,9 +57,30 @@ notes that you create or edit.
 - Apply rules to improve clarity. Do not make mechanical changes that reduce
   technical accuracy or readability.
 
-## Use DORI for Complete NVIDIA Doc Tools
+## NVIDIA DORI Routing
 
-Follow [NVIDIA DORI Routing](../AGENTS.md#nvidia-dori-routing).
+Select the documentation path from current host capabilities.
+Do not ask the user to classify themselves or store repository-scoped identity
+state during a normal documentation task.
+
+1. Check whether the current agent exposes `dori_handle` or `dori_route` and
+   `dori_collections`.
+   If the user explicitly asks not to use DORI, use the
+   [Writing Style Guide](#writing-style-guide) instead.
+2. When those tools are available, list the installed collections.
+   - If a collection source exactly matches `gitlab:tech-docs/skill-library`,
+     use DORI for task routing.
+   - If the collection is missing, inaccessible, or cannot be verified,
+     continue with the [Writing Style Guide](#writing-style-guide).
+3. When the DORI tools are unavailable, continue with the Writing Style Guide.
+   Do not inspect a shell-visible CLI, install software, or configure the host
+   during a normal documentation task.
+4. Use [NVIDIA DORI Setup](DORI_SETUP.md) only when the user explicitly asks to
+   install or configure DORI.
+
+Capability detection does not approve installation or host configuration.
+DORI unavailability must not block documentation work.
+
 Use the following DORI workflow only when current host capabilities include the
 verified NVIDIA documentation Skill Library. Complete the documentation before
 the developer opens the pull or merge request.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,134 @@
+# Nemotron Voice Agent Documentation Guidance
+
+## Role
+
+Maintain accurate, task-focused documentation for developers who evaluate,
+configure, deploy, extend, and troubleshoot Nemotron Voice Agent. Verify every
+command, profile, service name, model identifier, default, port, hardware
+requirement, and configuration key against checked-in repository sources.
+
+## Writing Style Guide
+
+Apply these rules to documentation, examples, headings, UI text, and release
+notes that you create or edit.
+
+- Write in a professional, active, conversational, and engaging voice.
+- Use active voice whenever possible. Use present tense for product behavior.
+  Address the reader in second person as "you."
+- Keep sentences concise. Prefer sentences with fewer than 30 words.
+- Use plain English and precise technical terms. Avoid jargon, filler,
+  colloquialisms, and flowery marketing claims.
+- Avoid contractions in technical documentation. Write "do not," "cannot,"
+  and "it is."
+- Write "NVIDIA" in all caps and use "an NVIDIA," not "a NVIDIA."
+- Spell out uncommon abbreviations on first use. Spell out LLM, RAG, SLM, VLM,
+  and MoE on first use.
+- Use NVIDIA spellings such as data center, dataset, open source, pretrained,
+  startup, webpage, website, and Wi-Fi.
+- Replace Latinisms with plain English. Use "for example," "that is," "and so
+  on," "through," and "compared to."
+- Use "refer to" instead of "see," "can" instead of "may" for possibility,
+  and "after" instead of "once" for time.
+- Do not use "please" in technical instructions.
+- Use numerals for specific values, parameters, measurements, and values of 10
+  or more. Spell out zero through nine in general prose.
+- Include a space between a number and its unit. Use a comma in numbers with
+  four or more digits.
+- Use title case for headings. Do not style headings with code, bold, italics,
+  quotation marks, ampersands, or exclamation marks.
+- Use the Oxford comma. Put periods inside quotation marks in U.S. style.
+- Use hyphens only for compound modifiers before nouns. Do not hyphenate an
+  adverb that ends in "ly."
+- Format commands, code, filenames, paths, and API identifiers as code. Use
+  bold for UI elements and the greater-than sign for UI navigation.
+- Introduce lists, tables, code examples, and images with a complete sentence.
+  Use parallel construction in lists.
+- Use descriptive link text. Do not use raw URLs in running text or generic
+  link text such as "click here" or "read more."
+- Write dates as Month DD, YYYY. Omit the year when it matches the publication
+  year. Write time with a 12-hour clock and include minutes only when needed.
+- Do not rewrite quoted UI labels, API field names, or audience role labels in
+  tables to enforce second person.
+- Provide useful alt text and preserve a logical heading hierarchy.
+- Verify commands, flags, API names, defaults, and technical claims against
+  source code or another checked-in source of truth.
+- Do not rewrite literal code, identifiers, commands, URLs, or quoted terminal
+  and API output to satisfy prose rules.
+- Apply rules to improve clarity. Do not make mechanical changes that reduce
+  technical accuracy or readability.
+
+## Use DORI for Complete NVIDIA Doc Tools
+
+Follow [NVIDIA DORI Routing](../AGENTS.md#nvidia-dori-routing).
+Use the following DORI workflow only when current host capabilities include the
+verified NVIDIA documentation Skill Library. Complete the documentation before
+the developer opens the pull or merge request.
+
+1. Route the documentation task through DORI. Include the changed source files,
+   the user-visible impact, the documentation that might need updates, and the
+   required validation.
+2. Follow the skill or workflow that DORI returns. Verify product behavior
+   against checked-in sources before drafting.
+3. When the host supports subagents, start a documentation subagent while the
+   primary developer finishes the implementation. Reconcile the documentation
+   changes and validation evidence before opening the pull or merge request.
+4. When the host does not support subagents, complete the same documentation
+   work in the primary task.
+
+If the verified Skill Library is unavailable, inaccessible, or fails, skip DORI.
+Do not attempt routing, prompt for setup, or ask for or persist a user
+classification. Continue using the Writing Style Guide above.
+
+## Documentation Structure
+
+- Keep `README.md` as the product overview, quick start, example map, and
+  documentation index.
+- Keep `docs/01-getting-started.md` aligned with the supported Compose recipes,
+  prerequisites, and local-development workflow.
+- Keep `docs/02-configuration-guide.md` as the index for configuration and
+  customization tasks. Put focused procedures in `docs/how-to/`.
+- Keep `docs/03-jetson-thor.md` aligned with Jetson-specific Compose and Docker
+  sources.
+- Keep `docs/04-evaluation-and-performance.md` and the benchmarking-tool
+  READMEs aligned with checked-in benchmark procedures and published evidence.
+- Use `docs/05-best-practices.md` for production guidance and
+  `docs/06-troubleshooting.md` for symptoms, causes, and verified resolutions.
+- Keep each `src/examples/<example>/README.md` aligned with that example's
+  pipeline, prompts, service catalogs, supported transports, and deployment
+  profiles.
+
+## Documentation Sources and Maintenance
+
+- Verify the example list, identifiers, transports, and defaults in
+  `examples_registry.yaml`.
+- Verify pipeline behavior in `src/examples/<example>/pipeline.py` and shared
+  behavior in `src/examples/shared/` and `src/server.py`.
+- Verify prompt and service configuration in the example-local `prompts.yaml`,
+  `services.cloud.yaml`, and `services.local.yaml` files.
+- Verify Compose profiles, service names, ports, image tags, environment
+  variables, and hardware placement in `docker-compose.yml`, `docker/`, and
+  `.env.example`.
+- Verify Python and client dependencies in `pyproject.toml`, `uv.lock`,
+  `client/package.json`, and `client/package-lock.json`.
+- Preserve the relative-link style used by the existing Markdown files. When
+  adding or renaming a page, update `README.md`,
+  `docs/02-configuration-guide.md`, and other indexes that should expose it.
+- Do not publish secrets, private environment values, unsupported performance
+  claims, or results that lack checked-in evidence.
+
+## Documentation Validation
+
+This repository does not configure a dedicated documentation renderer or
+Markdown link checker. For documentation-only changes:
+
+1. Run
+   `uv run --project . --group dev pre-commit run --files <changed-files>` on
+   every changed file.
+2. Inspect changed relative links, anchors, commands, and referenced paths.
+3. Run `git diff --check`.
+4. Record any validation that requires unavailable credentials, NVIDIA
+   services, GPUs, or deployment hardware as a gap.
+
+When documentation accompanies code, configuration, Compose, or client
+changes, also run the applicable validation commands from the root
+`AGENTS.md`.

--- a/docs/DORI_SETUP.md
+++ b/docs/DORI_SETUP.md
@@ -1,0 +1,138 @@
+# NVIDIA DORI Setup
+
+Use this guide only when the user explicitly asks to install or configure
+NVIDIA DORI.
+Before inspecting or installing private components, ask the user to confirm
+that they can access `gitlab-master.nvidia.com`.
+If the user does not confirm access, stop this setup and use the checked-in
+[Writing Style Guide](AGENTS.md#writing-style-guide).
+Access confirmation does not approve installation or host configuration.
+
+Use these internal sources for the current installation and registration
+instructions:
+
+- [NVIDIA Skill Library](https://gitlab-master.nvidia.com/tech-docs/skill-library)
+  contains documentation-focused Agent Skills and guidance for installing them
+  with DORI and other supported hosts.
+- [NVIDIA Template Library](https://gitlab-master.nvidia.com/tech-docs/template-library)
+  contains reusable documentation templates and guidance for installing its
+  template skills with DORI.
+
+## Inspect the Environment
+
+1. Check for DORI MCP tools.
+   - If the current agent exposes `dori_handle` or `dori_route`, do not
+     reconfigure the host.
+   - When `dori_collections` is available, verify that a collection source
+     exactly matches `gitlab:tech-docs/skill-library`.
+   - If the Skill Library is missing, identify it as the only missing component
+     and continue to [Confirm Changes](#confirm-changes).
+2. When DORI MCP tools are unavailable, inspect the command-line interface
+   (CLI).
+   - Run `command -v dori`.
+   - If the CLI exists, run `dori collections list --json`.
+   - Treat a collection whose source exactly matches `gitlab:tech-docs/skill-library` as the
+     installed Skill Library.
+3. Identify the host from explicit runtime context.
+   Do not infer the host from the model name or repository files.
+4. Run `dori setup auto --dry-run` as a cross-check when the CLI exists.
+   - If auto-detection conflicts with the explicit host, use the explicit host.
+   - If no explicit host exists and auto-detection is uncertain, ask which host
+     is running.
+
+Use the following host commands:
+
+| Explicit Host | Setup Command |
+|---|---|
+| Codex CLI or Desktop | `dori setup codex` |
+| Cursor | `dori setup cursor --scope user` |
+| Claude Code | `dori setup claude-code --scope user` |
+| Claude Desktop | `dori setup claude` |
+| VS Code with GitHub Copilot | `dori setup vscode --scope user` |
+| Kiro | `dori setup kiro` |
+| Google Antigravity | `dori setup antigravity` |
+
+Keep the listed `--scope user` option.
+Project or combined scope requires separate repository-owner authorization
+because it can create a repository MCP configuration file.
+
+## Confirm Changes
+
+Report each missing component.
+Before an installation or host configuration change, ask:
+
+> DORI setup is incomplete: `<missing-components>`.
+> Do you want me to install or configure these components in your user
+> environment?
+
+Continue only after explicit approval.
+The user's private-source access confirmation does not approve these changes.
+If the user declines, use the
+[Writing Style Guide](AGENTS.md#writing-style-guide).
+
+## Install Missing Components
+
+When DORI MCP is unavailable and `dori` is missing, require an existing `uv`
+command.
+
+- If `uv` is missing, stop and direct the user to the
+  [internal DORI installation guide](https://gitlab-master.nvidia.com/tech-docs/dori/-/blob/main/docs/get-started/install.md).
+  Do not download or execute an installer script.
+- If `uv` exists, run:
+
+  ```bash
+  uv tool install --python 3.14+freethreaded 'dori==0.10.0' \
+    --index-url https://gitlab-master.nvidia.com/api/v4/projects/226768/packages/pypi/simple
+  ```
+
+When DORI MCP is unavailable and the Skill Library is missing, run:
+
+```bash
+dori install gitlab:tech-docs/skill-library --all --yes
+```
+
+When DORI MCP is available but the Skill Library is missing:
+
+1. Run `dori_collections` with `action="install"` and
+   `source="gitlab:tech-docs/skill-library"`.
+2. Run `dori_refresh`.
+3. Verify the source with `dori_collections(action="list")`.
+
+Do not depend on a shell-visible CLI or reconfigure the host on the DORI MCP
+path.
+
+## Configure and Validate the Host
+
+Complete this section only when DORI MCP is unavailable.
+After the CLI becomes available, run `dori setup auto --dry-run` if it did not
+run during inspection.
+If auto-detection conflicts with the explicit host, use the explicit host.
+If no explicit host exists and auto-detection is uncertain, ask which host is
+running.
+After approval, run the setup command for the resolved host.
+Then perform the following checks:
+
+1. Run the selected command with `--validate`.
+2. Run `dori doctor health --json`.
+3. Require a passing host validation and `"ok": true` health.
+
+Follow the activation action that DORI reports.
+The action can require an application restart, a new session, a window reload,
+or enabling the MCP server.
+
+Until the current agent exposes DORI tools, continue the original task with the
+[Writing Style Guide](AGENTS.md#writing-style-guide).
+
+## Protect Credentials and Repository State
+
+- Never search for, request, print, copy, export, or embed a token, password,
+  cookie, SSH key, or credential-bearing URL.
+- Let `uv`, Git, and DORI use credentials that the user already configured.
+  If access is denied or authentication is missing, stop and refer to the
+  internal DORI installation guide.
+- Do not create repository-scoped identity or authorization files.
+  Confirm private-source access only for an explicit setup request.
+- Do not bypass approval controls for writes outside the repository.
+- Do not create or commit project-scoped DORI state or MCP configuration
+  without separate repository-owner authorization.
+- Do not retry a failed installation in the same task.

--- a/scripts/docs-review-receipt.py
+++ b/scripts/docs-review-receipt.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Validate documentation-writer review receipts and report their adoption."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+_RESULTS = {"blocked", "docs-updated", "no-docs-needed"}
+_SHA_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
+_REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_DEFAULT_REPOSITORY = "NVIDIA-AI-Blueprints/nemotron-voice-agent"
+
+
+@dataclass
+class _ParsedReceipt:
+    agent: str | None
+    agents_blob_sha: str | None
+    completed: bool
+    duplicate_fields: list[str]
+    duplicate_sections: bool
+    evidence: str | None
+    present: bool
+    result: str | None
+    reviewed_head_sha: str | None
+
+
+def main() -> int:
+    """Run the receipt check or historical report command."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = subparsers.add_parser("check", help="Check one pull request event")
+    check_parser.add_argument("--event", required=True, type=Path)
+    check_parser.add_argument("--changed-files", required=True, type=Path)
+    check_parser.add_argument("--agents-blob", required=True)
+    check_parser.add_argument("--mode", choices=("advisory", "required"), default="advisory")
+
+    report_parser = subparsers.add_parser("report", help="Report receipt adoption")
+    report_parser.add_argument("--repo", default=_DEFAULT_REPOSITORY)
+    report_parser.add_argument("--since", required=True)
+    report_parser.add_argument("--until", default=date.today().isoformat())
+    report_parser.add_argument("--format", choices=("csv", "json", "summary"), default="json")
+
+    args = parser.parse_args()
+    if args.command == "check":
+        return _run_check(args)
+    return _run_report(args)
+
+
+def _run_check(args: argparse.Namespace) -> int:
+    event = _read_json(args.event)
+    pull_request = event.get("pull_request")
+    head_pr_sha = _nested_string(pull_request, "head", "sha")
+    if not isinstance(pull_request, dict) or not head_pr_sha or not _SHA_PATTERN.fullmatch(head_pr_sha):
+        raise ValueError("The event file does not contain a valid pull request head SHA")
+
+    body = pull_request.get("body") if isinstance(pull_request.get("body"), str) else ""
+    changed_files = [line.strip() for line in args.changed_files.read_text(encoding="utf-8").splitlines() if line]
+    record = _evaluate_receipt(
+        body,
+        _classify_changed_files(changed_files),
+        head_pr_sha,
+        args.agents_blob,
+    )
+    output = {
+        "type": "documentation-writer-review-receipt",
+        "pr": pull_request.get("number"),
+        "url": pull_request.get("html_url"),
+        "headPrSha": head_pr_sha,
+        **record,
+    }
+    print(json.dumps(output, sort_keys=True))
+    _write_step_summary(output)
+
+    if record["status"] in {"missing", "invalid"}:
+        for issue in record["issues"]:
+            print(
+                f"::warning title=Documentation writer review receipt::{_escape_annotation(issue)}",
+                file=sys.stderr,
+            )
+        if args.mode == "required":
+            return 1
+    return 0
+
+
+def _run_report(args: argparse.Namespace) -> int:
+    if not _REPOSITORY_PATTERN.fullmatch(args.repo):
+        raise ValueError(f"Invalid --repo value: {args.repo}")
+    since = _parse_date(args.since, "--since")
+    through = _parse_date(args.until, "--until")
+    if since > through:
+        raise ValueError("--since must not be later than --until")
+
+    pull_requests = _list_pull_requests(args.repo, since, through)
+    records = [_to_report_record(pull_request) for pull_request in pull_requests]
+    report = _build_report(args.repo, args.since, args.until, records)
+
+    if args.format == "csv":
+        sys.stdout.write(_render_csv(records))
+    elif args.format == "summary":
+        summary = {key: value for key, value in report.items() if key != "records"}
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+def _evaluate_receipt(
+    body: str,
+    changes: dict[str, bool | None],
+    head_pr_sha: str,
+    expected_agents_blob: str | None = None,
+) -> dict[str, Any]:
+    parsed = _parse_receipt(body)
+    code_changed = changes["codeChanged"]
+    docs_changed = changes["docsChanged"]
+    issues: list[str] = []
+
+    if code_changed is None or docs_changed is None:
+        issues.append("The PR description does not select one code or documentation-only change type.")
+        return _receipt_record(parsed, changes, issues, "unclassified")
+
+    if not code_changed and not docs_changed:
+        return _receipt_record(parsed, changes, issues, "not-required")
+
+    if not parsed.present:
+        issues.append(
+            "Pull requests that change code or documentation must include the Documentation Writer Review section."
+        )
+    else:
+        if parsed.duplicate_sections:
+            issues.append("The PR description contains more than one Documentation Writer Review section.")
+        if parsed.duplicate_fields:
+            issues.append(
+                "The Documentation Writer Review section repeats singleton fields: "
+                f"{', '.join(parsed.duplicate_fields)}."
+            )
+        if not parsed.completed:
+            issues.append("Mark the documentation writer review as completed.")
+        if not parsed.result:
+            issues.append("Keep exactly one result: docs-updated, no-docs-needed, or blocked.")
+        if not parsed.evidence or _looks_like_placeholder(parsed.evidence):
+            issues.append("Add documentation review evidence or a no-docs-needed rationale.")
+        if not parsed.agent or _looks_like_placeholder(parsed.agent):
+            issues.append("Record the agent surface that ran the documentation writer review.")
+        if not parsed.reviewed_head_sha:
+            issues.append("Refresh the hidden head SHA after the documentation writer review.")
+        if not parsed.agents_blob_sha:
+            issues.append("Record a valid AGENTS.md blob SHA with 7 to 40 hexadecimal characters.")
+        if parsed.result == "docs-updated" and docs_changed is not True:
+            issues.append("The docs-updated result requires a changed Markdown or docs/ file.")
+
+    head_matches = bool(parsed.reviewed_head_sha and head_pr_sha.lower().startswith(parsed.reviewed_head_sha))
+    if parsed.reviewed_head_sha and not head_matches:
+        issues.append("The documentation writer review is stale after a new commit.")
+
+    agents_matches: bool | None = None
+    if parsed.agents_blob_sha and expected_agents_blob:
+        agents_matches = expected_agents_blob.strip().lower().startswith(parsed.agents_blob_sha)
+        if not agents_matches:
+            issues.append("The reviewed AGENTS.md blob SHA does not match the pull request version.")
+
+    status = "missing" if not parsed.present else ("valid" if not issues else "invalid")
+    return _receipt_record(
+        parsed,
+        changes,
+        issues,
+        status,
+        head_matches=head_matches if parsed.reviewed_head_sha else None,
+        agents_matches=agents_matches,
+    )
+
+
+def _receipt_record(
+    parsed: _ParsedReceipt,
+    changes: dict[str, bool | None],
+    issues: list[str],
+    status: str,
+    *,
+    head_matches: bool | None = None,
+    agents_matches: bool | None = None,
+) -> dict[str, Any]:
+    return {
+        "agent": parsed.agent,
+        "agentsBlobSha": parsed.agents_blob_sha,
+        "agentsShaMatches": agents_matches,
+        "codeChanged": changes["codeChanged"],
+        "docsChanged": changes["docsChanged"],
+        "evidence": parsed.evidence,
+        "headShaMatches": head_matches,
+        "issues": issues,
+        "result": parsed.result,
+        "reviewedHeadSha": parsed.reviewed_head_sha,
+        "status": status,
+    }
+
+
+def _parse_receipt(body: str) -> _ParsedReceipt:
+    matches = list(re.finditer(r"^## Documentation Writer Review\s*$", body, flags=re.MULTILINE))
+    if not matches:
+        return _ParsedReceipt(None, None, False, [], False, None, False, None, None)
+
+    start = matches[0].end()
+    remaining = body[start:]
+    next_heading = re.search(r"^##\s+", remaining, flags=re.MULTILINE)
+    section = remaining[: next_heading.start() if next_heading else len(remaining)]
+    lines = [line.strip() for line in section.splitlines()]
+    review_pattern = re.compile(
+        r"^- \[[ xX]\] Documentation writer (?:subagent )?reviewed the completed (?:changes|implementation)$"
+    )
+    completion_pattern = re.compile(
+        r"^- \[[xX]\] Documentation writer (?:subagent )?reviewed the completed (?:changes|implementation)$"
+    )
+    duplicate_fields = [name for name in ("Result", "Evidence", "Agent") if len(_field_values(lines, name)) > 1]
+    for name in ("docs-review-head-sha", "docs-review-agents-blob-sha"):
+        if len(_hidden_field_values(lines, name)) > 1:
+            duplicate_fields.append(name)
+    if sum(bool(review_pattern.fullmatch(line)) for line in lines) > 1:
+        duplicate_fields.append("review completion checkbox")
+
+    result_value = _field_value(lines, "Result")
+    result_match = re.fullmatch(r"`(blocked|docs-updated|no-docs-needed)`", result_value or "")
+    result = result_match.group(1) if result_match and result_match.group(1) in _RESULTS else None
+    return _ParsedReceipt(
+        agent=_non_empty(_field_value(lines, "Agent")),
+        agents_blob_sha=_parse_sha(_hidden_field_value(lines, "docs-review-agents-blob-sha")),
+        completed=any(completion_pattern.fullmatch(line) for line in lines),
+        duplicate_fields=duplicate_fields,
+        duplicate_sections=len(matches) > 1,
+        evidence=_non_empty(_field_value(lines, "Evidence")),
+        present=True,
+        result=result,
+        reviewed_head_sha=_parse_sha(_hidden_field_value(lines, "docs-review-head-sha")),
+    )
+
+
+def _field_value(lines: list[str], name: str) -> str | None:
+    values = _field_values(lines, name)
+    return values[0] if values else None
+
+
+def _field_values(lines: list[str], name: str) -> list[str]:
+    prefix = f"- {name}:"
+    return [line[len(prefix) :].strip() for line in lines if line.startswith(prefix)]
+
+
+def _hidden_field_value(lines: list[str], name: str) -> str | None:
+    values = _hidden_field_values(lines, name)
+    return values[0] if values else None
+
+
+def _hidden_field_values(lines: list[str], name: str) -> list[str]:
+    prefix = f"<!-- {name}:"
+    suffix = "-->"
+    return [
+        line[len(prefix) : -len(suffix)].strip() for line in lines if line.startswith(prefix) and line.endswith(suffix)
+    ]
+
+
+def _parse_sha(value: str | None) -> str | None:
+    normalized = value.strip().strip("`").lower() if value else ""
+    return normalized if _SHA_PATTERN.fullmatch(normalized) else None
+
+
+def _non_empty(value: str | None) -> str | None:
+    normalized = value.strip() if value else ""
+    return normalized or None
+
+
+def _looks_like_placeholder(value: str) -> bool:
+    return bool(re.search(r"[<>|]", value))
+
+
+def _classify_changed_files(changed_files: list[str]) -> dict[str, bool]:
+    return {
+        "codeChanged": any(not _is_documentation_file(file) for file in changed_files),
+        "docsChanged": any(_is_documentation_file(file) for file in changed_files),
+    }
+
+
+def _classify_pr_type(body: str) -> dict[str, bool | None]:
+    checked = [line.strip() for line in body.splitlines() if re.match(r"^- \[[xX]\] ", line.strip())]
+    code_only = any(line.lower().startswith("- [x] code change (") for line in checked)
+    code_with_docs = any(re.fullmatch(r"- \[[xX]\] Code change with doc updates", line) for line in checked)
+    docs_only = any(re.fullmatch(r"- \[[xX]\] Doc only \(.+\)", line) for line in checked)
+    if (code_only or code_with_docs) and not docs_only:
+        return {"codeChanged": True, "docsChanged": code_with_docs}
+    if docs_only and not code_only and not code_with_docs:
+        return {"codeChanged": False, "docsChanged": True}
+    return {"codeChanged": None, "docsChanged": None}
+
+
+def _is_documentation_file(file: str) -> bool:
+    lower = file.lower()
+    return file.startswith("docs/") or lower.endswith(".md") or lower.endswith(".mdx")
+
+
+def _to_report_record(pull_request: dict[str, Any]) -> dict[str, Any]:
+    body = pull_request.get("body") if isinstance(pull_request.get("body"), str) else ""
+    head_sha = pull_request.get("headRefOid")
+    if not isinstance(head_sha, str) or not _SHA_PATTERN.fullmatch(head_sha):
+        raise ValueError(f"Pull request #{pull_request.get('number')} has an invalid head SHA")
+    author = pull_request.get("author")
+    record = _evaluate_receipt(body, _classify_pr_type(body), head_sha)
+    return {
+        "author": author.get("login") if isinstance(author, dict) else None,
+        "createdAt": pull_request.get("createdAt"),
+        "headPrSha": head_sha,
+        "isDraft": pull_request.get("isDraft"),
+        "mergedAt": pull_request.get("mergedAt"),
+        "number": pull_request.get("number"),
+        "state": pull_request.get("state"),
+        "url": pull_request.get("url"),
+        **record,
+    }
+
+
+def _list_pull_requests(repository: str, since: date, through: date) -> list[dict[str, Any]]:
+    pull_requests = _query_pull_request_range(repository, since, through)
+    if len(pull_requests) < 1000:
+        return pull_requests
+    if since == through:
+        raise RuntimeError(f"The {since.isoformat()} report reached GitHub's 1000-PR search limit.")
+    midpoint = since + timedelta(days=(through - since).days // 2)
+    return [
+        *_list_pull_requests(repository, since, midpoint),
+        *_list_pull_requests(repository, midpoint + timedelta(days=1), through),
+    ]
+
+
+def _query_pull_request_range(repository: str, since: date, through: date) -> list[dict[str, Any]]:
+    command = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repository,
+        "--state",
+        "all",
+        "--limit",
+        "1000",
+        "--search",
+        f"created:{since.isoformat()}..{through.isoformat()}",
+        "--json",
+        "number,url,state,isDraft,author,createdAt,mergedAt,headRefOid,body",
+    ]
+    try:
+        completed = subprocess.run(command, check=True, capture_output=True, text=True, timeout=60)
+    except subprocess.CalledProcessError as exc:
+        details = exc.stderr.strip()
+        raise RuntimeError(f"{' '.join(command)} failed{f': {details}' if details else ''}") from exc
+    parsed = json.loads(completed.stdout)
+    if not isinstance(parsed, list):
+        raise RuntimeError("GitHub CLI did not return a JSON array")
+    return parsed
+
+
+def _parse_date(value: str, option: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"Invalid {option} value: {value}") from exc
+
+
+def _build_report(repository: str, since: str, through: str, records: list[dict[str, Any]]) -> dict[str, Any]:
+    eligible = [record for record in records if record["codeChanged"] is True or record["docsChanged"] is True]
+    recorded = [record for record in eligible if record["status"] != "missing"]
+    valid = [record for record in eligible if record["status"] == "valid"]
+    fresh = [record for record in recorded if record["headShaMatches"] is True]
+    result_counts = {result: 0 for result in sorted(_RESULTS)}
+    agent_counts: dict[str, int] = {}
+    for record in valid:
+        if record["result"]:
+            result_counts[record["result"]] += 1
+        if record["agent"]:
+            agent = record["agent"].lower()
+            agent_counts[agent] = agent_counts.get(agent, 0) + 1
+
+    return {
+        "repository": repository,
+        "since": since,
+        "through": through,
+        "metrics": {
+            "totalPrs": len(records),
+            "eligiblePrs": len(eligible),
+            "eligibleCodePrs": sum(record["codeChanged"] is True for record in eligible),
+            "eligibleDocsOnlyPrs": sum(
+                record["codeChanged"] is False and record["docsChanged"] is True for record in eligible
+            ),
+            "unclassifiedPrs": sum(
+                record["codeChanged"] is None or record["docsChanged"] is None for record in records
+            ),
+            "recordedReceipts": len(recorded),
+            "receiptCoverage": _ratio(len(recorded), len(eligible)),
+            "validReceipts": len(valid),
+            "validReceiptRate": _ratio(len(valid), len(eligible)),
+            "freshReceipts": len(fresh),
+            "freshReceiptRate": _ratio(len(fresh), len(recorded)),
+            "results": result_counts,
+            "agents": agent_counts,
+        },
+        "records": records,
+    }
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    return round(numerator / denominator, 4) if denominator else None
+
+
+def _render_csv(records: list[dict[str, Any]]) -> str:
+    headers = [
+        "number",
+        "url",
+        "state",
+        "is_draft",
+        "author",
+        "created_at",
+        "merged_at",
+        "code_changed",
+        "docs_changed",
+        "receipt_status",
+        "result",
+        "agent",
+        "reviewed_head_sha",
+        "head_pr_sha",
+        "head_sha_matches",
+        "agents_blob_sha",
+        "evidence",
+        "issues",
+    ]
+    output = io.StringIO()
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerow(headers)
+    for record in records:
+        writer.writerow(
+            _csv_cell(value)
+            for value in (
+                record["number"],
+                record["url"],
+                record["state"],
+                record["isDraft"],
+                record["author"],
+                record["createdAt"],
+                record["mergedAt"],
+                record["codeChanged"],
+                record["docsChanged"],
+                record["status"],
+                record["result"],
+                record["agent"],
+                record["reviewedHeadSha"],
+                record["headPrSha"],
+                record["headShaMatches"],
+                record["agentsBlobSha"],
+                record["evidence"],
+                "; ".join(record["issues"]),
+            )
+        )
+    return output.getvalue()
+
+
+def _csv_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        text = str(value).lower()
+    else:
+        text = str(value)
+    return f"'{text}" if re.match(r"^[=+\-@\t\r]", text) else text
+
+
+def _write_step_summary(output: dict[str, Any]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    lines = [
+        "## Documentation writer review receipt",
+        "",
+        f"- PR: #{output['pr']}" if output["pr"] is not None else "- PR: unknown",
+        f"- Head PR SHA: `{output['headPrSha'][:12]}`",
+        f"- Status: `{output['status']}`",
+        f"- Result: `{output['result']}`" if output["result"] else "- Result: not recorded",
+        f"- Agent: {output['agent'] or 'not recorded'}",
+    ]
+    if output["issues"]:
+        lines.extend(("", "### Advisory findings", "", *(f"- {issue}" for issue in output["issues"])))
+    with Path(summary_path).open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines) + "\n")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Expected a JSON object in {path}")
+    return parsed
+
+
+def _nested_string(value: Any, *keys: str) -> str | None:
+    current = value
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current if isinstance(current, str) else None
+
+
+def _escape_annotation(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(str(error), file=sys.stderr)
+        raise SystemExit(1) from error

--- a/tests/test_docs_review_receipt.py
+++ b/tests/test_docs_review_receipt.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Tests for the documentation-writer review receipt tooling."""
+
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "docs-review-receipt.py"
+_HEAD_SHA = "a" * 40
+_AGENTS_BLOB_SHA = "b" * 40
+
+
+def _receipt(**overrides: str) -> str:
+    values = {
+        "checked": "x",
+        "result": "`docs-updated`",
+        "evidence": "Updated docs/01-getting-started.md.",
+        "agent": "Codex Desktop",
+        "head_sha": _HEAD_SHA[:12],
+        "agents_sha": _AGENTS_BLOB_SHA[:12],
+        **overrides,
+    }
+    return f"""## Documentation Writer Review
+
+- [{values["checked"]}] Documentation writer reviewed the completed changes
+- Result: {values["result"]}
+- Evidence: {values["evidence"]}
+- Agent: {values["agent"]}
+<!-- docs-review-head-sha: {values["head_sha"]} -->
+<!-- docs-review-agents-blob-sha: {values["agents_sha"]} -->
+"""
+
+
+def _run_check(
+    tmp_path: Path,
+    body: str,
+    changed_files: list[str],
+    *,
+    mode: str = "advisory",
+    agents_blob: str = _AGENTS_BLOB_SHA,
+) -> subprocess.CompletedProcess[str]:
+    event_path = tmp_path / "event.json"
+    files_path = tmp_path / "changed-files.txt"
+    summary_path = tmp_path / "summary.md"
+    event_path.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "number": 42,
+                    "html_url": "https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/pull/42",
+                    "body": body,
+                    "head": {"sha": _HEAD_SHA},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    files_path.write_text(f"{'\n'.join(changed_files)}\n", encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "check",
+            "--event",
+            str(event_path),
+            "--changed-files",
+            str(files_path),
+            "--agents-blob",
+            agents_blob,
+            "--mode",
+            mode,
+        ],
+        capture_output=True,
+        check=False,
+        env={**os.environ, "GITHUB_STEP_SUMMARY": str(summary_path)},
+        text=True,
+        timeout=10,
+    )
+
+
+def test_accepts_fresh_receipt_for_code_and_documentation(tmp_path: Path) -> None:
+    result = _run_check(tmp_path, _receipt(), ["src/server.py", "docs/01-getting-started.md"])
+
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    assert output["status"] == "valid"
+    assert output["result"] == "docs-updated"
+    assert output["headShaMatches"] is True
+    assert output["agentsShaMatches"] is True
+    assert output["issues"] == []
+
+
+def test_reports_missing_receipt_without_blocking_advisory_mode(tmp_path: Path) -> None:
+    result = _run_check(tmp_path, "## Summary\n\nChange the server.\n", ["src/server.py"])
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout)["status"] == "missing"
+    assert "change code or documentation must include" in result.stderr
+
+
+def test_fails_required_mode_when_receipt_is_missing(tmp_path: Path) -> None:
+    result = _run_check(tmp_path, "## Summary\n\nChange the server.\n", ["src/server.py"], mode="required")
+
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["status"] == "missing"
+
+
+def test_rejects_stale_head_and_agents_revisions(tmp_path: Path) -> None:
+    body = _receipt(
+        result="`no-docs-needed`",
+        evidence="The change affects an internal test helper only.",
+        head_sha="c" * 12,
+        agents_sha="d" * 12,
+    )
+    result = _run_check(tmp_path, body, ["tests/test_service_catalog.py"])
+
+    output = json.loads(result.stdout)
+    assert output["status"] == "invalid"
+    assert "The documentation writer review is stale after a new commit." in output["issues"]
+    assert "The reviewed AGENTS.md blob SHA does not match the pull request version." in output["issues"]
+
+
+def test_docs_updated_requires_a_documentation_path(tmp_path: Path) -> None:
+    result = _run_check(tmp_path, _receipt(), ["src/server.py"])
+
+    output = json.loads(result.stdout)
+    assert output["status"] == "invalid"
+    assert "The docs-updated result requires a changed Markdown or docs/ file." in output["issues"]
+
+
+def test_rejects_duplicate_receipt_fields(tmp_path: Path) -> None:
+    body = _receipt().replace(
+        "- Result: `docs-updated`",
+        "- Result: `docs-updated`\n- Result: `no-docs-needed`",
+    )
+    result = _run_check(tmp_path, body, ["src/server.py", "docs/01-getting-started.md"])
+
+    output = json.loads(result.stdout)
+    assert output["status"] == "invalid"
+    assert "The Documentation Writer Review section repeats singleton fields: Result." in output["issues"]
+
+
+def test_rejects_duplicate_receipt_sections(tmp_path: Path) -> None:
+    result = _run_check(
+        tmp_path,
+        f"{_receipt()}\n{_receipt()}",
+        ["src/server.py", "docs/01-getting-started.md"],
+    )
+
+    output = json.loads(result.stdout)
+    assert output["status"] == "invalid"
+    assert "The PR description contains more than one Documentation Writer Review section." in output["issues"]
+
+
+def test_rejects_unmodified_template_fields(tmp_path: Path) -> None:
+    body = _receipt(
+        checked=" ",
+        result="`docs-updated` | `no-docs-needed` | `blocked`",
+        evidence="",
+        agent="<Codex Desktop | Codex CLI | Claude Code | Cursor>",
+        head_sha="",
+        agents_sha="",
+    )
+    result = _run_check(tmp_path, body, ["docs/01-getting-started.md"])
+
+    output = json.loads(result.stdout)
+    assert output["status"] == "invalid"
+    assert len(output["issues"]) == 6
+
+
+def test_report_emits_summary_and_formula_safe_csv(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh_path = bin_dir / "gh"
+    pull_requests = [
+        {
+            "number": 1,
+            "url": "https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/pull/1",
+            "state": "MERGED",
+            "isDraft": False,
+            "author": {"login": "engineer"},
+            "createdAt": "2026-06-13T00:00:00Z",
+            "mergedAt": "2026-06-14T00:00:00Z",
+            "headRefOid": _HEAD_SHA,
+            "body": f"""## Type of Change
+
+- [x] Code change with doc updates
+
+{_receipt(evidence="=1+1")}""",
+        },
+        {
+            "number": 2,
+            "url": "https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/pull/2",
+            "state": "OPEN",
+            "isDraft": True,
+            "author": {"login": "engineer"},
+            "createdAt": "2026-06-15T00:00:00Z",
+            "mergedAt": None,
+            "headRefOid": "c" * 40,
+            "body": "## Type of Change\n\n- [x] Code change (feature, bug fix, or refactor)\n",
+        },
+        {
+            "number": 3,
+            "url": "https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/pull/3",
+            "state": "MERGED",
+            "isDraft": False,
+            "author": {"login": "writer"},
+            "createdAt": "2026-06-16T00:00:00Z",
+            "mergedAt": "2026-06-17T00:00:00Z",
+            "headRefOid": "d" * 40,
+            "body": "## Type of Change\n\n- [x] Doc only (prose changes, no code sample modifications)\n",
+        },
+    ]
+    gh_path.write_text(
+        f"#!/usr/bin/env python3\nimport json\nprint(json.dumps({pull_requests!r}))\n",
+        encoding="utf-8",
+    )
+    gh_path.chmod(0o755)
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+    command = [
+        sys.executable,
+        str(_SCRIPT),
+        "report",
+        "--since",
+        "2026-06-12",
+        "--until",
+        "2026-06-12",
+    ]
+
+    json_result = subprocess.run(command, capture_output=True, check=False, env=env, text=True, timeout=10)
+    assert json_result.returncode == 0
+    metrics = json.loads(json_result.stdout)["metrics"]
+    assert metrics["eligiblePrs"] == 3
+    assert metrics["recordedReceipts"] == 1
+    assert metrics["validReceipts"] == 1
+    assert metrics["receiptCoverage"] == 0.3333
+
+    csv_result = subprocess.run(
+        [*command, "--format", "csv"],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+        timeout=10,
+    )
+    assert csv_result.returncode == 0
+    assert "receipt_status" in csv_result.stdout
+    assert "1,https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/pull/1" in csv_result.stdout
+    assert "'=1+1" in csv_result.stdout


### PR DESCRIPTION
## Summary

- Add repository-level agent guidance for product sources of truth, supported workflows, validation, and documentation impact.
- Add scoped documentation guidance with the NVIDIA Writing Style Guide and capability-based optional DORI routing from `docs-agent-setup` v1.3.2.
- Add an explicit-request-only DORI setup guide.
- Add a NemoClaw-style documentation writer review receipt, advisory GitHub workflow, local validator, adoption reports, and automated tests.

## Changes

- Add the receipt fields and quality gates to `.github/PULL_REQUEST_TEMPLATE.md`.
- Add the advisory `CI / Documentation Writer Review` workflow.
- Add `scripts/docs-review-receipt.py` with receipt validation and JSON, summary, and CSV adoption reports.
- Add receipt tests and contributor guidance.
- Route completed documentation reviews back to the primary agent for the PR receipt.
- Keep DORI routing and workflow guidance in `docs/AGENTS.md` as the single documentation-policy owner.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:

## Documentation Writer Review

- [x] Documentation writer reviewed the completed changes
- Result: `docs-updated`
- Evidence: `.github/PULL_REQUEST_TEMPLATE.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/AGENTS.md`, and `docs/DORI_SETUP.md`; centralized and clarified the optional DORI guidance in `docs/AGENTS.md`, including a non-blocking installation recommendation for users with internal NVIDIA GitLab access.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 3afbd22 -->
<!-- docs-review-agents-blob-sha: b73fe32 -->

## Developer and User Impact

- Agents can identify user-visible changes that require documentation updates and leave a structured, commit-bound review receipt.
- Maintainers get advisory receipt findings in GitHub Actions and can measure adoption with summary, JSON, or formula-safe CSV output.
- Documentation work uses the checked-in Writing Style Guide on every host. DORI remains optional and is used only when the current host exposes the verified NVIDIA Skill Library.
- Runtime product behavior is unchanged.

## Verification

- [x] Applicable lint, test, and build checks passed
- [x] Documentation validation passed for changed documentation
- [x] No secrets, API keys, or credentials are committed

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q` (`108 passed`)
- `uv run pre-commit run --files .github/PULL_REQUEST_TEMPLATE.md .github/workflows/docs-review-receipt.yml AGENTS.md CONTRIBUTING.md docs/AGENTS.md scripts/docs-review-receipt.py tests/test_docs_review_receipt.py`
- `uv run pre-commit run --files AGENTS.md docs/AGENTS.md`
- `uv run pre-commit run --files docs/AGENTS.md`
- `git diff --check`
- Verified the Writing Style Guide and DORI setup guide against the current `docs-agent-setup` v1.3.2 maintained assets. Preserved the routing rules while moving their ownership to `docs/AGENTS.md` and clarified the fallback in response to review feedback.
- Confirmed the repository contains no `.dori_user_status` references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor and documentation guidance covering validation, deployment setup, accessibility, credential handling, and repository workflows.
  * Added a step-by-step NVIDIA DORI setup guide.
* **Workflow Improvements**
  * Added pull request checklists and automated advisory checks for documentation review receipts.
  * Added reporting for documentation review adoption and historical metrics.
* **Tests**
  * Added coverage for receipt validation, stale revisions, reporting, and safe CSV output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->