### PR TITLE
LLM Language Gating for Available Language Listing

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -264,6 +264,8 @@ export function useVoiceCatalog(
   asrFunctionId?: string,
   functionId?: string,
   model?: string,
+  pipelineMode?: string,
+  llmId?: string,
 ) {
   return useQuery<TTSConfig>({
     queryKey: [
@@ -275,6 +277,8 @@ export function useVoiceCatalog(
       asrServer || "",
       asrModel || "",
       asrFunctionId || "",
+      pipelineMode || "",
+      llmId || "",
     ],
     queryFn: () => {
       const params = new URLSearchParams();
@@ -285,6 +289,8 @@ export function useVoiceCatalog(
       if (asrServer) params.set("asr_server", asrServer);
       if (asrModel) params.set("asr_model", asrModel);
       if (asrFunctionId) params.set("asr_function_id", asrFunctionId);
+      if (pipelineMode) params.set("pipeline_mode", pipelineMode);
+      if (llmId) params.set("llm_id", llmId);
       const url = params.size > 0 ? `/api/tts-config?${params.toString()}` : "/api/tts-config";
       return fetchJson<TTSConfig>(url);
     },

--- a/client/src/components/VoiceSettings.tsx
+++ b/client/src/components/VoiceSettings.tsx
@@ -27,6 +27,7 @@ export function VoiceSettings() {
   const { isConnected, isConnecting, isLocked } = useConnectionState();
   const {
     selectedExample,
+    selectedLLM,
     selectedASR,
     selectedTTS,
     selectedSessionLanguage,
@@ -45,6 +46,8 @@ export function VoiceSettings() {
     sessionLanguagesEnabled ? selectedASR?.functionId : undefined,
     selectedTTS?.functionId,
     selectedTTS?.model,
+    sessionLanguagesEnabled ? selectedExample?.key : undefined,
+    sessionLanguagesEnabled ? selectedLLM?.id : undefined,
   );
 
   const [voiceOverride, setVoiceOverride] = useState<VoiceOverrideState>({
@@ -146,7 +149,7 @@ export function VoiceSettings() {
       return (
         <PanelSection label="VOICE SETTINGS">
           <p style={{ fontSize: "11px", color: "var(--text-muted)" }}>
-            No shared ASR/TTS languages found for the selected services
+            No shared ASR/TTS/LLM languages found for the selected services
           </p>
         </PanelSection>
       );

--- a/src/examples/multilingual/multilingual_processor.py
+++ b/src/examples/multilingual/multilingual_processor.py
@@ -125,8 +125,9 @@ def get_lang_codes(
     asr_function_id: str = "",
     tts_server: str = "",
     tts_voice_id: str = "",
+    llm_supported_languages=None,
 ) -> str:
-    """Comma-separated language codes shared by the ASR and TTS services (informational)."""
+    """Comma-separated language codes compatible with the selected services."""
     if asr_server or tts_server:
         languages = build_session_languages(
             asr_server,
@@ -134,8 +135,9 @@ def get_lang_codes(
             asr_function_id,
             tts_server,
             tts_voice_id,
+            llm_supported_languages=llm_supported_languages,
         ).get("languages", [])
-        if languages:
+        if languages or llm_supported_languages is not None:
             return ", ".join(languages)
 
     tts_config = config_store.get("tts", {})

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -54,13 +54,19 @@ from examples.shared.pipeline_utils import (
     build_user_mute_strategies,
     create_transport,
 )
-from examples.shared.prewarm import prewarm_asr, prewarm_tts, resolve_voice_for_language
+from examples.shared.prewarm import (
+    prewarm_asr,
+    prewarm_tts,
+    resolve_voice_for_language,
+    validate_llm_session_language,
+)
 from tracing import IS_TRACING_ENABLED
 from utils import (
     is_nvcf,
     load_ipa_dictionary,
     load_prompt_catalog,
     load_service_entry,
+    load_service_entry_by_id,
     normalize_lang_code,
     parse_env_bool,
     parse_env_float,
@@ -114,6 +120,7 @@ async def _prepare_session_language_codes(
     asr_server: str,
     asr_model: str,
     asr_function_id: str,
+    llm_supported_languages=None,
 ) -> str:
     """Prewarm speech services and return UI language codes when startup should probe them."""
     if _is_eval_transport(runner_args):
@@ -125,13 +132,16 @@ async def _prepare_session_language_codes(
         asyncio.to_thread(prewarm_tts, tts_server, tts_voice, tts_function_id, tts_model),
     ]
     await asyncio.gather(*prewarm_tasks)
-    return get_lang_codes(
-        asr_server=asr_server,
-        asr_model=asr_model,
-        asr_function_id=asr_function_id,
-        tts_server=tts_server,
-        tts_voice_id=tts_voice,
-    )
+    language_catalog_kwargs = {
+        "asr_server": asr_server,
+        "asr_model": asr_model,
+        "asr_function_id": asr_function_id,
+        "tts_server": tts_server,
+        "tts_voice_id": tts_voice,
+    }
+    if llm_supported_languages is not None:
+        language_catalog_kwargs["llm_supported_languages"] = llm_supported_languages
+    return get_lang_codes(**language_catalog_kwargs)
 
 
 async def bot(runner_args: RunnerArguments) -> None:
@@ -148,6 +158,14 @@ async def bot(runner_args: RunnerArguments) -> None:
     default_llm = load_service_entry("llm", "")
     default_tts = load_service_entry("tts", "")
     default_asr = load_service_entry("asr", "")
+    selected_llm_id = str(body.get("llm_id", "") or "")
+    custom_llm = selected_llm_id.startswith("custom-") or (not selected_llm_id and bool(body.get("model_id")))
+    selected_llm_entry = {}
+    if not custom_llm:
+        selected_llm_entry = load_service_entry_by_id("llm", selected_llm_id) if selected_llm_id else default_llm
+        if not selected_llm_entry:
+            selected_llm_entry = default_llm
+    llm_supported_languages = selected_llm_entry.get("supported_languages") if selected_llm_entry else None
 
     # --- ASR ---
     asr_server = body.get("asr_server", "") or default_asr.get("server", "grpc.nvcf.nvidia.com:443")
@@ -166,6 +184,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     if not asr_language_code or asr_language_code.strip().lower() == "auto":
         asr_language_code = DEFAULT_SESSION_LANGUAGE
     fixed_session_language = normalize_lang_code(asr_language_code)
+    validate_llm_session_language(fixed_session_language, llm_supported_languages)
     if asr_function_id or asr_model:
         asr_kwargs["model_function_map"] = {
             "function_id": asr_function_id,
@@ -196,6 +215,7 @@ async def bot(runner_args: RunnerArguments) -> None:
         asr_server=asr_server,
         asr_model=asr_model,
         asr_function_id=asr_function_id,
+        llm_supported_languages=llm_supported_languages,
     )
 
     # --- LLM ---

--- a/src/examples/multilingual/services.cloud.yaml
+++ b/src/examples/multilingual/services.cloud.yaml
@@ -9,6 +9,7 @@ llm:
     name: "Nemotron 3 Nano 30B A3B"
     model_id: "nvidia/nemotron-3-nano-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
+    supported_languages: [en, de, es, fr, it, ja]
     system_prompt: ""
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
 
@@ -16,6 +17,7 @@ llm:
     name: "Nemotron 3 Nano 30B A3B (Reasoning)"
     model_id: "nvidia/nemotron-3-nano-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
+    supported_languages: [en, de, es, fr, it, ja]
     system_prompt: ""
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true},"repetition_penalty":1.05}}'
 
@@ -23,6 +25,7 @@ llm:
     name: "Nemotron 3 Super 120B A12B"
     model_id: "nvidia/nemotron-3-super-120b-a12b"
     base_url: "https://integrate.api.nvidia.com/v1"
+    supported_languages: [en, de, es, fr, it, ja, zh]
     system_prompt: ""
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
 
@@ -30,6 +33,7 @@ llm:
     name: "Nemotron 3 Super 120B A12B (Reasoning)"
     model_id: "nvidia/nemotron-3-super-120b-a12b"
     base_url: "https://integrate.api.nvidia.com/v1"
+    supported_languages: [en, de, es, fr, it, ja, zh]
     system_prompt: ""
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true},"repetition_penalty":1.05}}'
 

--- a/src/examples/multilingual/services.local.yaml
+++ b/src/examples/multilingual/services.local.yaml
@@ -8,6 +8,7 @@ workstation:
       name: "Nemotron 3 Nano 30B A3B"
       model_id: "nvidia/nemotron-3-nano"
       base_url: "http://nvidia-llm:8000/v1"
+      supported_languages: [en, de, es, fr, it, ja]
       system_prompt: ""
       extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:
@@ -50,6 +51,7 @@ dgxspark:
       name: "Nemotron 3 Nano NVFP4"
       model_id: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4"
       base_url: "http://nvidia-llm-vllm:8000/v1"
+      supported_languages: [en, de, es, fr, it, ja]
       system_prompt: ""
       extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
   tts:

--- a/src/examples/shared/prewarm.py
+++ b/src/examples/shared/prewarm.py
@@ -4,6 +4,7 @@
 """Service pre-warming to avoid blocking the event loop during first connection."""
 
 import os
+from collections.abc import Iterable
 
 from loguru import logger
 from pipecat.services.nvidia.stt import NvidiaSTTService
@@ -127,11 +128,55 @@ def _normalize_catalog_code(code: str) -> str:
     return normalize_lang_code(code).lower()
 
 
+def _llm_language_set(supported_languages: Iterable[str] | str) -> set[str]:
+    """Normalize LLM language capabilities to base language codes."""
+    if isinstance(supported_languages, str):
+        supported_languages = supported_languages.split(",")
+    return {
+        _normalize_catalog_code(code.strip()).split("-", 1)[0]
+        for code in supported_languages
+        if isinstance(code, str) and code.strip()
+    }
+
+
+def llm_supports_session_language(
+    language_code: str,
+    supported_languages: Iterable[str] | str | None,
+) -> bool:
+    """Return whether an LLM capability list supports a BCP-47 session locale.
+
+    ``None`` preserves compatibility for custom LLMs whose capabilities are not
+    declared. An explicit empty collection supports no session languages.
+    """
+    if supported_languages is None:
+        return True
+    language_base = _normalize_catalog_code(language_code).split("-", 1)[0]
+    return language_base in _llm_language_set(supported_languages)
+
+
+def validate_llm_session_language(
+    language_code: str,
+    supported_languages: Iterable[str] | str | None,
+) -> None:
+    """Reject a session locale that the selected built-in LLM cannot serve."""
+    if llm_supports_session_language(language_code, supported_languages):
+        return
+    supported = ", ".join(sorted(_llm_language_set(supported_languages or []))) or "none"
+    raise ValueError(
+        f"Session language {normalize_lang_code(language_code)!r} is not supported by the selected LLM "
+        f"(supported languages: {supported})"
+    )
+
+
 _EMPTY_ASR_LANGUAGE_FALLBACK = "es-US"
 
 
-def intersect_session_languages(asr_config: dict, tts_config: dict) -> list[str]:
-    """Languages supported by both ASR and TTS (LLM prompt uses the TTS catalog)."""
+def intersect_session_languages(
+    asr_config: dict,
+    tts_config: dict,
+    llm_supported_languages: Iterable[str] | str | None = None,
+) -> list[str]:
+    """Languages supported by ASR, TTS, and the selected LLM when declared."""
     tts_langs = _tts_language_set(tts_config)
     if not tts_langs:
         return []
@@ -141,6 +186,9 @@ def intersect_session_languages(asr_config: dict, tts_config: dict) -> list[str]
         asr_langs = {_normalize_catalog_code(_EMPTY_ASR_LANGUAGE_FALLBACK)}
 
     result = asr_langs & tts_langs
+    if llm_supported_languages is not None:
+        llm_langs = _llm_language_set(llm_supported_languages)
+        result = {code for code in result if code.split("-", 1)[0] in llm_langs}
 
     return sorted(
         (normalize_lang_code(code) for code in result),
@@ -156,8 +204,9 @@ def build_session_languages(
     tts_voice_id: str,
     tts_function_id: str = "",
     tts_model: str = "",
+    llm_supported_languages: Iterable[str] | str | None = None,
 ) -> dict:
-    """Return the ASR∩TTS language catalog and TTS voices for session configuration."""
+    """Return the compatible session-language catalog and TTS voices."""
     tts_config = prewarm_tts(
         tts_server,
         tts_voice_id,
@@ -165,7 +214,7 @@ def build_session_languages(
         tts_model,
     )
     asr_config = prewarm_asr(asr_server, asr_model, asr_function_id)
-    languages = intersect_session_languages(asr_config, tts_config)
+    languages = intersect_session_languages(asr_config, tts_config, llm_supported_languages)
     return {
         "languages": languages,
         "voices": tts_config.get("voices", []),

--- a/src/server.py
+++ b/src/server.py
@@ -77,6 +77,7 @@ from utils import (
     is_nvcf,
     load_prompt_catalog,
     load_service_entry,
+    load_service_entry_by_id,
     load_tools_catalog,
     parse_endpoint,
     set_active_slots,
@@ -957,6 +958,8 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
 
     @app.get("/api/tts-config")
     async def tts_config(
+        pipeline_mode: str = Query(default=""),
+        llm_id: str = Query(default=""),
         server: str = Query(default=""),
         voice_id: str = Query(default=""),
         function_id: str = Query(default=""),
@@ -965,8 +968,16 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
         asr_model: str = Query(default=""),
         asr_function_id: str = Query(default=""),
     ):
+        _bind_example_context_by_key(pipeline_mode or fallback_example_key)
         if asr_server or asr_model or asr_function_id:
             default_asr_server, default_asr_model, default_asr_function_id = _get_default_asr_catalog()
+            if llm_id.startswith("custom-"):
+                llm_entry = {}
+            elif llm_id:
+                llm_entry = load_service_entry_by_id("llm", llm_id) or load_service_entry("llm", "")
+            else:
+                llm_entry = load_service_entry("llm", "")
+            llm_supported_languages = llm_entry.get("supported_languages") if llm_entry else None
             tts_server, tts_voice, tts_function_id, tts_model = _resolve_tts_selection(
                 server, voice_id, function_id, model
             )
@@ -980,11 +991,12 @@ def create_app(host: str = "localhost", prompt_file: str = "") -> FastAPI:
                     tts_voice,
                     tts_function_id,
                     tts_model,
+                    llm_supported_languages,
                     timeout=_CONNECT_PREWARM_TIMEOUT_SECS,
                 )
             except TimeoutError:
                 logger.warning(
-                    "tts-config ASR/TTS intersection timed out after {}s",
+                    "tts-config ASR/TTS/LLM intersection timed out after {}s",
                     _CONNECT_PREWARM_TIMEOUT_SECS,
                 )
                 return JSONResponse(

--- a/src/utils.py
+++ b/src/utils.py
@@ -544,7 +544,7 @@ def hydrate_config_from_catalog(config: dict) -> None:
     the client-provided details continue to drive the pipeline.
     """
     for id_field, category, field_map in _CATALOG_HYDRATION:
-        entry = _load_catalog_entry_by_id(category, config.get(id_field, ""))
+        entry = load_service_entry_by_id(category, config.get(id_field, ""))
         if not entry:
             continue
         for yaml_field, body_field in field_map.items():
@@ -583,7 +583,7 @@ def filter_session_config(data: dict) -> dict:
     return filtered
 
 
-def _load_catalog_entry_by_id(category: str, entry_id: str) -> dict:
+def load_service_entry_by_id(category: str, entry_id: str) -> dict:
     """Look up a built-in catalog entry by category and API id.
 
     Supports UI ids (``<source>:<key>``) and raw catalog keys for direct

--- a/tests/unit/test_multilingual_turn_strategy.py
+++ b/tests/unit/test_multilingual_turn_strategy.py
@@ -158,7 +158,25 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
             tts_voice_id="Magpie-Multilingual.EN-US.Aria",
         )
 
-    def _run_prepare_session_language_codes(self, runner_args: RunnerArguments) -> str:
+    def test_non_eval_transport_passes_llm_language_capabilities(self) -> None:
+        get_lang_codes = Mock(return_value="en-US,de-DE")
+
+        with (
+            patch("examples.multilingual.pipeline.asyncio.to_thread", AsyncMock()),
+            patch("examples.multilingual.pipeline.get_lang_codes", get_lang_codes),
+        ):
+            self._run_prepare_session_language_codes(
+                RunnerArguments(),
+                llm_supported_languages=["en", "de"],
+            )
+
+        self.assertEqual(get_lang_codes.call_args.kwargs["llm_supported_languages"], ["en", "de"])
+
+    def _run_prepare_session_language_codes(
+        self,
+        runner_args: RunnerArguments,
+        llm_supported_languages=None,
+    ) -> str:
         return asyncio.run(
             _prepare_session_language_codes(
                 runner_args,
@@ -169,5 +187,6 @@ class MultilingualTurnStrategyTests(unittest.TestCase):
                 asr_server="asr.example:443",
                 asr_model="parakeet",
                 asr_function_id="fn-123",
+                llm_supported_languages=llm_supported_languages,
             )
         )

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -12,7 +12,13 @@ from unittest.mock import patch
 
 import examples_registry
 import utils
-from utils import build_services_api_response, filter_session_config, hydrate_config_from_catalog, load_service_entry
+from utils import (
+    build_services_api_response,
+    filter_session_config,
+    hydrate_config_from_catalog,
+    load_service_entry,
+    load_service_entry_by_id,
+)
 
 
 class ServiceCatalogHydrationTests(unittest.TestCase):
@@ -206,6 +212,32 @@ llm:
             "nemotron-asr-streaming",
         )
         self.assertNotIn("nemotron-asr-streaming-multilingual", multilingual_catalog["asr"])
+
+    def test_multilingual_llms_declare_supported_languages(self) -> None:
+        cloud = utils.load_yaml_file(Path("src/examples/multilingual/services.cloud.yaml"))["llm"]
+        local = utils.load_yaml_file(Path("src/examples/multilingual/services.local.yaml"))
+
+        nano_languages = ["en", "de", "es", "fr", "it", "ja"]
+        super_languages = [*nano_languages, "zh"]
+        self.assertEqual(cloud["nemotron-nano"]["supported_languages"], nano_languages)
+        self.assertEqual(cloud["nemotron-nano-reasoning"]["supported_languages"], nano_languages)
+        self.assertEqual(cloud["nemotron-super"]["supported_languages"], super_languages)
+        self.assertEqual(cloud["nemotron-super-reasoning"]["supported_languages"], super_languages)
+        self.assertEqual(
+            local["workstation"]["llm"]["nemotron-nano"]["supported_languages"],
+            nano_languages,
+        )
+        self.assertEqual(
+            local["dgxspark"]["llm"]["nemotron-nano"]["supported_languages"],
+            nano_languages,
+        )
+
+        token = utils._service_context.set((Path("src/examples/multilingual"), ("llm", "asr", "tts")))
+        try:
+            selected_nano = load_service_entry_by_id("llm", "cloud-nim:nemotron-nano")
+        finally:
+            utils._service_context.reset(token)
+        self.assertEqual(selected_nano["supported_languages"], nano_languages)
 
     def test_multilingual_agent_prompt_keys_are_registry_declared(self) -> None:
         unlocked = examples_registry.Selection(

--- a/tests/unit/test_session_languages.py
+++ b/tests/unit/test_session_languages.py
@@ -119,6 +119,17 @@ class SessionLanguageCatalogTests(unittest.TestCase):
 
         self.assertEqual(languages, ["el-GR"])
 
+    def test_empty_llm_capabilities_exclude_and_reject_all_languages(self) -> None:
+        languages = intersect_session_languages(
+            {"languages": ["de-DE", "en-US"]},
+            {"languages": ["de-DE", "en-US"], "voices": []},
+            [],
+        )
+
+        self.assertEqual(languages, [])
+        with self.assertRaisesRegex(ValueError, "en-US.*not supported.*none"):
+            validate_llm_session_language("en-US", [])
+
     def test_runtime_validation_rejects_greek_for_nano(self) -> None:
         with self.assertRaisesRegex(ValueError, "el-GR.*not supported"):
             validate_llm_session_language("el-GR", ["en", "de", "es", "fr", "it", "ja"])

--- a/tests/unit/test_session_languages.py
+++ b/tests/unit/test_session_languages.py
@@ -42,7 +42,11 @@ if "riva.client.proto.riva_asr_pb2" not in sys.modules:
     sys.modules["riva.client.proto"] = proto
     sys.modules["riva.client.proto.riva_asr_pb2"] = riva_asr_pb2
 
-from examples.shared.prewarm import intersect_session_languages, prewarm_asr
+from examples.shared.prewarm import (
+    intersect_session_languages,
+    prewarm_asr,
+    validate_llm_session_language,
+)
 
 
 class _FakeModelConfig:
@@ -96,6 +100,31 @@ class SessionLanguageCatalogTests(unittest.TestCase):
         )
 
         self.assertEqual(languages, ["fr-FR"])
+
+    def test_llm_capabilities_filter_speech_languages_by_base_code(self) -> None:
+        languages = intersect_session_languages(
+            {"languages": ["de-DE", "el-GR", "en-US", "fr-FR"]},
+            {"languages": ["de-DE", "el-GR", "en-US", "fr-FR"], "voices": []},
+            ["de", "en", "fr"],
+        )
+
+        self.assertEqual(languages, ["de-DE", "en-US", "fr-FR"])
+
+    def test_missing_llm_capabilities_preserve_custom_llm_behavior(self) -> None:
+        languages = intersect_session_languages(
+            {"languages": ["el-GR"]},
+            {"languages": ["el-GR"], "voices": []},
+            None,
+        )
+
+        self.assertEqual(languages, ["el-GR"])
+
+    def test_runtime_validation_rejects_greek_for_nano(self) -> None:
+        with self.assertRaisesRegex(ValueError, "el-GR.*not supported"):
+            validate_llm_session_language("el-GR", ["en", "de", "es", "fr", "it", "ja"])
+
+    def test_runtime_validation_accepts_locale_for_supported_base_code(self) -> None:
+        validate_llm_session_language("de-DE", ["de"])
 
     def test_asr_prewarm_uses_default_config_request_without_model_name(self) -> None:
         _FakeNvidiaSTTService.last = None


### PR DESCRIPTION
## Summary

  Prevents unsupported language combinations from being offered or started in the multilingual assistant.

  PR 54 derived available session languages from only the ASR and TTS capabilities. This allowed languages such as `ar-AR` and `el-GR` to be paired with Nemotron 3 Nano even though the LLM does not officially support them. The resulting mixed-language LLM responses appeared in the UI and were passed directly to TTS, causing broken or incomplete speech.

  The change makes language selection reflect the complete ASR, TTS, and LLM pipeline and adds runtime validation for bypassed or stale client requests.

  ## Changes

  - Added supported-language metadata for the built-in Nemotron 3 Nano and Nemotron 3 Super LLM configurations.
  - Changed session-language discovery from ASR ∩ TTS to ASR ∩ TTS ∩ selected LLM.
  - Updated the client language-catalog request to include the selected pipeline and LLM.
  - Refreshes available session languages when the selected LLM changes.
  - Added base-language matching so locale variants such as `de-DE` match LLM capability `de`.
  - Added pipeline-start validation for unsupported built-in LLM and session-language combinations.
  - Prevented direct, stale, or bypassed requests from starting unsupported sessions.
  - Preserved backward compatibility for custom LLMs whose language capabilities are not declared.
  - Updated the empty-state message to describe the ASR, TTS, and LLM compatibility requirement.
  - Added unit and regression coverage for LLM language metadata, catalog filtering, runtime rejection, and multilingual prewarm behavior.

  ## Type of Change

  - [x] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates
  - [ ] Doc only (prose changes, no code sample modifications)
  - [ ] Doc only (includes code sample changes)

  ## Quality Gates

  - [x] Tests added or updated for changed behavior
  - [ ] Existing tests cover changed behavior — justification:
  - [ ] Tests not applicable — justification:
  - [ ] Docs updated for user-facing behavior changes
  - [x] Docs not applicable — justification: Available languages are dynamically derived from service capability metadata; no documented configuration interface was added or changed.

  ## Documentation Writer Review

  - [ ] Documentation writer reviewed the completed changes
  - Result: `docs-not-applicable`
  - Evidence: No documentation files were changed. The fix corrects dynamically generated language availability and startup validation.

  ## Verification

  - [x] Applicable lint, test, and build checks passed
  - [ ] Documentation validation passed for changed documentation
  - [x] No secrets, API keys, or credentials are committed

  Validation performed:

  - Full Python test suite: 242 passed, plus 8 subtests
  - Session-language tests: 8 passed
  - Service-catalog tests: 15 passed, plus 2 subtests
  - Multilingual pipeline tests: 9 passed
  - Arabic regression probe confirmed `ar-AR` is removed for Nemotron 3 Nano
  - Arabic bypass probe confirmed unsupported sessions are rejected at pipeline startup
  - `ruff check .`
  - `ruff format --check .`
  - `npm run lint`
  - `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Voice catalog results now reflect the selected pipeline and language model.
  - Multilingual sessions now account for language compatibility across speech recognition, text-to-speech, and language models.
  - Added supported-language metadata for multilingual language model options.
  - Unsupported session languages are identified before startup, while compatible regional locales remain supported.

- **Bug Fixes**
  - Preserved existing behavior for custom language models without declared language capabilities.

- **Tests**
  - Added coverage for language filtering, validation, locale handling, and catalog metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->