### PR TITLE
chore(tts): update Chatterbox NIM to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Nemotron ASR Streaming NIM to version 1.3.1.
 - Updated Parakeet CTC 1.1B ASR NIM to version 1.5.3.
 - Updated Magpie TTS Multilingual NIM to version 1.10.0 and `nvidia-riva-client` to version 2.27.0.
+- Updated Chatterbox TTS Multilingual NIM to version 1.1.0 and documented its available model profiles.
 - Standardized the self-hosted Nemotron 3.5 Lightning served model ID with NVIDIA Cloud across NIM and single-GPU vLLM deployments.
 - Consolidated on-prem deployment recipes under `<example>/server` for scaling-oriented stacks and universal `<example>/single-gpu` for supported one-GPU deployments on workstations, DGX Spark, and Jetson Thor. Renamed `generic-assistant/workstation-perf` to `generic-assistant/server-perf`.
 - Replaced `PLATFORM`-based local service selection with endpoint reachability.

--- a/docker/docker-compose.chatterbox-tts.yaml
+++ b/docker/docker-compose.chatterbox-tts.yaml
@@ -11,7 +11,7 @@
 
 services:
   chatterbox-tts-service:
-    image: nvcr.io/nim/nvidia/chatterbox-tts-multilingual:1.0.0
+    image: nvcr.io/nim/nvidia/chatterbox-tts-multilingual:1.1.0
     user: "0:0"
     profiles:
       - chatterbox-tts
@@ -19,8 +19,8 @@ services:
       NGC_API_KEY: ${NVIDIA_API_KEY:-not-needed}
       NIM_HTTP_API_PORT: "9000"
       NIM_GRPC_API_PORT: "50051"
-      # Single profile (~52.5 GB GPU / ~6.4 GB CPU). No batch_size selector.
-      NIM_TAGS_SELECTOR: name=chatterbox-tts-multilingual
+      # Default 1.1.0 profile (~44.61 GiB GPU / ~4.86 GiB host memory).
+      NIM_TAGS_SELECTOR: name=chatterbox-tts-multilingual,batch_size=8
     ports:
       - "50151:50051"
       - "9000:9000"
@@ -39,7 +39,7 @@ services:
       resources:
         reservations:
           devices:
-            # ~52.5 GB VRAM. Edit device_ids if you want a second workstation GPU.
+            # Requires A100, H100, L40S, or DGX Spark. Edit device_ids to select the target GPU.
             - driver: nvidia
               device_ids: ['0']
               capabilities: [gpu]

--- a/docker/docker-compose.chatterbox-tts.yaml
+++ b/docker/docker-compose.chatterbox-tts.yaml
@@ -39,7 +39,7 @@ services:
       resources:
         reservations:
           devices:
-            # Requires A100, H100, L40S, or DGX Spark. Edit device_ids to select the target GPU.
+            # Requires A100 80 GB, H100, L40S, or DGX Spark. Edit device_ids to select the target GPU.
             - driver: nvidia
               device_ids: ['0']
               capabilities: [gpu]

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -64,15 +64,24 @@ TTS runs one of these ways, and the repo wires the right one per profile:
 |-------|--------------|-------|
 | Magpie TTS Multilingual | **~14 GB** | Can share a single ~80 GB GPU with ASR (~15 GB) and the LLM (~30 GB FP8). Split across GPUs with `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support). |
 | Magpie TTS Zeroshot | **~13.06 GB** GPU / ~4.00 GB CPU at `batch_size=8` | Default `NIM_TAGS_SELECTOR=name=magpie-tts-zeroshot,batch_size=8` ([Speech NIM support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#magpie-tts-zeroshot)). Fits the shared H100 layout when Magpie Multilingual is scaled off. `batch_size=32` needs **~41.30 GB** GPU / ~7.08 GB CPU and should not share a single 80 GB GPU with ASR + LLM. |
-| Chatterbox TTS | **~52.5 GB** GPU / ~6.4 GB CPU | `NIM_TAGS_SELECTOR=name=chatterbox-tts-multilingual` (GPU `0` by default). Does **not** fit the Magpie single-80-GB shared layout with LLM + ASR on a typical workstation GPU. |
+| Chatterbox TTS | **44.61 GiB** GPU / 4.86 GiB host memory at `batch_size=8` | The default Compose selector is `name=chatterbox-tts-multilingual,batch_size=8` on GPU `0`. This profile supports A100, H100, L40S, and DGX Spark. It does **not** fit the Magpie single-80-GB shared layout with LLM + ASR. |
 
 ### Performance & scaling
 
-`batch_size` is the main Magpie throughput knob (`NIM_TAGS_SELECTOR`):
+`batch_size` is the main TTS throughput knob (`NIM_TAGS_SELECTOR`):
 
 - Magpie Multilingual: `name=magpie-tts-multilingual,batch_size=8`
 - Magpie Zeroshot: `batch_size=8` (default) or `batch_size=32` — keep `8` on shared single-GPU recipes
-- Chatterbox: single profile `name=chatterbox-tts-multilingual` (no `batch_size` selector)
+
+Chatterbox TTS Multilingual 1.1.0 provides these model profiles:
+
+| `batch_size` | GPU memory | Host memory | Supported hardware |
+| --- | --- | --- | --- |
+| `8` (default) | 44.61 GiB | 4.86 GiB | A100, H100, L40S, and DGX Spark |
+| `32` | 46.84 GiB | 5.40 GiB | A100, H100, and L40S |
+| `64` | 49.72 GiB | 5.54 GiB | A100, H100, and L40S |
+
+The Compose service selects `batch_size=8`. DGX Spark supports only this profile.
 
 For first-chunk and inter-chunk latency and throughput (RTFX) across GPUs, refer to the **[TTS performance benchmarks](https://docs.nvidia.com/nim/speech/latest/reference/performances/tts/performance.html)**. For end-to-end pipeline latency (TTS time-to-first-byte) in this blueprint, refer to [Evaluation and Performance](../04-evaluation-and-performance.md).
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -64,7 +64,7 @@ TTS runs one of these ways, and the repo wires the right one per profile:
 |-------|--------------|-------|
 | Magpie TTS Multilingual | **12.58 GiB** GPU / 5.182 GiB host memory at `batch_size=8` | Can share a single ~80 GB GPU with ASR (~15 GB) and the LLM (~30 GB FP8). Split across GPUs with `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support). |
 | Magpie TTS Zeroshot | **13.06 GB** GPU / 4.00 GB CPU memory at `batch_size=8` | The default Compose selector is `name=magpie-tts-zeroshot,batch_size=8`. This profile fits the shared H100 layout when Magpie Multilingual is scaled off. |
-| Chatterbox TTS | **44.61 GiB** GPU / 4.86 GiB host memory at `batch_size=8` | The default Compose selector is `name=chatterbox-tts-multilingual,batch_size=8` on GPU `0`. This profile supports A100, H100, L40S, and DGX Spark. It does **not** fit the Magpie single-80-GB shared layout with LLM + ASR. |
+| Chatterbox TTS | **44.61 GiB** GPU / 4.86 GiB host memory at `batch_size=8` | The default Compose selector is `name=chatterbox-tts-multilingual,batch_size=8` on GPU `0`. This profile supports A100 80 GB, H100, L40S, and DGX Spark. The A100 40 GB variant does not have enough memory. Chatterbox does **not** fit the Magpie single-80-GB shared layout with LLM + ASR. |
 
 ### Performance & scaling
 
@@ -97,7 +97,7 @@ The Compose service selects `batch_size=8`. Use `batch_size=32` only on a dedica
 | `32` | 46.84 GiB | 5.40 GiB |
 | `64` | 49.72 GiB | 5.54 GiB |
 
-The Compose service selects `batch_size=8`. A100, H100, and L40S support all three profiles. DGX Spark supports only `batch_size=8`.
+The Compose service selects `batch_size=8`. A100 80 GB, H100, and L40S support all three profiles. The A100 40 GB variant does not have enough memory for any profile. DGX Spark supports only `batch_size=8`.
 
 For first-chunk and inter-chunk latency and throughput (RTFX) across GPUs, refer to the **[TTS performance benchmarks](https://docs.nvidia.com/nim/speech/latest/reference/performances/tts/performance.html)**. For end-to-end pipeline latency (TTS time-to-first-byte) in this blueprint, refer to [Evaluation and Performance](../04-evaluation-and-performance.md).
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -62,26 +62,42 @@ TTS runs one of these ways, and the repo wires the right one per profile:
 
 | Model | Typical VRAM | Notes |
 |-------|--------------|-------|
-| Magpie TTS Multilingual | **~14 GB** | Can share a single ~80 GB GPU with ASR (~15 GB) and the LLM (~30 GB FP8). Split across GPUs with `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support). |
-| Magpie TTS Zeroshot | **~13.06 GB** GPU / ~4.00 GB CPU at `batch_size=8` | Default `NIM_TAGS_SELECTOR=name=magpie-tts-zeroshot,batch_size=8` ([Speech NIM support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#magpie-tts-zeroshot)). Fits the shared H100 layout when Magpie Multilingual is scaled off. `batch_size=32` needs **~41.30 GB** GPU / ~7.08 GB CPU and should not share a single 80 GB GPU with ASR + LLM. |
+| Magpie TTS Multilingual | **12.58 GiB** GPU / 5.182 GiB host memory at `batch_size=8` | Can share a single ~80 GB GPU with ASR (~15 GB) and the LLM (~30 GB FP8). Split across GPUs with `device_ids` in [`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml). See [Configure LLM → VRAM & hardware support](configure-llm.md#vram--hardware-support). |
+| Magpie TTS Zeroshot | **13.06 GB** GPU / 4.00 GB CPU memory at `batch_size=8` | The default Compose selector is `name=magpie-tts-zeroshot,batch_size=8`. This profile fits the shared H100 layout when Magpie Multilingual is scaled off. |
 | Chatterbox TTS | **44.61 GiB** GPU / 4.86 GiB host memory at `batch_size=8` | The default Compose selector is `name=chatterbox-tts-multilingual,batch_size=8` on GPU `0`. This profile supports A100, H100, L40S, and DGX Spark. It does **not** fit the Magpie single-80-GB shared layout with LLM + ASR. |
 
 ### Performance & scaling
 
 `batch_size` is the main TTS throughput knob (`NIM_TAGS_SELECTOR`):
 
-- Magpie Multilingual: `name=magpie-tts-multilingual,batch_size=8`
-- Magpie Zeroshot: `batch_size=8` (default) or `batch_size=32` — keep `8` on shared single-GPU recipes
+#### Magpie TTS Multilingual 1.10.0
 
-Chatterbox TTS Multilingual 1.1.0 provides these model profiles:
+| `batch_size` | GPU memory | Host memory |
+| --- | --- | --- |
+| `8` (default) | 12.58 GiB | 5.182 GiB |
+| `32` | 41.46 GiB | 5.208 GiB |
+| `64` | 74.74 GiB | 5.258 GiB |
 
-| `batch_size` | GPU memory | Host memory | Supported hardware |
-| --- | --- | --- | --- |
-| `8` (default) | 44.61 GiB | 4.86 GiB | A100, H100, L40S, and DGX Spark |
-| `32` | 46.84 GiB | 5.40 GiB | A100, H100, and L40S |
-| `64` | 49.72 GiB | 5.54 GiB | A100, H100, and L40S |
+The standard Compose service selects `batch_size=8`. The `generic-assistant/workstation-perf` profile selects `batch_size=64` on a dedicated GPU.
 
-The Compose service selects `batch_size=8`. DGX Spark supports only this profile.
+#### Magpie TTS Zeroshot 1.2.0
+
+| `batch_size` | GPU memory | CPU memory |
+| --- | --- | --- |
+| `8` (default) | 13.06 GB | 4.00 GB |
+| `32` | 41.30 GB | 7.08 GB |
+
+The Compose service selects `batch_size=8`. Use `batch_size=32` only on a dedicated GPU because it does not fit the shared H100 layout.
+
+#### Chatterbox TTS Multilingual 1.1.0
+
+| `batch_size` | GPU memory | Host memory |
+| --- | --- | --- |
+| `8` (default) | 44.61 GiB | 4.86 GiB |
+| `32` | 46.84 GiB | 5.40 GiB |
+| `64` | 49.72 GiB | 5.54 GiB |
+
+The Compose service selects `batch_size=8`. A100, H100, and L40S support all three profiles. DGX Spark supports only `batch_size=8`.
 
 For first-chunk and inter-chunk latency and throughput (RTFX) across GPUs, refer to the **[TTS performance benchmarks](https://docs.nvidia.com/nim/speech/latest/reference/performances/tts/performance.html)**. For end-to-end pipeline latency (TTS time-to-first-byte) in this blueprint, refer to [Evaluation and Performance](../04-evaluation-and-performance.md).
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -78,7 +78,7 @@ TTS runs one of these ways, and the repo wires the right one per profile:
 | `32` | 41.46 GiB | 5.208 GiB |
 | `64` | 74.74 GiB | 5.258 GiB |
 
-The standard Compose service selects `batch_size=8`. The `generic-assistant/workstation-perf` profile selects `batch_size=64` on a dedicated GPU.
+The standard Compose service selects `batch_size=8`. The `generic-assistant/server-perf` profile selects `batch_size=64` on a dedicated GPU.
 
 #### Magpie TTS Zeroshot 1.2.0
 


### PR DESCRIPTION
## Summary

Upgrade the optional local Chatterbox TTS deployment from NIM 1.0.0 to 1.1.0. Select the new default `batch_size=8` profile explicitly and align the TTS profile documentation with NVIDIA's current support matrix.

## Changes

- Pin `chatterbox-tts-multilingual:1.1.0` in the Compose service.
- Select `name=chatterbox-tts-multilingual,batch_size=8` explicitly.
- Document the Magpie Multilingual, Magpie Zeroshot, and Chatterbox batch profiles consistently, including memory requirements and Compose defaults.
- Record the upgrade in the Unreleased changelog.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: service-catalog tests verify Chatterbox selection and `per_sentence` synthesis behavior; the upgrade does not change client APIs.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:

## Documentation Writer Review

- [x] Documentation writer reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/how-to/configure-tts.md` and `CHANGELOG.md` with consistent TTS profile tables, memory requirements, Compose defaults, and supported hardware.
- Agent: Cursor Agent
<!-- docs-review-head-sha: eb34f5e -->
<!-- docs-review-agents-blob-sha: b73fe32 -->

## Verification

- [x] Applicable lint, test, and build checks passed
- [x] Documentation validation passed for changed documentation
- [x] No secrets, API keys, or credentials are committed

- `uv run pytest tests/unit/test_service_catalog.py -v` — 20 passed, 6 subtests passed.
- `uv run --project . --group dev pre-commit run --files docker/docker-compose.chatterbox-tts.yaml docs/how-to/configure-tts.md CHANGELOG.md` — passed.
- `docker compose --profile chatterbox-tts config --quiet` — passed.
- Chatterbox 1.1.0 startup, health, voice discovery, offline HTTP synthesis, streaming HTTP synthesis, and streaming gRPC synthesis verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Chatterbox TTS Multilingual NIM version 1.1.0.
  * Added documented batch-size profiles, including default, 32, and 64 options.
* **Documentation**
  * Updated hardware, GPU, memory, and scaling guidance.
  * Clarified supported hardware and DGX Spark limitations.
* **Chores**
  * Updated the Chatterbox TTS service to version 1.1.0 with a default batch size of 8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->