### PR TITLE
fix: start proactive checks on client ready

### DIFF
--- a/examples_registry.yaml
+++ b/examples_registry.yaml
@@ -25,7 +25,7 @@ examples:
     label: Generic Assistant
     slots: [llm, asr, tts]
     activity_check:
-      first_warning_s: 600
+      first_warning_s: 480
       second_warning_s: 30
       warning_completion_timeout_s: 45
     defaults:

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -312,6 +312,8 @@ async def bot(runner_args: RunnerArguments) -> None:
         logger.info("Client connected")
         if audio_recorder:
             await audio_recorder.start_recording()
+        if activity_check:
+            activity_check.start()
         if not welcome_enabled:
             logger.info("Welcome message disabled; waiting for the user to speak first")
             return

--- a/src/examples/shared/activity_check.py
+++ b/src/examples/shared/activity_check.py
@@ -111,11 +111,11 @@ def activity_check_instruction(stage: int) -> str:
 class ActivityCheckProcessor(FrameProcessor):
     """Replace a silent hard timeout with two LLM/TTS activity checks.
 
-    Timers begin when the bot finishes speaking. A VAD ``UserStartedSpeakingFrame``
+    Timers begin when the client is ready. A VAD ``UserStartedSpeakingFrame``
     cancels the current countdown and returns the processor to normal operation.
     The callback is responsible for queueing an LLM run; the next timer is armed
-    only after the resulting TTS audio has finished. The second activity check
-    is the closing statement; the session disconnects when it finishes playing.
+    after the resulting TTS audio has finished. The second activity check is the
+    closing statement; the session disconnects when it finishes playing.
     """
 
     def __init__(
@@ -183,6 +183,15 @@ class ActivityCheckProcessor(FrameProcessor):
         self._retired_warning_stage = None
         self._pending_warning_response_stages.clear()
         self._warning_audio_started_stages.clear()
+
+    def start(self) -> None:
+        """Begin inactivity tracking when the client session becomes ready.
+
+        This is intentionally independent of bot speech so activity checks also
+        work for sessions configured without an initial welcome message.
+        """
+        if self._timer is None:
+            self._arm_timer()
 
     def _handle_tts_started(self) -> None:
         if not self._pending_warning_response_stages:

--- a/tests/unit/test_activity_check.py
+++ b/tests/unit/test_activity_check.py
@@ -39,6 +39,22 @@ class _TestActivityCheckProcessor(ActivityCheckProcessor):
 
 
 class ActivityCheckProcessorTests(unittest.IsolatedAsyncioTestCase):
+    async def test_start_arms_inactivity_timer_without_bot_speech(self) -> None:
+        async def on_warning(stage: int) -> None:
+            pass
+
+        processor = _TestActivityCheckProcessor(
+            activity_check_interval_s=60.0,
+            second_warning_s=30.0,
+            warning_completion_timeout_s=45.0,
+            on_warning=on_warning,
+        )
+
+        processor.start()
+
+        self.assertIsNotNone(processor._timer)
+        processor.reset()
+
     async def test_warning_watchdog_advances_then_requests_graceful_stop(self) -> None:
         warnings: list[int] = []
 
@@ -174,7 +190,7 @@ class ActivityCheckProcessorTests(unittest.IsolatedAsyncioTestCase):
     def test_generic_example_enables_activity_check_in_registry(self) -> None:
         config = examples_registry.activity_check_config("generic-assistant")
 
-        self.assertEqual(config["first_warning_s"], 600.0)
+        self.assertEqual(config["first_warning_s"], 480.0)
         self.assertEqual(config["second_warning_s"], 30.0)
         self.assertIsNone(examples_registry.activity_check_config("multilingual-assistant"))
 


### PR DESCRIPTION
## Summary

  Fix Generic Assistant proactive inactivity checks for sessions without a welcome message.

  The activity timer previously started only after bot speech completed. When welcome messages were disabled, no initial bot speech occurred and proactive checks never started. The first
  warning is now set to 8 minutes so it runs before the existing 10-minute worker idle-timeout fallback.

  ## Changes

  - Start the activity-check timer when the client becomes ready.
  - Preserve existing timer re-arming after bot speech.
  - Reduce the first proactive warning delay from 10 minutes to 8 minutes.
  - Add regression coverage for starting inactivity tracking without bot speech.
  - Update the Generic Assistant activity-check registry test.

  ## Type of Change

  - [x] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates
  - [ ] Doc only (prose changes, no code sample modifications)
  - [ ] Doc only (includes code sample changes)

  ## Quality Gates

  - [x] Tests added or updated for changed behavior
  - [ ] Existing tests cover changed behavior — justification:
  - [ ] Tests not applicable — justification:
  - [ ] Docs updated for user-facing behavior changes
  - [x] Docs not applicable — justification: Internal inactivity-timer behavior; no user documentation changes are needed.

  ## Documentation Writer Review

  - [x] Documentation writer reviewed the completed changes
  - Result: `no-docs-needed`
  - Evidence: No documentation paths changed; the behavior is internal session lifecycle handling.
  - Agent: Codex CLI
  <!-- docs-review-head-sha: ce122d3 -->
  <!-- docs-review-agents-blob-sha: not-applicable -->

  ## Verification

  - [x] Applicable lint, test, and build checks passed
  - [ ] Documentation validation passed for changed documentation
  - [x] No secrets, API keys, or credentials are committed

  Validation performed:
  - `.venv/bin/ruff format --check src/examples/generic/pipeline.py src/examples/shared/activity_check.py tests/unit/test_activity_check.py`
  - `.venv/bin/ruff check src/examples/generic/pipeline.py src/examples/shared/activity_check.py tests/unit/test_activity_check.py`
  - `.venv/bin/python -m pytest tests/unit/test_activity_check.py` — 8 passed
  - Manual cloud-endpoint E2E verification: proactive check fired successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inactivity monitoring now starts when a session is ready, including sessions without an initial welcome message.
  * Audio recording begins before optional activity monitoring.

* **Bug Fixes**
  * Improved inactivity warnings for sessions where the assistant does not speak first.
  * The first generic assistant inactivity warning now appears after 8 minutes instead of 10 minutes.

* **Tests**
  * Added coverage for starting inactivity monitoring without assistant speech.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->