### PR TITLE
chore(asr): bump Nemotron ASR NIM to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated Nemotron ASR Streaming NIM to version 1.3.1.
 - Updated Magpie TTS Multilingual NIM to version 1.10.0 and `nvidia-riva-client` to version 2.27.0.
 - Consolidated on-prem deployment recipes under `<example>/server` for scaling-oriented stacks and universal `<example>/single-gpu` for supported one-GPU deployments on workstations, DGX Spark, and Jetson Thor. Renamed `generic-assistant/workstation-perf` to `generic-assistant/server-perf`.
 - Replaced `PLATFORM`-based local service selection with endpoint reachability.

--- a/docker/docker-compose.nemotron-asr.yaml
+++ b/docker/docker-compose.nemotron-asr.yaml
@@ -1,5 +1,5 @@
 x-nemotron-asr: &nemotron-asr
-  image: nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.0
+  image: nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.1
   user: "0:0"
   ports:
     - "50152:50052"

--- a/docs/how-to/configure-services.md
+++ b/docs/how-to/configure-services.md
@@ -33,7 +33,7 @@ To configure a specific local model, check its Docker Compose file under [`docke
 ```yaml
 services:
   nemotron-asr-streaming-english:
-    image: nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.0
+    image: nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.1
     profiles:
       - generic-assistant/server
       - frontend-backend-agent/server


### PR DESCRIPTION
## Summary
- bump the Nemotron ASR Streaming server image from 1.3.0 to 1.3.1
- keep the service configuration documentation aligned with the deployed image
- record the update in the Unreleased changelog

## Test plan
- [x] Validate the `generic-assistant/server` Compose profile
- [x] Confirm the profile resolves `nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.1`
- [x] Verify no stale `nemotron-asr-streaming:1.3.0` references remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Nemotron ASR Streaming service to version 1.3.1.

* **Documentation**
  * Updated configuration guidance to reference the latest Nemotron ASR Streaming version.
  * Added the update to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->