### PR TITLE
chore(nim): update ASR images and align LLM model ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated Nemotron ASR Streaming NIM to version 1.3.1.
+- Updated Parakeet CTC 1.1B ASR NIM to version 1.5.3.
 - Updated Magpie TTS Multilingual NIM to version 1.10.0 and `nvidia-riva-client` to version 2.27.0.
+- Standardized the self-hosted Nemotron 3.5 Lightning served model ID with NVIDIA Cloud across NIM and single-GPU vLLM deployments.
 - Consolidated on-prem deployment recipes under `<example>/server` for scaling-oriented stacks and universal `<example>/single-gpu` for supported one-GPU deployments on workstations, DGX Spark, and Jetson Thor. Renamed `generic-assistant/workstation-perf` to `generic-assistant/server-perf`.
 - Replaced `PLATFORM`-based local service selection with endpoint reachability.
 - Set **Nemotron 3.5 Lightning** as the default LLM across cascaded examples. Nemotron 3 Super remains available in the service catalogs.

--- a/docker/docker-compose.nemotron-asr.yaml
+++ b/docker/docker-compose.nemotron-asr.yaml
@@ -1,5 +1,5 @@
 x-nemotron-asr: &nemotron-asr
-  image: nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.0
+  image: nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.1
   user: "0:0"
   ports:
     - "50152:50052"

--- a/docker/docker-compose.nemotron35-lightning-nim.yaml
+++ b/docker/docker-compose.nemotron35-lightning-nim.yaml
@@ -27,7 +27,7 @@ x-nim-llm-env: &nim-llm-env
   NIM_HTTP_API_PORT: "8000"
   NIM_KVCACHE_PERCENT: ${NIM_KVCACHE_PERCENT:-0.6}
   NIM_MAX_MODEL_LEN: "32768"
-  NIM_PASSTHROUGH_ARGS: --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3 --max-num-seqs ${LLM_MAX_NUM_SEQS:-256}
+  NIM_PASSTHROUGH_ARGS: --served-model-name nvidia/nemotron-3.5-lightning-30b-a3b --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3 --max-num-seqs ${LLM_MAX_NUM_SEQS:-256}
 
 services:
   nvidia-llm:

--- a/docker/docker-compose.parakeet-asr.yaml
+++ b/docker/docker-compose.parakeet-asr.yaml
@@ -44,7 +44,7 @@ services:
       NIM_TAGS_SELECTOR: mode=str,vad=silero
     profiles:
       - parakeet-ctc-asr
-    image: nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0
+    image: nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.3
 
   parakeet-rnnt-asr:
     <<: *parakeet-asr-base

--- a/docs/how-to/configure-services.md
+++ b/docs/how-to/configure-services.md
@@ -33,7 +33,7 @@ To configure a specific local model, check its Docker Compose file under [`docke
 ```yaml
 services:
   nemotron-asr-streaming-english:
-    image: nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.0
+    image: nvcr.io/nim/nvidia/nemotron-asr-streaming:1.3.1
     profiles:
       - generic-assistant/server
       - frontend-backend-agent/server


### PR DESCRIPTION
## Summary
- update Nemotron ASR Streaming to 1.3.1 and Parakeet CTC ASR to 1.5.3
- expose the NVIDIA Cloud-compatible Nemotron 3.5 Lightning model ID from the self-hosted NIM
- update the changelog and service configuration documentation

## Test plan
- [x] Validate the Generic Assistant server Compose configuration
- [x] Validate the Parakeet CTC Compose configuration
- [x] Start Nemotron 3.5 Lightning NIM with NVFP4 and confirm the served model alias
- [x] Pull and start Parakeet CTC ASR NIM 1.5.3 with the streaming profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updated Nemotron ASR Streaming, Parakeet CTC ASR, and Nemotron 3.5 Lightning service versions.
  * Standardized the Nemotron 3.5 Lightning model name across supported deployments.

* **Documentation**
  * Updated service configuration guidance to reflect the latest Nemotron ASR Streaming version.

* **Chores**
  * Refreshed container images for the ASR services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->