### PR TITLE
fix(subagents): harden runtime response guardrails

### DIFF
--- a/docker/docker-compose.nemotron3-omni.yaml
+++ b/docker/docker-compose.nemotron3-omni.yaml
@@ -36,7 +36,7 @@ services:
           --max-model-len 32768 \
           --port 8002 \
           --trust-remote-code \
-          --gpu-memory-utilization 0.3 \
+          --gpu-memory-utilization 0.5 \
           --limit-mm-per-prompt '{"video": 999, "image": 999, "audio": 999}' \
           --media-io-kwargs '{"video": {"fps": 2,  "num_frames": 256}}' \
           --video-pruning-rate 0.5 \

--- a/src/examples/omni_assistant_subagents/prompts.yaml
+++ b/src/examples/omni_assistant_subagents/prompts.yaml
@@ -127,18 +127,19 @@ agent_prompts:
         {"observation": "<one short sentence>", "focus": "<short visible focus from the conversation, or empty>", "visual_control": {"intent": "none|greet|stop|continue|down", "confidence": 0.0, "reason": "<short>"}}
         observation: in natural, professional language, say what the person is DOING and name the KIND of item they hold up or show (a phone, a screen, a document, an object). {{webcam_appearance_rule}} {{webcam_text_too_small_rule}} Interpret cues as behavior ('speaking', 'thinking', 'smiling'), never raw anatomy ('mouth open'); keep hand gestures OUT of the observation. {{webcam_no_change_rule}}
         focus: when recent conversation steers attention to a visible subject, name that subject in a few words; otherwise "".
-        visual_control.intent: set it only for a clear, deliberate hand gesture, else 'none'. Judge the HANDS, not the face (a smile never changes the gesture):
+        visual_control.intent: score ONLY a clear, deliberate hand gesture occurring in the final roughly 1.5 seconds of the video. Earlier frames are historical context and MUST NOT produce an intent, even if they contain an unmistakable gesture. The gesture must still be visible or actively finishing in the newest frames; otherwise return 'none'. Judge the HANDS, not the face (a smile never changes the gesture):
         - greet: ONLY a hand that CLEARLY and REPEATEDLY moves side to side across the video (an unmistakable wave). A hand that is merely raised, reaching toward the camera or webcam, adjusting the device, scratching, resting, gesturing while talking, or holding something is NOT a wave — use 'none'.
         - stop: a raised open palm held STILL and steady toward the camera.
-        - continue: a thumbs-UP (thumb points up).
-        - down: a thumbs-DOWN (thumb points down).
+        - continue: a deliberate thumbs-UP (thumb points up) directed at the camera. A thumb visible while gripping, holding, or manipulating an object is NOT thumbs-up.
+        - down: a deliberate thumbs-DOWN (thumb points down) directed at the camera. A thumb visible while gripping, holding, or manipulating an object is NOT thumbs-down.
         Wave vs stop is a TEMPORAL judgement from the video's motion: a wave is a hand that repeatedly CHANGES position side to side across the video; a steady raised palm that does not move is 'stop', otherwise 'none'. Never call a still or singly-raised hand 'greet'. For thumbs, thumb up is 'continue' and thumb down is 'down' — never swap those.
         Default to 'none'. Only score a gesture when it is deliberate and directed at the camera. Set confidence 0.0-1.0 and be conservative: use 0.85+ only when the gesture is unmistakable; if there is ANY doubt, use intent 'none'. Keep reason to a few words.
     gesture_prompt:
       description: "Webcam per-frame user prompt requesting the strict-JSON gesture object."
       content: >-
-        Now — from this short video: what is the person doing and what changed, and are they making a clear hand
-        gesture toward the camera? Reply with the strict JSON object only.
+        Now — use the older part of this short video only as background, report the person's current state from its
+        newest frames, and score a hand gesture only if it occurs in the final roughly 1.5 seconds. Reply with the
+        strict JSON object only.
 
   TransportAgent:
     proactive_greet:

--- a/src/examples/omni_assistant_subagents/subagents/speaker/agent.py
+++ b/src/examples/omni_assistant_subagents/subagents/speaker/agent.py
@@ -185,6 +185,8 @@ class SubagentsSpeakerOmniService(NvidiaOmniLLMService):
         action_text = ""
         raw_content = ""
         spoken_text = ""
+        response_buffer = ""
+        stream_released = False
         transcript_emitted = False
         spoke = False
         gated = False
@@ -206,13 +208,29 @@ class SubagentsSpeakerOmniService(NvidiaOmniLLMService):
             if not action_field.done:
                 action_text += action_field.feed(content)
 
-            spoken = response_field.feed(content)
-            if spoken and not gated and not spoke:
+            response_delta = response_field.feed(content)
+            if response_delta and not gated and not spoke:
                 gated = normalize_turn_action(action_text) not in TURN_ACTIONS
                 if gated:
                     logger.info("Speaker Omni withheld streamed text: turn ownership was not declared first")
             if gated:
                 spoken = ""
+            elif stream_released:
+                spoken = response_delta
+            else:
+                response_buffer += response_delta
+                spoken = ""
+                if response_buffer and response_field.done:
+                    filler = self._repeat.bridge_filler(response_buffer)
+                    if filler is not None:
+                        logger.info(
+                            f"Speaker Omni suppressed a streamed verbatim repeat; bridging with filler={filler!r}"
+                        )
+                    spoken = filler or response_buffer
+                    stream_released = True
+                elif response_buffer and not self._repeat.could_be_repeat_prefix(response_buffer):
+                    spoken = response_buffer
+                    stream_released = True
             spoke = spoke or bool(spoken)
             spoken_text += spoken
             delta.content = spoken or None

--- a/src/examples/omni_assistant_subagents/subagents/speaker/repeat_guard.py
+++ b/src/examples/omni_assistant_subagents/subagents/speaker/repeat_guard.py
@@ -63,6 +63,13 @@ class RepeatGuard:
         self._filler_index += 1
         return self.filler
 
+    def could_be_repeat_prefix(self, text: str) -> bool:
+        """Whether an incomplete streamed reply could still become an exact recent repeat."""
+        normalized = normalize_text(text)
+        if not normalized:
+            return bool(self._recent)
+        return any(recent.startswith(normalized) for recent in self._recent)
+
     def note_spoken(self, text: str) -> None:
         """Record a reply that already streamed to TTS.
 

--- a/src/examples/omni_assistant_subagents/subagents/transport/proactive_gesture_controller.py
+++ b/src/examples/omni_assistant_subagents/subagents/transport/proactive_gesture_controller.py
@@ -40,8 +40,12 @@ from examples.omni_assistant_subagents.subagents.gestures import (
 _GESTURE_CONFIDENCE = {
     GESTURE_GREET: 0.85,
     GESTURE_STOP: 0.75,
-    GESTURE_CONTINUE: 0.7,
-    GESTURE_DOWN: 0.7,
+    GESTURE_CONTINUE: 0.9,
+    GESTURE_DOWN: 0.9,
+}
+_GESTURE_CONFIRMATIONS = {
+    GESTURE_CONTINUE: 2,
+    GESTURE_DOWN: 2,
 }
 _COOLDOWN_SECONDS = 5.0
 _RESUME_WINDOW_SECONDS = 30.0
@@ -80,6 +84,8 @@ class ProactiveGestureController:
         self._cooldown_secs = _COOLDOWN_SECONDS
         self._resume_window_secs = _RESUME_WINDOW_SECONDS
         self._last_intent = GESTURE_NONE
+        self._candidate_intent = GESTURE_NONE
+        self._candidate_count = 0
         self._last_action_at = float("-inf")
         self._last_interrupted_at = float("-inf")
 
@@ -91,6 +97,8 @@ class ProactiveGestureController:
 
         if intent == GESTURE_NONE:
             self._last_intent = GESTURE_NONE
+            self._candidate_intent = GESTURE_NONE
+            self._candidate_count = 0
             return
         if intent == self._last_intent:
             return
@@ -99,7 +107,21 @@ class ProactiveGestureController:
             logger.debug(f"Gesture {intent!r} ignored: within cooldown")
             return
         if confidence < self._confidence[intent]:
+            self._candidate_intent = GESTURE_NONE
+            self._candidate_count = 0
             logger.debug(f"Gesture {intent!r} ignored: confidence {confidence:.2f} below threshold")
+            return
+        if intent == self._candidate_intent:
+            self._candidate_count += 1
+        else:
+            self._candidate_intent = intent
+            self._candidate_count = 1
+        confirmations = _GESTURE_CONFIRMATIONS.get(intent, 1)
+        if self._candidate_count < confirmations:
+            logger.debug(
+                f"Gesture {intent!r} awaiting confirmation "
+                f"({self._candidate_count}/{confirmations}, confidence={confidence:.2f})"
+            )
             return
 
         acted = False
@@ -114,6 +136,8 @@ class ProactiveGestureController:
 
         if acted:
             self._last_intent = intent
+        self._candidate_intent = GESTURE_NONE
+        self._candidate_count = 0
 
     async def _on_greet(self, control: dict[str, Any], frame: dict[str, Any], now: float) -> bool:
         """Greet back — but only when idle, never over the user's or our own turn.

--- a/src/examples/omni_assistant_subagents/subagents/webcam/agent.py
+++ b/src/examples/omni_assistant_subagents/subagents/webcam/agent.py
@@ -70,12 +70,16 @@ def _steering_preamble(conversation: str) -> str:
             f"RECENT CONVERSATION (context only; the person cannot be heard in this silent video):\n{conversation}\n"
         )
     parts.append(
-        "Lead with what the person is actively holding, showing, or doing right now, and describe ALL the items "
-        "they are presenting or interacting with, not just one. When the conversation above is about something "
-        "visible, emphasize that; otherwise simply prioritize their current activity. Report ONLY what is genuinely "
-        "visible in this video: never state a detail the conversation implies but the video does not actually show, "
-        "and if a relevant detail is not visually clear, say so rather than guessing. Still obey the output format, "
-        "the rule against reading fine printed text, and the gesture rules below exactly.\n"
+        "TEMPORAL PRIORITY: this video is ordered oldest to newest. Treat its earlier portion only as background "
+        "for understanding how the scene reached its current state. The final roughly 1.5 seconds are the source of "
+        "truth for what is happening NOW. Lead with what the person is actively holding, showing, or doing in those "
+        "newest frames, and describe ALL items they are currently presenting or interacting with, not stale items that "
+        "disappeared earlier. Mention an earlier event only when it is necessary to explain the current action. "
+        "When the conversation above is about something visible, emphasize that; otherwise simply prioritize their "
+        "current activity. Report ONLY what is genuinely visible in this video: never state a detail the conversation "
+        "implies but the video does not actually show, and if a relevant detail is not visually clear, say so rather "
+        "than guessing. Still obey the output format, the rule against reading fine printed text, and the gesture "
+        "rules below exactly.\n"
     )
     return "".join(parts)
 

--- a/tests/unit/test_proactive_gesture_controller.py
+++ b/tests/unit/test_proactive_gesture_controller.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# ruff: noqa: D100, D101, D102
+
+import unittest
+from unittest.mock import AsyncMock
+
+from examples.omni_assistant_subagents.subagents.transport.proactive_gesture_controller import (
+    ProactiveGestureController,
+)
+
+
+def _controller(resume_or_compliment: AsyncMock) -> ProactiveGestureController:
+    return ProactiveGestureController(
+        queue_frame=AsyncMock(),
+        greet=AsyncMock(),
+        barge_in=AsyncMock(),
+        resume_or_compliment=resume_or_compliment,
+        acknowledge_feedback=AsyncMock(),
+        is_assistant_speaking=lambda: False,
+        is_user_speaking=lambda: False,
+    )
+
+
+class GestureConfirmationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_single_thumbs_up_does_not_trigger(self) -> None:
+        callback = AsyncMock()
+        controller = _controller(callback)
+
+        await controller.handle({"intent": "continue", "confidence": 0.99}, frame={})
+
+        callback.assert_not_awaited()
+
+    async def test_two_consecutive_thumbs_up_detections_trigger_once(self) -> None:
+        callback = AsyncMock()
+        controller = _controller(callback)
+
+        await controller.handle({"intent": "continue", "confidence": 0.99}, frame={})
+        await controller.handle({"intent": "continue", "confidence": 0.99}, frame={})
+        await controller.handle({"intent": "continue", "confidence": 0.99}, frame={})
+
+        callback.assert_awaited_once_with(False)
+
+    async def test_none_resets_thumbs_up_confirmation(self) -> None:
+        callback = AsyncMock()
+        controller = _controller(callback)
+
+        await controller.handle({"intent": "continue", "confidence": 0.99}, frame={})
+        await controller.handle({"intent": "none", "confidence": 0.0}, frame={})
+        await controller.handle({"intent": "continue", "confidence": 0.99}, frame={})
+
+        callback.assert_not_awaited()
+
+    async def test_low_confidence_thumbs_up_does_not_accumulate(self) -> None:
+        callback = AsyncMock()
+        controller = _controller(callback)
+
+        await controller.handle({"intent": "continue", "confidence": 0.85}, frame={})
+        await controller.handle({"intent": "continue", "confidence": 0.85}, frame={})
+
+        callback.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_speaker_action_contract.py
+++ b/tests/unit/test_speaker_action_contract.py
@@ -296,6 +296,26 @@ class EnvelopeStreamingTests(unittest.IsolatedAsyncioTestCase):
         # Already streamed, so the parsed envelope must not repeat it.
         self.assertEqual(self.spoken, [])
 
+    async def test_streamed_repeat_is_replaced_before_reaching_tts(self) -> None:
+        service = self._service()
+        envelope = {
+            "transcript": "White",
+            "turn_action": "respond",
+            "response": "Could you confirm what color the comb is?",
+            "selected_input_source": "none",
+            "media_analysis_action": "none",
+            "media_analysis_prompt": "",
+            "highres_query": "",
+        }
+
+        first = await self._drain(service, envelope)
+        repeated = await self._drain(service, envelope)
+
+        self.assertEqual(first, envelope["response"])
+        self.assertIn(repeated, BRIDGE_FILLERS)
+        self.assertNotIn(envelope["response"], repeated)
+        service._thinking_handler.assert_awaited_once_with("White", "high", "repetition")
+
     async def test_invalid_action_withholds_streamed_text(self) -> None:
         service = self._service()
         visible = await self._drain(

--- a/tests/unit/test_webcam_steering.py
+++ b/tests/unit/test_webcam_steering.py
@@ -72,8 +72,10 @@ class SteeringPreambleTests(unittest.TestCase):
         block = _steering_preamble("")
         self.assertNotIn("RECENT CONVERSATION", block)
         self.assertIn("actively holding, showing, or doing", block)
-        self.assertIn("describe ALL the items", block)
+        self.assertIn("describe ALL items", block)
         self.assertIn("ONLY what is genuinely visible", block)
+        self.assertIn("final roughly 1.5 seconds", block)
+        self.assertIn("earlier portion only as background", block)
 
     def test_conversation_is_included_and_grounded(self) -> None:
         block = _steering_preamble("User: what am I holding?\nAssistant: a camera")


### PR DESCRIPTION
Prevent false gesture actions and repeated speech while improving webcam recency and Nemotron startup reliability.

BUG 6574403

## Summary

Bug fix for BUG 6574403

## Related Issue

BUG 6574403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved webcam understanding by prioritizing the most recent video activity and avoiding stale or uncertain interpretations.
  - Gesture actions now require high-confidence detections across consecutive frames, reducing accidental triggers.
  - Gesture scoring better distinguishes deliberate camera-facing thumbs-up and thumbs-down gestures.
  - Increased available GPU memory utilization for the Nemotron service.

- **Bug Fixes**
  - Reduced repeated spoken responses by detecting duplicate streamed replies and substituting a brief transition message before retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->