### PR TITLE
fix(omni): order delayed transcripts by turn timestamp

### DIFF
--- a/client/src/components/content/ConversationPanel.tsx
+++ b/client/src/components/content/ConversationPanel.tsx
@@ -377,9 +377,6 @@ export function ConversationPanel() {
 
       if (type !== "user-turn-finalized") return;
       setCurrentUserTurnActive(false);
-      // Omni's transcript arrives after its response begins. Use the turn's
-      // server-side boundary timestamp so the eventual user bubble is ordered
-      // before that response, rather than at the time the transcript arrives.
       const anchorISO = validTimestampOrNow(stringField(message, "timestamp"));
       const anchors = userTurnAnchorsRef.current;
       const target =

--- a/client/src/components/content/ConversationPanel.tsx
+++ b/client/src/components/content/ConversationPanel.tsx
@@ -133,6 +133,9 @@ const findLatestUnanchoredUser = (
 
 const normalizeTranscript = (text?: string | null) => (text ?? "").trim().replace(/\s+/g, " ");
 
+const validTimestampOrNow = (timestamp: string) =>
+  Number.isNaN(Date.parse(timestamp)) ? new Date().toISOString() : timestamp;
+
 const findUserMessageByTranscript = (
   messages: ConversationMessage[],
   transcript: string | null | undefined,
@@ -374,7 +377,10 @@ export function ConversationPanel() {
 
       if (type !== "user-turn-finalized") return;
       setCurrentUserTurnActive(false);
-      const anchorISO = new Date().toISOString();
+      // Omni's transcript arrives after its response begins. Use the turn's
+      // server-side boundary timestamp so the eventual user bubble is ordered
+      // before that response, rather than at the time the transcript arrives.
+      const anchorISO = validTimestampOrNow(stringField(message, "timestamp"));
       const anchors = userTurnAnchorsRef.current;
       const target =
         findUserMessageByTranscript(visibleMessagesRef.current, stringField(message, "transcript"), anchors) ??


### PR DESCRIPTION
## Summary

  Fixes Omni Assistant conversation ordering when its delayed user transcript arrives after the bot has begun responding. The UI now anchors
  that user bubble to the server-provided turn timestamp instead of the later browser receipt time.

  ## Changes

  - Use the `user-turn-finalized` server timestamp when anchoring delayed Omni transcript bubbles.
  - Fall back to the current browser time if the timestamp is missing or invalid.

  ## Type of Change

  - [x] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates
  - [ ] Doc only (prose changes, no code sample modifications)
  - [ ] Doc only (includes code sample changes)

  ## Quality Gates

  - [ ] Tests added or updated for changed behavior
  - [ ] Existing tests cover changed behavior — justification:
  - [x] Tests not applicable — justification: the client has no configured unit-test runner; client lint and production build validate this UI-
  only ordering change.
  - [ ] Docs updated for user-facing behavior changes
  - [x] Docs not applicable — justification: this is an internal rendering correction with no configuration or workflow change.

  ## Documentation Writer Review

  - [x] Documentation writer reviewed the completed changes
  - Result: `no-docs-needed`
  - Evidence: No documentation change: internal Omni transcript ordering correction preserves documented transcript behavior.
  - Agent: Codex CLI — Omni Assistant browser conversation rendering
  <!-- docs-review-head-sha: 37e7616 -->
  <!-- docs-review-agents-blob-sha: b73fe32 -->

  ## Verification

  - [x] Applicable lint, test, and build checks passed
  - [ ] Documentation validation passed for changed documentation
  - [x] No secrets, API keys, or credentials are committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation transcript ordering by preserving valid server-provided timestamps.
  * Added a fallback to the current time when timestamps are invalid, ensuring messages continue to display reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->