### PR TITLE
chore(release): prepare v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-08-21
+
+Patch release replacing the deprecated Nemotron 3 Nano cloud endpoint in cascaded pipelines.
+
+### Changed
+
+- Replaced the deprecated Nemotron 3 Nano cloud endpoint with Nemotron 3.5 Lightning across cascaded NVIDIA Cloud service catalogs and defaults.
+
 ## [2.1.0] - 2026-08-18
 
 Minor release with expanded TTS options, improved turn-taking, Omni Assistant Subagents refinements, multilingual model compatibility checks, and broader evaluation coverage.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Built on the open-source [Pipecat framework](https://github.com/pipecat-ai/pipec
 | | [Magpie TTS Zeroshot](https://build.nvidia.com/nvidia/magpie-tts-zeroshot/modelcard) | |
 | | [Chatterbox TTS Multilingual](https://build.nvidia.com/resembleai/chatterbox-multilingual-tts/modelcard) | |
 | **LLM** | [Nemotron 3 Nano 30B A3B](https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b/modelcard) | Any OpenAI-compatible |
+| | [Nemotron 3.5 Lightning 30B A3B](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b/modelcard) | |
 | | [Nemotron 3 Super 120B A12B](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard) | |
 | | [Nemotron 3 Nano Omni 30B A3B](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) | |
 | **Orchestration** | [Pipecat](https://github.com/pipecat-ai/pipecat) | [LiveKit Agents with NVIDIA plugin](https://github.com/livekit/agents/tree/main/livekit-plugins/livekit-plugins-nvidia) |

--- a/benchmarking_tools/scaling-perf/README.md
+++ b/benchmarking_tools/scaling-perf/README.md
@@ -81,8 +81,8 @@ This setup is available as the dedicated Compose recipe
 `generic-assistant/workstation-perf`. It automatically applies the published
 scaling configuration:
 
-- Generic Assistant inherits the existing `nemotron-nano` default from
-  [`examples_registry.yaml`](../../examples_registry.yaml)
+- Generic Assistant selects the reachable self-hosted `nemotron-nano` entry
+  from its local service catalog
 - `nvidia-llm`: `NIM_TAGS_SELECTOR=precision=fp8,tp=2`, GPUs `2,3`, alias
   `nvidia-llm`
 - `nemotron-asr-streaming-english`:

--- a/docs/how-to/configure-llm.md
+++ b/docs/how-to/configure-llm.md
@@ -10,11 +10,12 @@ Models are declared per example in `services.cloud.yaml` (remote / NVCF) and `se
 
 ## Models
 
-Three unique Nemotron models back the examples. Each is served by the self-hosted Compose service(s) below, or from the cloud catalog with no sidecar.
+Four unique Nemotron models back the examples. Self-hosted models use the Compose service shown below. Cloud-only models need no sidecar.
 
 | Model | Self-hosted compose service | Modelcard |
 |-------|-----------------------------|-----------|
 | **Nemotron 3 Nano 30B A3B**: fast, efficient text LLM | [`docker-compose.nemotron3-nano.yaml`](../../docker/docker-compose.nemotron3-nano.yaml) | [modelcard](https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b/modelcard) |
+| **Nemotron 3.5 Lightning 30B A3B**: default cloud text LLM | Cloud only | [modelcard](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b/modelcard) |
 | **Nemotron 3 Super 120B A12B**: recommended for cloud deployments, higher capability for complex tasks | [`docker-compose.nemotron3-super.yaml`](../../docker/docker-compose.nemotron3-super.yaml) | [modelcard](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard) |
 | **Nemotron 3 Nano Omni 30B A3B**: audio-input model that does ASR and the LLM in one, used by the Omni examples | [`docker-compose.nemotron3-omni.yaml`](../../docker/docker-compose.nemotron3-omni.yaml) | [modelcard](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) |
 
@@ -22,9 +23,12 @@ Each model is exposed as one or more **catalog keys** in `services.cloud.yaml` /
 
 | Model | Catalog keys |
 |-------|--------------|
-| Nemotron 3 Nano | `nemotron-nano`, `nemotron-nano-reasoning` |
+| Nemotron 3 Nano (self-hosted) | `nemotron-nano`, `nemotron-nano-reasoning` |
+| Nemotron 3.5 Lightning (cloud) | `nemotron-lightning`, `nemotron-lightning-reasoning` |
 | Nemotron 3 Super | `nemotron-super`, `nemotron-super-reasoning` |
 | Nemotron 3 Nano Omni | `nemotron-omni-nvfp4` |
+
+The cascaded Nemotron 3 Nano cloud endpoint is deprecated. Cascaded NVIDIA Cloud catalogs now use Nemotron 3.5 Lightning.
 
 The `*-reasoning` keys are the **same weights** with thinking enabled (see [Reasoning, parser & tool calling](#reasoning-parser--tool-calling)). The active default per slot is set in [`examples_registry.yaml`](../../examples_registry.yaml) under `defaults`.
 
@@ -35,9 +39,10 @@ The multilingual assistant exposes only locales supported by the selected ASR, T
 | Built-in LLM | Supported language bases |
 | --- | --- |
 | Nemotron 3 Nano (`nemotron-nano`, `nemotron-nano-reasoning`) | English (`en`), German (`de`), Spanish (`es`), French (`fr`), Italian (`it`), Japanese (`ja`) |
+| Nemotron 3.5 Lightning (`nemotron-lightning`, `nemotron-lightning-reasoning`) | English (`en`), German (`de`), Spanish (`es`), French (`fr`), Italian (`it`), Japanese (`ja`) |
 | Nemotron 3 Super (`nemotron-super`, `nemotron-super-reasoning`) | English (`en`), German (`de`), Spanish (`es`), French (`fr`), Italian (`it`), Japanese (`ja`), Chinese (`zh`) |
 
-The source of truth for the built-in capability metadata is the NVIDIA [Nemotron 3 Nano model card](https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b/modelcard) and [Nemotron 3 Super model card](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8).
+The source of truth for the built-in capability metadata is the NVIDIA [Nemotron 3 Nano model card](https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b/modelcard), [Nemotron 3.5 Lightning model card](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b/modelcard), and [Nemotron 3 Super model card](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8).
 
 ## Hardware requirements and deployment configs
 
@@ -101,13 +106,13 @@ Nemotron LLMs support a chain-of-thought "thinking" mode, controlled per catalog
 ```yaml
 llm:
   # Reasoning OFF: lowest latency (recommended default for spoken pipelines)
-  nemotron-nano:
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning:
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}'
 
   # Reasoning ON: better on complex tasks, higher time-to-first-response
-  nemotron-nano-reasoning:
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning-reasoning:
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true}}}'
 ```
 
@@ -131,9 +136,9 @@ LLM request parameters are set per catalog entry via `extra_params`, a JSON stri
 
 ```yaml
 llm:
-  nemotron-nano:
-    name: "Nemotron 3 Nano 30B A3B"
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning:
+    name: "Nemotron 3.5 Lightning 30B A3B"
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
     extra_params: '{"temperature":0.6,"top_p":0.95,"max_tokens":1024,"extra_body":{"repetition_penalty":1.05,"chat_template_kwargs":{"enable_thinking":false}}}'
 ```

--- a/examples_registry.yaml
+++ b/examples_registry.yaml
@@ -30,7 +30,7 @@ examples:
       warning_completion_timeout_s: 45
     defaults:
       prompt: [generic_assistant]
-      llm: [nemotron-nano]
+      llm: [nemotron-lightning]
       asr: [nemotron-asr-streaming-english]
       tts: [magpie-multilingual-tts]
     bot: examples.generic.pipeline:bot
@@ -73,8 +73,8 @@ examples:
     slots: [llm, thinker-llm, booking-server, asr, tts]
     defaults:
       prompt: [talker]
-      llm: [nemotron-nano]
-      thinker-llm: [nemotron-nano]
+      llm: [nemotron-lightning]
+      thinker-llm: [nemotron-lightning]
       booking-server: [default]
       asr: [nemotron-asr-streaming-english]
       tts: [magpie-multilingual-tts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nemotron-voice-agent"
-version = "2.1.0"
+version = "2.1.1"
 description = "End-to-end voice agent blueprint powered by NVIDIA Nemotron ASR, LLM, and TTS"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"

--- a/skills/configure-pipeline/SKILL.md
+++ b/skills/configure-pipeline/SKILL.md
@@ -55,7 +55,7 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
 
 **Switch the default LLM to a different cloud model:**
 
-1. Open `examples_registry.yaml` and update the relevant `defaults` entry for the active example (e.g. change `llm: [nemotron-nano]` to `llm: [nemotron-super]`). The catalog key must exist in the active example's `services.cloud.yaml` / `services.local.yaml`.
+1. Open `examples_registry.yaml` and update the relevant `defaults` entry for the active example (e.g. change `llm: [nemotron-lightning]` to `llm: [nemotron-super]`). The catalog key must exist in the active example's `services.cloud.yaml` / `services.local.yaml`.
 2. Compose restart of the example service and refresh browser.
 
 **Add a multilingual persona prompt:**

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -139,7 +139,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     )
 
     # --- Talker LLM ---
-    model_id = body.get("model_id", "") or default_llm.get("model_id", "nvidia/nemotron-3-nano-30b-a3b")
+    model_id = body.get("model_id", "") or default_llm.get("model_id", "nvidia/nemotron-3.5-lightning-30b-a3b")
     base_url = body.get("base_url", "") or default_llm.get("base_url", "https://integrate.api.nvidia.com/v1")
     system_prompt = body.get("system_prompt", "") or default_llm.get("system_prompt", "")
     talker_max_tokens = _parse_optional_int(body.get("max_tokens", "") or default_llm.get("max_tokens"), 2048)

--- a/src/examples/frontend_backend_agent/services.cloud.yaml
+++ b/src/examples/frontend_backend_agent/services.cloud.yaml
@@ -1,18 +1,18 @@
 # Cloud service catalog for the Frontend/Backend Agent cascaded example.
 
 llm:
-  nemotron-nano:
-    name: "Nemotron 3 Nano 30B A3B"
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning:
+    name: "Nemotron 3.5 Lightning 30B A3B"
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
     system_prompt: ""
     max_tokens: 2048
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
 
 thinker-llm:
-  nemotron-nano:
-    name: "Nemotron 3 Nano 30B A3B Thinker"
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning:
+    name: "Nemotron 3.5 Lightning 30B A3B Thinker"
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
     max_tokens: 4096
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true,"thinking_budget":1024},"repetition_penalty":1.05}}'

--- a/src/examples/generic/README.md
+++ b/src/examples/generic/README.md
@@ -70,6 +70,6 @@ To change models, voices, prompts, or tool wiring, see [Configure Services](../.
 ## Tips & best practices
 
 - **Start from this baseline.** The generic example is intentionally minimal. Add domain logic, custom tools, and deployment-specific service choices on top of it rather than starting from scratch.
-- **Pick the model for the deployment.** Nemotron 3 Nano suits latency-sensitive local profiles, and Nemotron 3 Super is the higher-capability cloud default. See [Configure LLM](../../../docs/how-to/configure-llm.md) for sizing and precision.
+- **Pick the model for the deployment.** Nemotron 3 Nano suits latency-sensitive local profiles. Nemotron 3.5 Lightning is the default cloud model, while Nemotron 3 Super offers higher capability for complex tasks. See [Configure LLM](../../../docs/how-to/configure-llm.md) for sizing and precision.
 - **Tune turn-taking and latency** with the shared pipeline knobs in [Tune Pipeline Performance](../../../docs/how-to/tune-pipeline-performance.md).
 - For deployment, ASR/LLM/TTS, and general failure modes, see the [Troubleshooting guide](../../../docs/06-troubleshooting.md).

--- a/src/examples/generic/pipeline.py
+++ b/src/examples/generic/pipeline.py
@@ -96,7 +96,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     )
 
     # --- LLM ---
-    model_id = body.get("model_id", "") or default_llm.get("model_id", "nvidia/nemotron-3-nano-30b-a3b")
+    model_id = body.get("model_id", "") or default_llm.get("model_id", "nvidia/nemotron-3.5-lightning-30b-a3b")
     base_url = body.get("base_url", "") or default_llm.get("base_url", "https://integrate.api.nvidia.com/v1")
     system_prompt = body.get("system_prompt", "") or default_llm.get("system_prompt", "")
     extra_params = parse_json_dict(

--- a/src/examples/generic/services.cloud.yaml
+++ b/src/examples/generic/services.cloud.yaml
@@ -5,16 +5,16 @@
 # "(Reasoning)" entries enable chain-of-thought via enable_thinking; the others
 # run reasoning-off for lowest latency.
 llm:
-  nemotron-nano:
-    name: "Nemotron 3 Nano 30B A3B"
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning:
+    name: "Nemotron 3.5 Lightning 30B A3B"
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
     system_prompt: ""
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
 
-  nemotron-nano-reasoning:
-    name: "Nemotron 3 Nano 30B A3B (Reasoning)"
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning-reasoning:
+    name: "Nemotron 3.5 Lightning 30B A3B (Reasoning)"
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
     system_prompt: ""
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true},"repetition_penalty":1.05}}'

--- a/src/examples/multilingual/pipeline.py
+++ b/src/examples/multilingual/pipeline.py
@@ -227,7 +227,7 @@ async def bot(runner_args: RunnerArguments) -> None:
     )
 
     # --- LLM ---
-    model_id = body.get("model_id", "") or default_llm.get("model_id", "nvidia/nemotron-3-nano-30b-a3b")
+    model_id = body.get("model_id", "") or default_llm.get("model_id", "nvidia/nemotron-3.5-lightning-30b-a3b")
     base_url = body.get("base_url", "") or default_llm.get("base_url", "https://integrate.api.nvidia.com/v1")
     system_prompt = body.get("system_prompt", "") or default_llm.get("system_prompt", "")
     base_extra = parse_json_dict(

--- a/src/examples/multilingual/services.cloud.yaml
+++ b/src/examples/multilingual/services.cloud.yaml
@@ -5,17 +5,17 @@
 # "(Reasoning)" entries enable chain-of-thought via enable_thinking; the others
 # run reasoning-off for lowest latency.
 llm:
-  nemotron-nano:
-    name: "Nemotron 3 Nano 30B A3B"
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning:
+    name: "Nemotron 3.5 Lightning 30B A3B"
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
     supported_languages: [en, de, es, fr, it, ja]
     system_prompt: ""
     extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
 
-  nemotron-nano-reasoning:
-    name: "Nemotron 3 Nano 30B A3B (Reasoning)"
-    model_id: "nvidia/nemotron-3-nano-30b-a3b"
+  nemotron-lightning-reasoning:
+    name: "Nemotron 3.5 Lightning 30B A3B (Reasoning)"
+    model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
     base_url: "https://integrate.api.nvidia.com/v1"
     supported_languages: [en, de, es, fr, it, ja]
     system_prompt: ""

--- a/src/server.py
+++ b/src/server.py
@@ -312,7 +312,7 @@ def _get_default_llm_selection() -> tuple[str, str]:
     default_llm = load_service_entry("llm", "")
     return (
         default_llm.get("base_url", "https://integrate.api.nvidia.com/v1"),
-        default_llm.get("model_id", "nvidia/nemotron-3-nano-30b-a3b"),
+        default_llm.get("model_id", "nvidia/nemotron-3.5-lightning-30b-a3b"),
     )
 
 

--- a/tests/pipecat_evals/service/runner_bodies/cloud_tts.yaml
+++ b/tests/pipecat_evals/service/runner_bodies/cloud_tts.yaml
@@ -1,5 +1,5 @@
 defaults:
-  llm_id: cloud-nim:nemotron-nano
+  llm_id: cloud-nim:nemotron-lightning
   asr_id: cloud-nim:nemotron-asr-streaming-english
   tts_server: grpc.nvcf.nvidia.com:443
   tts_voice_id: Magpie-Multilingual.EN-US.Aria
@@ -49,7 +49,7 @@ bodies:
   frontend_backend_default:
     pipeline_mode: frontend-backend-agent
     prompt_key: talker
-    thinker_llm_id: cloud-nim:nemotron-nano
+    thinker_llm_id: cloud-nim:nemotron-lightning
     session_id: eval-frontend-backend-cloud-tts-default
 
   omni_default:

--- a/tests/pipecat_evals/service/runner_bodies/generic_audio_default.json
+++ b/tests/pipecat_evals/service/runner_bodies/generic_audio_default.json
@@ -1,7 +1,7 @@
 {
   "pipeline_mode": "generic-assistant",
   "prompt_key": "generic_assistant",
-  "llm_id": "cloud-nim:nemotron-nano",
+  "llm_id": "cloud-nim:nemotron-lightning",
   "asr_id": "cloud-nim:nemotron-asr-streaming-english",
   "tts_server": "localhost:50151",
   "tts_voice_id": "Magpie-Multilingual.EN-US.Aria",

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -310,27 +310,27 @@ llm:
         cloud = utils.load_yaml_file(Path("src/examples/multilingual/services.cloud.yaml"))["llm"]
         local = utils.load_yaml_file(Path("src/examples/multilingual/services.local.yaml"))
 
-        nano_languages = ["en", "de", "es", "fr", "it", "ja"]
-        super_languages = [*nano_languages, "zh"]
-        self.assertEqual(cloud["nemotron-nano"]["supported_languages"], nano_languages)
-        self.assertEqual(cloud["nemotron-nano-reasoning"]["supported_languages"], nano_languages)
+        common_languages = ["en", "de", "es", "fr", "it", "ja"]
+        super_languages = [*common_languages, "zh"]
+        self.assertEqual(cloud["nemotron-lightning"]["supported_languages"], common_languages)
+        self.assertEqual(cloud["nemotron-lightning-reasoning"]["supported_languages"], common_languages)
         self.assertEqual(cloud["nemotron-super"]["supported_languages"], super_languages)
         self.assertEqual(cloud["nemotron-super-reasoning"]["supported_languages"], super_languages)
         self.assertEqual(
             local["workstation"]["llm"]["nemotron-nano"]["supported_languages"],
-            nano_languages,
+            common_languages,
         )
         self.assertEqual(
             local["dgxspark"]["llm"]["nemotron-nano"]["supported_languages"],
-            nano_languages,
+            common_languages,
         )
 
         token = utils._service_context.set((Path("src/examples/multilingual"), ("llm", "asr", "tts")))
         try:
-            selected_nano = load_service_entry_by_id("llm", "cloud-nim:nemotron-nano")
+            selected_lightning = load_service_entry_by_id("llm", "cloud-nim:nemotron-lightning")
         finally:
             utils._service_context.reset(token)
-        self.assertEqual(selected_nano["supported_languages"], nano_languages)
+        self.assertEqual(selected_lightning["supported_languages"], common_languages)
 
     def test_multilingual_agent_prompt_keys_are_registry_declared(self) -> None:
         unlocked = examples_registry.Selection(

--- a/uv.lock
+++ b/uv.lock
@@ -1416,7 +1416,7 @@ wheels = [
 
 [[package]]
 name = "nemotron-voice-agent"
-version = "2.1.0"
+version = "2.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "imageio-ffmpeg" },


### PR DESCRIPTION
## Summary

Patch release **v2.1.1**. Replaces the deprecated Nemotron 3 Nano cloud endpoint with Nemotron 3.5 Lightning across the cascaded NVIDIA Cloud service catalogs and defaults. Self-hosted Nano and Nano Omni deployments are unchanged.

### Changed

- Renamed cloud catalog keys `nemotron-nano(-reasoning)` to `nemotron-lightning(-reasoning)` and pointed `model_id` at `nvidia/nemotron-3.5-lightning-30b-a3b` in the generic, multilingual, and frontend-backend cloud catalogs.
- Updated `examples_registry.yaml` defaults and the pipeline/server model-id fallbacks to `nemotron-lightning`.
- Refreshed eval runner bodies and service-catalog unit tests.
- Updated `configure-llm`, generic/scaling docs, root README, and the `configure-pipeline` skill for the new cloud default.
- Bumped version to `2.1.1` (`pyproject.toml`, `uv.lock`) and added the `2.1.1` CHANGELOG entry.

## Test plan

- [x] `uv run pytest tests/unit` (256 passed)
- [x] `uv run ruff check` on all modified Python files
- [x] YAML/JSON catalog validation and `uv lock --check`
- [x] Confirmed self-hosted Nano, Nano Omni, Docker recipes, and the Brev notebook are untouched
- [ ] Smoke-test the Lightning cloud endpoint end-to-end after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nemotron 3.5 Lightning 30B A3B as the default cloud model.
  * Added standard and reasoning configurations, including multilingual support.

* **Bug Fixes**
  * Replaced deprecated Nemotron 3 Nano cloud catalog entries with Nemotron 3.5 Lightning.

* **Documentation**
  * Updated model-selection guidance, configuration examples, scaling instructions, and changelog.

* **Chores**
  * Bumped the project version to 2.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->