### PR TITLE
fix(client): restore audio after reconnect

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024–2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { useCallback, useMemo, useState, type ComponentProps } from "react";
+import { useCallback, useState, type ComponentProps } from "react";
 import { PipecatClient } from "@pipecat-ai/client-js";
 import { PipecatClientProvider, PipecatClientAudio } from "@pipecat-ai/client-react";
 import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
@@ -36,7 +36,7 @@ function ClientSession({
   selectedTransport,
 }: Readonly<ClientSessionProps>) {
   const { currentSessionId } = useApp();
-  const client = useMemo(() => {
+  const [client] = useState(() => {
     if (selectedTransport === "websocket") {
       return new PipecatClient({
         transport: new WebSocketTransport({
@@ -53,7 +53,7 @@ function ClientSession({
       transport: new SmallWebRTCTransport({ iceServers }),
       enableMic: true,
     });
-  }, [iceServers, playerSampleRate, recorderSampleRate, selectedTransport]);
+  });
 
   return (
     <PipecatClientProvider client={client as unknown as ProviderClient}>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024–2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { useMemo, type ComponentProps } from "react";
+import { useCallback, useMemo, useState, type ComponentProps } from "react";
 import { PipecatClient } from "@pipecat-ai/client-js";
 import { PipecatClientProvider, PipecatClientAudio } from "@pipecat-ai/client-react";
 import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
 import { WebSocketTransport, ProtobufFrameSerializer } from "@pipecat-ai/websocket-transport";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { queryClient, useDeployment, useIceServers } from "./api";
+import { queryClient, useDeployment, useIceServers, type TransportType } from "./api";
 import { AppProvider } from "./context/AppContext";
 import { useApp } from "./context/useApp";
 import { Header } from "./components/Header";
@@ -20,17 +20,24 @@ const DEFAULT_AUDIO_INPUT_SAMPLE_RATE = 16000;
 const DEFAULT_AUDIO_OUTPUT_SAMPLE_RATE = 22050;
 type ProviderClient = ComponentProps<typeof PipecatClientProvider>["client"];
 
-function AppInner() {
-  const { selectedTransport } = useApp();
-  const { data: deployment, isFetched: deploymentLoaded } = useDeployment();
-  const { data: iceConfig, isFetched: iceServersLoaded } = useIceServers();
-  const iceServers = iceConfig?.iceServers ?? EMPTY_ICE_SERVERS;
-  const recorderSampleRate = deployment?.audio?.input_sample_rate ?? DEFAULT_AUDIO_INPUT_SAMPLE_RATE;
-  const playerSampleRate = deployment?.audio?.output_sample_rate ?? DEFAULT_AUDIO_OUTPUT_SAMPLE_RATE;
+type ClientSessionProps = {
+  iceServers: RTCIceServer[];
+  onClientReset: () => void;
+  playerSampleRate: number;
+  recorderSampleRate: number;
+  selectedTransport: TransportType;
+};
 
+function ClientSession({
+  iceServers,
+  onClientReset,
+  playerSampleRate,
+  recorderSampleRate,
+  selectedTransport,
+}: Readonly<ClientSessionProps>) {
+  const { currentSessionId } = useApp();
   const client = useMemo(() => {
     if (selectedTransport === "websocket") {
-      if (!deploymentLoaded) return null;
       return new PipecatClient({
         transport: new WebSocketTransport({
           serializer: new ProtobufFrameSerializer(),
@@ -42,36 +49,55 @@ function AppInner() {
         enableScreenShare: false,
       });
     }
-    if (!iceServersLoaded) return null;
     return new PipecatClient({
       transport: new SmallWebRTCTransport({ iceServers }),
       enableMic: true,
     });
-  }, [
-    deploymentLoaded,
-    iceServers,
-    iceServersLoaded,
-    playerSampleRate,
-    recorderSampleRate,
-    selectedTransport,
-  ]);
-
-  if (!client) {
-    return <div className="h-screen d-flex items-center justify-center">Loading connection...</div>;
-  }
+  }, [iceServers, playerSampleRate, recorderSampleRate, selectedTransport]);
 
   return (
     <PipecatClientProvider client={client as unknown as ProviderClient}>
       <div className="h-screen d-flex flex-col overflow-hidden">
-        <Header />
+        <Header onClientReset={onClientReset} />
         <div className="flex-1 d-flex overflow-hidden">
           <StatusPanel />
           <CenterPanel />
           <Sidebar />
         </div>
-        <PipecatClientAudio />
+        <PipecatClientAudio key={currentSessionId || "idle"} />
       </div>
     </PipecatClientProvider>
+  );
+}
+
+function AppInner() {
+  const { selectedTransport } = useApp();
+  const { data: deployment, isFetched: deploymentLoaded } = useDeployment();
+  const { data: iceConfig, isFetched: iceServersLoaded } = useIceServers();
+  const iceServers = iceConfig?.iceServers ?? EMPTY_ICE_SERVERS;
+  const recorderSampleRate = deployment?.audio?.input_sample_rate ?? DEFAULT_AUDIO_INPUT_SAMPLE_RATE;
+  const playerSampleRate = deployment?.audio?.output_sample_rate ?? DEFAULT_AUDIO_OUTPUT_SAMPLE_RATE;
+  const [clientGeneration, setClientGeneration] = useState(0);
+  const resetClient = useCallback(() => {
+    setClientGeneration((generation) => generation + 1);
+  }, []);
+
+  if (
+    (selectedTransport === "websocket" && !deploymentLoaded) ||
+    (selectedTransport !== "websocket" && !iceServersLoaded)
+  ) {
+    return <div className="h-screen d-flex items-center justify-center">Loading connection...</div>;
+  }
+
+  return (
+    <ClientSession
+      key={`${selectedTransport}-${clientGeneration}`}
+      iceServers={iceServers}
+      onClientReset={resetClient}
+      playerSampleRate={playerSampleRate}
+      recorderSampleRate={recorderSampleRate}
+      selectedTransport={selectedTransport}
+    />
   );
 }
 

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024–2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { usePipecatClient } from "@pipecat-ai/client-react";
 import { useConnectionState } from "../hooks/useConnectionState";
 import { useApp } from "../context/useApp";
@@ -33,6 +33,10 @@ type SessionConfigOptions = {
   selectedPrompt?: Prompt;
   selectedPromptKey: string;
   selectedSessionLanguage?: string;
+};
+
+type HeaderProps = {
+  onClientReset: () => void;
 };
 
 function getConnectionErrorMessage(err: unknown): string {
@@ -156,9 +160,10 @@ function sessionIdFromWebRTCUrl(url: string): string {
   return new URLSearchParams(query).get("session_id") ?? "";
 }
 
-export function Header() {
+export function Header({ onClientReset }: Readonly<HeaderProps>) {
   const client = usePipecatClient() as StartBotClient | undefined;
   const { isConnected, isConnecting } = useConnectionState();
+  const mountedRef = useRef(true);
   const {
     selectedExample,
     selectedTransport,
@@ -173,6 +178,13 @@ export function Header() {
   } = useApp();
   const [connectionError, setConnectionError] = useState("");
 
+  useLayoutEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const handleClick = async () => {
     setConnectionError("");
 
@@ -185,8 +197,12 @@ export function Header() {
       }
 
       if (isConnected) {
-        await client.disconnect();
-        setCurrentSessionId("");
+        try {
+          await client.disconnect();
+        } finally {
+          setCurrentSessionId("");
+          onClientReset();
+        }
       } else {
         const config = buildSessionConfig({
           selectedExample,
@@ -201,13 +217,16 @@ export function Header() {
 
         if (selectedTransport === "websocket") {
           const sessionId = await createSessionConfig(config);
+          if (!mountedRef.current) return;
           const qs = `session_id=${sessionId}`;
           const wsProto = globalThis.location.protocol === "https:" ? "wss:" : "ws:";
           setCurrentSessionId(sessionId);
           await client.connect({ wsUrl: `${wsProto}//${globalThis.location.host}/api/ws?${qs}` });
         } else {
           await client.initDevices();
+          if (!mountedRef.current) return;
           const webrtcUrl = await createWebRTCSession(config);
+          if (!mountedRef.current) return;
           const sessionId = sessionIdFromWebRTCUrl(webrtcUrl);
           if (!sessionId) {
             throw new Error("WebRTC session URL did not include session_id.");
@@ -217,9 +236,11 @@ export function Header() {
         }
       }
     } catch (err) {
+      if (!mountedRef.current) return;
       setCurrentSessionId("");
       if (isWebRTCTimeoutError(err)) {
         await client?.disconnect().catch(() => undefined);
+        onClientReset();
         setConnectionError(getWebRTCTimeoutMessage());
       } else {
         setConnectionError(getConnectionErrorMessage(err));


### PR DESCRIPTION
## Summary
- recreate the Pipecat client and transport after disconnect so WebSocket and WebRTC sessions receive a fresh audio player
- remount the audio sink per session and prevent detached clients from completing asynchronous connection setup

Stacked on PR #67.

## Test plan
- [x] Client ESLint (`--max-warnings=0`)
- [x] TypeScript and Vite production build
- [x] Manually switch cloud Chatterbox to Magpie across disconnect/reconnect without refreshing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for switching between WebSocket and WebRTC connections.
  - Added a loading state while WebRTC connection settings are retrieved.
  - Audio sessions now refresh correctly when the connection changes.

- **Bug Fixes**
  - Improved cleanup when disconnecting or when WebRTC connection attempts time out.
  - Prevented stale connection updates after the interface is closed.
  - Automatically resets the client after connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->