### PR TITLE
feat(skills): add create-voice-agent skill

### DIFF
--- a/skills/create-voice-agent/SKILL.md
+++ b/skills/create-voice-agent/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: create-voice-agent
+description: Create or refine an NVIDIA voice agent with Pipecat or LiveKit. Covers cascaded and omni pipelines, domain speech customization, NVIDIA cloud, GPU workstations, DGX Spark, and Jetson Thor. Use when asked to build, scaffold, start, or modify a voice agent, voice bot, speech assistant, real-time audio pipeline, ASR word boosting, or TTS pronunciation.
+version: "2.1.0"
+metadata:
+  author: NVIDIA Voice Agent Team <nemotron-voice-agent@nvidia.com>
+  tags: [voice-agent, nvidia, nemotron, magpie, pipecat, livekit, nim, omni]
+---
+
+# Create Voice Agent
+
+Builds a working NVIDIA voice agent in an empty project:
+
+- **Cascaded**: ASR transcribes, a text LLM answers, TTS speaks.
+- **Omni**: one audio-in LLM replaces ASR and the text LLM. TTS still speaks.
+
+## Workflow
+
+Follow these phases in order:
+
+| Phase | Read |
+| --- | --- |
+| 1. Intake | `references/intake.md` resolves pipeline and framework first, then routes preflight, models, language, and domain files |
+| 2. Build | `references/platforms/readiness.md` if self-hosted → exact profile in the routed model file → `references/output-contract.md` → routed platform + `references/platforms/deployment.md` → `references/operations/observability.md` → selected framework files |
+| 3. Hand over | `references/operations/run.md` gates the client on the generated `scripts/smoke.sh`, then `references/operations/troubleshoot.md` if the spoken exchange fails |
+| 4. Iterate | `references/operations/iterate.md` for changes to a working agent |
+
+Wait for approval before writing files.
+
+During build, keep the approved language and behavior locks from intake. Read every routed
+file before generating code. Cloud deployment skips readiness, `list-model-profiles`,
+Compose, and the shared-GPU gate; wire endpoints per `references/platforms/deployment.md`
+§Cloud. Use `references/networking/remote-webrtc.md` when Pipecat WebRTC crosses hosts or
+networks.
+
+During handover, require a successful spoken exchange. A running process alone is not a
+working voice agent.

--- a/skills/create-voice-agent/references/domain/agent-behavior.md
+++ b/skills/create-voice-agent/references/domain/agent-behavior.md
@@ -1,0 +1,86 @@
+# Agent Behavior
+
+Read for every build. Convert the approved use case into a voice-safe system instruction
+before generating framework code.
+
+## Derive the behavior
+
+Use the user's description to define:
+
+- identity and role
+- who it serves and what it helps with
+- locked response language and speaking style
+- tasks it may complete
+- boundaries, escalation, and when to ask for clarification
+- tools it may call, if any
+
+Do not invent business policies, private data, tool access, or unsupported capabilities.
+Ask one focused follow-up only when a missing boundary would make the agent unsafe or
+materially change its behavior.
+
+## Voice-safe output
+
+The system instruction must require:
+
+- brief, conversational answers suitable for speech
+- plain text with no markdown, tables, code blocks, or emojis
+- no raw URLs, UUIDs, database keys, JSON, stack traces, or internal tool names
+- natural pronunciation of numbers, dates, abbreviations, and units
+- a short clarification instead of guessing when speech is ambiguous
+- the locked response language unless the approved route allows switching
+
+Keep spoken responses focused on the next useful action. Put machine-readable metadata in
+application state or logs, never in TTS text.
+
+Use the framework's current documented text filter when one exists. Do not invent a
+filter API. Prompt constraints remain required because filtering is only a fallback.
+
+## Persona and boundaries
+
+Give the agent a clear tone without role-playing beyond the approved use case. It must not
+claim actions succeeded until the corresponding tool or service confirms them.
+
+For regulated or sensitive domains, state the approved limitation and escalation path.
+Do not add legal, medical, financial, or safety claims that the user did not provide.
+
+## Tools
+
+Add tools only when the user explicitly requests and approves the tool-backed action.
+Query the selected framework documentation MCP for current tool and function-calling
+APIs.
+
+For every tool:
+
+1. define its purpose and required inputs
+2. validate inputs before calling
+3. handle success, empty results, and failure
+4. speak a user-friendly result, not the raw payload
+5. keep identifiers and session state out of spoken output
+
+Do not generate fake business data or placeholder tool results unless the user explicitly
+asks for a demo. Label demo data clearly.
+
+## Domain vocabulary
+
+This file owns meaning and response behavior. `domain/speech-customization.md` separately
+owns how specialized terms are recognized and pronounced.
+
+Add approved domain terms to the system instruction when they affect meaning, but do not
+treat prompt vocabulary as ASR word boosting.
+
+## Generated project
+
+Store the system instruction in agent code or a checked-in prompt file. Do not put it in
+`.env`. Document where to edit behavior in `README.md`.
+
+## Verify
+
+Test at least:
+
+- a normal in-scope request
+- an ambiguous request
+- an out-of-scope request
+- one tool success and failure when tools exist
+- a response containing an identifier, URL, or structured payload upstream
+
+The spoken result must remain concise, plain, and free of internal data.

--- a/skills/create-voice-agent/references/domain/speech-customization.md
+++ b/skills/create-voice-agent/references/domain/speech-customization.md
@@ -1,0 +1,161 @@
+# Speech Customization
+
+Use when the agent must recognize or pronounce domain terms such as product names,
+people, acronyms, medicines, menu items, or internal vocabulary.
+
+This is runtime customization, not model retraining:
+
+- ASR word boosting biases recognition toward approved words and phrases.
+- TTS pronunciation customization maps approved words to supported IPA pronunciations.
+
+Language and locale routing is a separate model-selection concern. Resolve it through
+`models/language-routing.md`. This file owns only domain vocabulary.
+
+## Trigger
+
+Offer speech customization when the request names a domain with specialized vocabulary,
+or when the user asks for boosting, hotwords, a glossary, pronunciation, or phonemes.
+Skip it for a generic assistant unless requested.
+
+After the base model table is approved, ask once:
+
+```text
+This use case has domain vocabulary. Should I add ASR word boosting and TTS pronunciation
+rules? If yes, send any required terms or I will draft a glossary for approval.
+```
+
+## Verify support first
+
+Read the current official documentation before drafting or wiring:
+
+- [ASR customization](https://docs.nvidia.com/nim/speech/latest/asr/customization/customization.html)
+- [ASR support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html)
+- [TTS customization](https://docs.nvidia.com/nim/speech/latest/tts/customization.html)
+- [TTS support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html)
+
+Confirm the locked model and API support the requested feature. Word-boosting modes,
+limits, score ranges, and model support differ by decoder and release. TTS phoneme and
+custom-dictionary support also differs by model and language.
+
+If the locked model lacks a required feature, show the affected model row and propose one
+supported streaming alternative. Never swap models silently.
+
+### Platform source
+
+| Platform | Customization source |
+| --- | --- |
+| Cloud / workstation / DGX Spark | Speech NIM docs and matrices above |
+| Jetson Thor | current Riva Quick Start plus the Riva ASR / TTS docs below |
+
+Jetson Thor runs Riva L4T, not Speech NIM. For the Riva model selected in
+`platforms/jetson-thor.md`, verify against:
+
+- [Riva ASR customization and word boosting](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/asr/asr-customizing.html#word-boosting)
+- [Riva TTS custom models and pronunciations](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/public/tts/tts-custom.html)
+
+Prefer request-time Riva customization:
+
+- ASR: add the approved phrases and score to the streaming recognition request through
+  `SpeechContext` or the current Riva client helper.
+- TTS: send approved custom pronunciations or SSML through the synthesis request when the
+  selected Riva model supports them.
+
+Do not apply Speech NIM tags or assume every ARM64 Quick Start model supports the same
+decoder or phoneme set. Global ASR lexicon changes and server-side TTS dictionaries require
+the current Riva model-build flow and may regenerate the model repository. Treat that as a
+deployment change, preserve the current repository, and get approval before rebuilding.
+
+## Glossary approval
+
+Draft one table and show every term before writing files:
+
+| Term | Locale | ASR phrase | Boost score | TTS IPA |
+| --- | --- | --- | --- | --- |
+| user or domain term | approved locale | exact spoken form | value from current ASR docs | supported IPA |
+
+Use the current docs for score ranges and IPA support. Start with the lowest recommended
+boost that solves the ambiguity. Higher scores increase false positives.
+
+Wait for explicit approval of the displayed terms, scores, and pronunciations. “Use your
+suggestions” counts only after the complete table has been shown. Do not create a glossary
+or wire customization before this confirmation.
+
+## ASR
+
+Keep streaming ASR. Choose the customization mode from the current ASR docs:
+
+- Per-stream boosting for a request-specific glossary.
+- Global boosting only when the approved list or deployment requires server-side
+  configuration.
+
+Wire the approved phrases and scores through the selected framework's current NVIDIA ASR
+API. Query its documentation MCP for field names. Do not reuse score ranges across CTC,
+RNNT, TDT, or Nemotron ASR without checking the current docs.
+
+## TTS
+
+Use the current TTS docs to choose request-time SSML phonemes or a custom pronunciation
+dictionary. Use only phonemes supported by the locked model and language.
+
+Wire the approved dictionary through the selected framework's current NVIDIA TTS API.
+After startup, synthesize every customized term and let the user confirm pronunciation.
+
+## Omni
+
+Omni has no ASR slot, so ASR word boosting does not apply. Do not add ASR just for domain
+terms. TTS pronunciation customization still applies.
+
+Domain terms may also be added to the Omni system instruction for response consistency,
+but that is not ASR boosting.
+
+## Generated project
+
+When customization is approved:
+
+- Write the confirmed terms to `speech_glossary.json` with this schema:
+
+```json
+{
+  "version": 1,
+  "terms": [
+    {
+      "term": "approved display form",
+      "locale": "en-US",
+      "asr": {
+        "phrase": "approved spoken form",
+        "boost": 4.0
+      },
+      "tts": {
+        "mode": "ipa",
+        "grapheme": "approved display form",
+        "pronunciation": "approved IPA"
+      }
+    }
+  ]
+}
+```
+
+- Omit `asr` for Omni or when boosting is not approved. Omit `tts` when pronunciation
+  customization is not approved. Do not write placeholder or `null` entries.
+- Keep model ids, scores, and pronunciation data out of `.env`.
+- Load the glossary from agent code and map it to the framework APIs documented today.
+- Include a short README note explaining how to edit and revalidate the glossary.
+
+## Verify
+
+Test each term in a natural sentence:
+
+1. ASR returns the intended spelling without causing nearby false positives.
+2. TTS pronounces the term correctly.
+3. A normal sentence without glossary terms still works.
+4. The full spoken exchange in `operations/run.md` still passes.
+
+Tune one term or score at a time. Use `operations/iterate.md` for later glossary changes.
+
+## Anti-patterns
+
+- Writing or wiring a glossary before showing it and receiving approval.
+- Assuming every ASR model supports word boosting.
+- Applying ASR boosting to Omni.
+- Inventing IPA unsupported by the selected TTS model or language.
+- Raising boost scores without checking false positives.

--- a/skills/create-voice-agent/references/frameworks/livekit.md
+++ b/skills/create-voice-agent/references/frameworks/livekit.md
@@ -1,0 +1,120 @@
+# LiveKit
+
+Read after the user approves the table and the framework row says LiveKit. Cascaded only:
+STT → LLM → TTS through an `AgentSession`. Omni is not supported on LiveKit. If the table
+also asked for omni, stop and ask which to keep (intake already requires this).
+
+LiveKit owns the session transport. Do not apply Pipecat transport rows, `-t` flags, or
+`:7860` client wiring here. The connect path is the LiveKit Agents console (or the path
+the LiveKit docs MCP currently documents), not a Pipecat browser client.
+
+## Code comes from the MCP
+
+This skill ships no `agent.py`, no skeleton, and no template. Agent code is generated from
+the LiveKit docs MCP. Discover it by capability first. Endpoint to add if missing:
+`docs.livekit.io/mcp`. Index for degraded fetch only: `docs.livekit.io/llms.txt`.
+
+Query for the pieces you need. For a cascaded NVIDIA stack that means:
+
+- Voice AI quickstart and Agents console
+- `AgentSession` wiring
+- NVIDIA STT and TTS plugins (`livekit-plugins-nvidia`)
+- LLM plugin or OpenAI-compatible client pointed at the locked NVIDIA model id
+- LiveKit Cloud API keys and `lk cloud auth`
+- Deployment / worker run commands
+- current prompt, text-output, metrics, tool, and exception hooks required by
+  `domain/agent-behavior.md` and `operations/observability.md`
+
+Never write a LiveKit import, class name, or API call from memory. If a query fails or
+comes back empty, say so and stop. Do not fill the gap with a guess.
+
+### When the MCP is not available
+
+Stop and ask the user to enable the LiveKit docs MCP, or explicitly approve the less
+reliable `docs.livekit.io/llms.txt` fallback. On fallback, fetch one current example from
+LiveKit docs or `livekit-examples`. Never invent structure.
+
+## What gets written
+
+Write one `agent.py`. Do not mix Pipecat (`bot.py`) into the project. Follow
+`output-contract.md` for the remaining files and any generated Compose services. Model
+ids are constants in code, not `.env` values. `.env` holds secrets only:
+`NVIDIA_API_KEY`, `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`.
+
+## LiveKit server
+
+Default is **LiveKit Cloud** (`wss://<project>.livekit.cloud`), not `localhost:7880`.
+
+Before generating, `LIVEKIT_*` must already clear `preflight.md`. If any key is missing,
+guide the user and wait. Prefer current steps from the MCP (`lk cloud auth` / project API
+keys). Manual path starts at https://cloud.livekit.io/.
+
+Self-hosted LiveKit server is an override only when the user asks for it by name. Still
+require all three `LIVEKIT_*` variables.
+
+## NVIDIA models
+
+Resolve exact ASR, LLM, and TTS ids through `models/catalog.md` → slot files before
+writing constants. Streaming ASR first (`models/asr.md`).
+
+- STT / TTS: NVIDIA plugin from the MCP (`livekit.plugins.nvidia` or current package name).
+  Cloud uses NVIDIA endpoints and `NVIDIA_API_KEY`. Self-hosted points `server` (or the
+  current equivalent) at the local NIM started from that model’s build.nvidia.com `/deploy`
+  page (`platforms/deployment.md`).
+- LLM: use the MCP’s documented way to call the locked Nemotron model id (NVIDIA cloud or
+  self-hosted OpenAI-compatible base URL). Do not invent a plugin class from memory.
+
+A self-hosted LLM has two traps. The OpenAI-compatible client may refuse to construct
+without an API-key argument even though a local NIM needs no authentication, so pass a
+non-secret placeholder when the resolved version behaves that way. Reasoning-off must reach
+the request nested inside `extra_body` (`models/llm.md`), so ask the MCP which plugin
+argument carries provider-specific fields and confirm the shape in the smoke test. The
+model string is the served id from `GET /v1/models`, not the catalog slug.
+
+Function ids for cloud speech come from build.nvidia.com, not from `/v1/models`.
+
+On Jetson Thor, follow `platforms/jetson-thor.md`: point both NVIDIA speech plugins at the
+shared Riva gRPC endpoint, leave function ids empty, and point the OpenAI-compatible LLM
+client at vLLM. Resolve the current `server`, SSL, language, and voice arguments from the
+LiveKit docs MCP.
+
+## Run shape
+
+The LiveKit CLI (`lk`) runs the worker. Before handover, confirm it is installed; if not,
+give the current install steps from the LiveKit docs MCP and wait. The worker start command
+depends on it.
+
+Credentials set → LiveKit CLI available → start self-hosted model services if the deployment
+row needs them → run the worker the way the MCP documents (typically `lk agent dev` on
+`agent.py`). Success is a spoken exchange, same bar as `operations/run.md`.
+
+Do not tell the user to open a Pipecat WebRTC client or hit `:7860`, and never present the
+worker’s local HTTP or health port as a client URL. LiveKit’s Agents Console (or the current
+documented client) is the path.
+
+## Connect and verify
+
+`scripts/smoke.sh` must pass before the worker joins a room.
+
+Then, with the worker still running and its `registered worker` line shown:
+
+1. open the LiveKit project whose credentials match `.env` `LIVEKIT_URL`
+2. refresh its Agents page and select the generated agent by name
+3. start a session, allow the microphone, and speak
+
+Confirm the worker connects without auth errors and STT → LLM → TTS each produce a turn. End
+the handover by pointing the user to that LiveKit URL to try the agent. Full handover steps
+are in `operations/run.md`.
+
+## After it runs
+
+Re-query the MCP before changing any LiveKit API. For workstation / DGX NIM LLM profile
+changes, return to the `list-model-profiles` and `NIM_MODEL_PROFILE` section in
+`models/llm.md`. Jetson Thor returns to its model card and platform guide.
+
+## Anti-patterns
+
+- Generating Omni on LiveKit, or generating `bot.py` for a LiveKit row.
+- Pointing the user at Pipecat `:7860` / transport `-t` flags.
+- Defaulting to self-hosted LiveKit server when Cloud was not overridden.
+- Pinning LiveKit or plugin versions from memory instead of resolving them.

--- a/skills/create-voice-agent/references/frameworks/omni.md
+++ b/skills/create-voice-agent/references/frameworks/omni.md
@@ -1,0 +1,85 @@
+# Omni
+
+Read with `frameworks/pipecat.md` when the approved pipeline is Omni. LiveKit is not
+supported.
+
+Omni replaces ASR and the text LLM with one audio-in model. TTS remains separate:
+
+```text
+transport → user context → Omni service → TTS → transport → assistant context
+```
+
+Do not add an ASR service, ASR NIM, or transcription-dependent turn strategy.
+
+## Sources
+
+Pipecat does not provide the required Omni service. Use NVIDIA's
+[`nvidia_omni_multimodal_service.py`](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/blob/main/src/examples/omni_assistant/nvidia_omni_multimodal_service.py)
+directly and build the pipeline around `NvidiaOmniMultimodalService`. Copy the current
+upstream file into the generated project. Do not reimplement or simplify it.
+
+Also copy NVIDIA's current
+[`audio_only_smart_turn_strategy.py`](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/blob/main/src/examples/omni_assistant/audio_only_smart_turn_strategy.py).
+Pipecat's stock Smart Turn stop strategy waits for an upstream `TranscriptionFrame`, which
+does not exist before an Omni audio turn completes.
+
+Generate the surrounding Pipecat pipeline, transport, context, turn handling, and TTS
+wiring from the Pipecat docs MCP. Use NVIDIA's current
+[`omni_assistant/pipeline.py`](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/blob/main/src/examples/omni_assistant/pipeline.py)
+as the behavioral reference. Read the locked model's API reference or Hugging Face model
+card for endpoint settings.
+
+## Model and deployment
+
+Resolve the exact model through `models/llm.md`. Keep reasoning off for voice.
+
+| Host | Source |
+| --- | --- |
+| Cloud | model id from `/v1/models`, API shape from its build.nvidia.com reference |
+| Workstation / DGX Spark | current self-host instructions from the locked model page or card |
+| Jetson Thor | Omni Hugging Face card and vLLM path in `platforms/jetson-thor.md` |
+
+Budget Omni + TTS only. `NIM_MODEL_PROFILE` applies only when the chosen self-hosted page
+actually deploys a NIM. It never applies to raw vLLM.
+
+A self-hosted Omni endpoint hits the same client traps as the cascaded LLM in
+`frameworks/pipecat.md` §Local LLM wiring: an API-key argument may be required even
+locally, reasoning-off has to arrive nested inside `extra_body`, and the model string is
+the served id from the endpoint rather than the catalog slug.
+
+For domain vocabulary, follow `domain/speech-customization.md`. Only TTS pronunciation
+customization applies because Omni has no ASR slot.
+
+## Turn handling
+
+Wire transport audio and context into `NvidiaOmniMultimodalService`, then route its text
+output to TTS.
+
+- Start turns from VAD and stop them with `AudioOnlySmartTurnStopStrategy`.
+- Use Pipecat's current `MuteUntilFirstBotCompleteUserMuteStrategy` so microphone input
+  cannot race the first response.
+- Follow the current upstream pipeline for the connect greeting and use one greeting path
+  only. The current Omni service supports text turns.
+- When user transcripts are enabled, request the structured response shape expected by
+  the upstream service. It parses the JSON and sends only `response` text to TTS.
+- Keep reasoning off through the request settings in `models/llm.md`.
+
+## Verify
+
+- `scripts/smoke.sh` passes, using the Omni audio request rather than a chat completion.
+- No ASR service or ASR sidecar exists.
+- The upstream Omni service and audio-only Smart Turn strategy were copied unchanged.
+- The model endpoint serves the locked Omni model, and the agent uses its exact served id.
+- User audio produces a coherent response and, when supported, a user transcription.
+- Exactly one greeting plays and microphone input begins after it completes.
+- TTS never speaks reasoning, JSON wrappers, or transcript metadata.
+- Barge-in cancels the current Omni response.
+- Complete the spoken exchange in `operations/run.md`.
+
+## Anti-patterns
+
+- LiveKit Omni.
+- Stock text-only LLM service or separate ASR used in place of Omni.
+- Rewriting `NvidiaOmniMultimodalService`.
+- Stock Smart Turn stop strategy waiting for a transcription.
+- Reasoning left at the model default.

--- a/skills/create-voice-agent/references/frameworks/pipecat.md
+++ b/skills/create-voice-agent/references/frameworks/pipecat.md
@@ -1,0 +1,109 @@
+# Pipecat
+
+Read after the user approves the table and the framework row says Pipecat. Covers both
+pipeline shapes. Omni has extra requirements on top, in `frameworks/omni.md`.
+
+## Code comes from the MCP
+
+This skill ships no `bot.py`, no skeleton, and no template. Pipeline code is generated from
+the Pipecat docs MCP. Discover it by capability first. The server is commonly exposed as
+`user-pipecat-docs`.
+
+Query it for the pieces you actually need, rather than pulling the whole surface. For a
+cascaded pipeline that means pipeline construction, the runner, the transports, and the
+NVIDIA STT, LLM, and TTS services. Omni adds LLM service subclassing, speech input, smart
+turn detection, and user turn strategies. Also query current prompt, text-filter,
+observer, metrics, tool, and exception hooks required by `domain/agent-behavior.md` and
+`operations/observability.md`.
+
+Never write a Pipecat import, class name, or API call from memory. If a query fails or
+comes back empty, say so and stop. Do not fill the gap with a guess, because a plausible
+wrong import costs the user more time than a missing file.
+
+### When the MCP is not available
+
+Ask the user to add `https://daily-docs.mcp.kapa.ai` to their coding agent's MCP
+configuration as a remote server named `pipecat-docs`, enable it, and reload the agent
+session. Wait for the user to continue, then discover the server by capability.
+
+If the user cannot enable it, ask them to explicitly approve the less reliable
+`docs.pipecat.ai/llms.txt` fallback. Never fall back silently.
+
+## What gets written
+
+Write one `bot.py`. Follow `output-contract.md` for the rest of the project and any
+generated Compose services.
+
+## Local LLM wiring
+
+Cascaded only, and it covers any local endpoint, whether that is a NIM or raw vLLM on
+Jetson Thor. Omni follows `frameworks/omni.md`. Two failures here cost a full connect
+cycle each because both look like a model problem, so resolve the exact shapes from the
+MCP before generating. Query it for the NVIDIA LLM service class and import, the local
+base-URL argument, the API-key argument's behaviour, and the settings wrapper that carries
+provider-specific request fields.
+
+**The client still wants an API key locally.** A local server needs no authentication, but the
+underlying OpenAI-compatible client can refuse to construct without a key argument. When the
+resolved version behaves that way, pass a non-secret placeholder. Never require a real cloud
+key to talk to a container on localhost, and never write one into `.env` for this.
+
+**Reasoning-off has to survive the wrapper.** The provider needs the thinking flag nested
+inside the request's `extra_body` (`models/llm.md`). Pipecat does not take a raw request
+dict, so the flag must be placed in the current settings wrapper's provider-extra field
+such that it arrives nested, not flattened to the top level. Confirm that field name in the
+MCP, then verify the shape in the smoke test rather than at the browser.
+
+The model string is the runtime model id from `GET /v1/models`, not the catalog slug
+(`models/llm.md` §Resolve three names).
+
+## Transport wiring
+
+The transport row is already settled by `intake.md`. It controls transport parameters,
+package extras, and the runner `-t` flag. The runner flag is the usual failure.
+
+| Transport | `transport_params` keys | Package extras | Run |
+| --- | --- | --- | --- |
+| WebRTC | `webrtc` | `webrtc` | pass `-t webrtc` |
+| WebSocket | `websocket` | `websocket` | pass `-t websocket` |
+| Both | `webrtc` and `websocket` | both | pass no `-t` at all |
+
+Passing `-t webrtc` when the user chose both is the failure. The flag restricts the server
+to that single transport, so a `/start` naming any other one is rejected outright and the
+WebSocket path never appears in the client UI. Omitting the flag lets the runner serve every
+transport at once and lets the caller pick one per session.
+
+Beyond the transport extras, the project needs the NVIDIA services, the runner, and a
+voice activity detector. Resolve the package version from the MCP or from PyPI rather than
+pinning a number from memory.
+
+Both is the right default when there is any doubt. A corporate network that blocks UDP can
+fall back to WebSocket without rebuilding the project.
+
+For remote browsers, NAT traversal, coturn, or a separate GPU host, follow
+`networking/remote-webrtc.md`.
+
+## Verify before handover
+
+`scripts/smoke.sh` must pass before the runner starts.
+
+Ask the runner what it registered rather than assuming. `GET /status` lists the accepted
+transports, and for the both case that list must include `webrtc` and `websocket`. A
+`POST /start` naming either one should open a session on it.
+
+Full startup and connection steps are in `operations/run.md`.
+
+## After it runs
+
+Re-query the MCP before changing any Pipecat API. Workstation / DGX NIM profile changes
+return to the `list-model-profiles` and `NIM_MODEL_PROFILE` section in `models/llm.md`.
+Jetson Thor returns to its model card and platform guide.
+
+## Anti-patterns
+
+- Passing `-t webrtc` when the user chose both transports.
+- Generating a separate bot file per transport.
+- Pinning a Pipecat version remembered rather than resolved.
+- Demanding a real cloud key to reach a container on localhost.
+- Passing the reasoning flag as a raw request dict, or flattening it out of `extra_body`.
+- Opening the client to find out whether the services construct. Run the smoke test.

--- a/skills/create-voice-agent/references/intake.md
+++ b/skills/create-voice-agent/references/intake.md
@@ -1,0 +1,151 @@
+# Intake
+
+Propose and confirm. Two pauses for base intake: after the ask, and after the table.
+Post-approval profile discovery adds a reconfirmation only when an approved row changes.
+Speech customization is optional. When the user accepts its offer, it adds one glossary
+approval after the base table.
+
+```
+0  probe    hardware + host class + base credential → preflight.md sections 1-3
+1  ask      use case + pipeline + framework
+2  propose  models + deployment fit + one filled table → preflight.md §Deployment fit
+            + models/catalog.md
+3  confirm  build, or amend a row
+```
+
+Do not ask anything this file does not define. Do not ask what the table can decide.
+
+## 0. Probe
+
+Before speaking. Missing credentials: say which key, how to get it, wait. Everything else
+becomes a table row.
+
+## 1. Ask priority questions
+
+Resolve **Pipeline** and **Framework** explicitly. Skip a choice only when the user
+already made it or compatibility forces it. Use structured choices when available and
+ask all applicable questions in one message.
+
+If the use case is unclear, also ask:
+
+> What are you building? Include who talks to it, what it helps with, and the spoken
+> language. Example: "a Hindi drive-through order taker."
+
+Ask: **Which pipeline should the agent use?**
+
+| Choice | Explain |
+| --- | --- |
+| Cascaded (Recommended) | streaming ASR → text LLM → TTS. Modular, easier to customize and troubleshoot |
+| Omni | audio-in model replaces ASR and the text LLM. TTS remains. Pipecat only |
+| Recommend for me | choose from the use case and explain the recommendation |
+
+Then ask: **Which framework should implement it?** Ask this when Cascaded is selected or
+the pipeline is undecided:
+
+| Choice | Explain |
+| --- | --- |
+| Pipecat (Recommended) | supports Cascaded and Omni, with direct transport control |
+| LiveKit | choose for LiveKit rooms, workers, or an existing LiveKit deployment. Cascaded only |
+| Recommend for me | choose from the use case and explain the recommendation |
+
+Omni locks Pipecat. LiveKit locks Cascaded. State the forced choice instead of asking an
+irrelevant question. If the user explicitly selects LiveKit + Omni, ask one conflict
+question: keep LiveKit with Cascaded, or keep Omni with Pipecat.
+
+As soon as the framework is resolved, read its framework file and verify that its docs MCP
+is available. If it is unavailable, give the setup steps from that file and wait. Complete
+this check before proposing models or offering speech customization.
+
+Infer language, vertical, reasoning hardness, and latency-vs-quality from the use case.
+Derive the system instruction through `domain/agent-behavior.md`. Do not run a separate
+persona wizard. One follow-up for missing use-case context is allowed. Never two.
+
+## 2. Propose
+
+One message. One table. Every row filled with a decision and a short reason. Exact model
+ids from `models/llm.md`, `models/asr.md`, `models/tts.md` (via `models/catalog.md`), not
+family names. These are catalog ids that record the choice, and two values stay open until
+the services answer: the LLM's served model id and the exact TTS voice (`models/llm.md`
+§Resolve three names). Lock the TTS locale now and present neither of those as final here.
+For shared self-hosting, show the candidate LLM profile and runtime cap, speech profile
+reserves, startup reserve, and usable VRAM from `preflight.md` §Deployment fit. Mark
+provisional co-location until post-approval profile discovery succeeds and
+`platforms/deployment.md` §Shared-GPU memory gate passes.
+No code, compose, or layout in this turn.
+
+The example below assumes W4A16 is the lightest candidate supported for this H100 in the
+matrix (Lightning NVFP4 needs Blackwell). Post-approval profile discovery must confirm it.
+
+```
+Framework    Pipecat                 supports both pipeline shapes
+Pipeline     cascaded                spoken Q&A
+Deployment   self-hosted             H100 80GB, provisional co-location
+Transport    both                    WebRTC + WebSocket
+Language     English (en-US)         fixed, lowest latency
+LLM          Nemotron 3.5 Lightning  nvidia/nemotron-3.5-lightning-30b-a3b, candidate vllm-w4a16-tp1-pp1
+ASR          Nemotron ASR Streaming  nvidia/nemotron-asr-streaming, streaming, batch_size=32
+TTS          Magpie TTS Multilingual nvidia/magpie-tts-multilingual, batch_size=8, en-US. Voice after startup
+Reasoning    off                     low turn latency
+Memory       runtime budget planned  context, LLM cap, speech reserves, startup reserve
+
+Reply "go" to build, or name a row to change.
+```
+
+### Shape changes
+
+- Omni: drop ASR, add the Omni model, and recalculate deployment fit
+  (`frameworks/omni.md`).
+- LiveKit: drop transport. LiveKit cannot run Omni. If both are requested, ask which to
+  keep.
+- DGX Spark: follow `platforms/dgx-spark.md`. Budget available unified memory and disclose
+  any hybrid slot.
+- Jetson Thor: use the vLLM + Riva rows from `platforms/jetson-thor.md`. Disclose the
+  platform substitutions.
+- Remote Pipecat WebRTC: route `networking/remote-webrtc.md`.
+- Several languages: route fixed vs automatic detection through
+  `models/language-routing.md`.
+
+### Defaults
+
+| Row | Default | Override when |
+| --- | --- | --- |
+| Framework | explicit intake choice, otherwise Pipecat recommendation | user chooses LiveKit |
+| Pipeline | explicit intake choice, otherwise Cascaded recommendation | user chooses Omni or audio-native |
+| Deployment | self-hosted when routed platform fit passes. Provisional when slots share one GPU | otherwise hybrid/cloud, name each cloud slot |
+| Transport | both | user named one, or LiveKit (omit this row) |
+| Language | fixed locale from `models/language-routing.md` | user requested several languages |
+| LLM | Nemotron 3.5 Lightning | user named Super, Ultra, or another id |
+| ASR | from language via `models/asr.md` | user named a model |
+| TTS | Magpie TTS Multilingual, smallest supported batch profile, locale. Voice after runtime discovery | user named a model or voice |
+| Reasoning | off | specialized workload → on, budget 8192 |
+| Memory | profile reserves + runtime and startup headroom | recalculate whenever profile, batch, context, or placement changes |
+
+Lightning always. Super/Ultra only if named. On one workstation GPU, say they will not fit.
+Use `models/llm.md` for reasoning wiring and `models/asr.md` for streaming-first selection
+and offline limitations.
+
+## 3. Confirm
+
+After base approval, offer `domain/speech-customization.md` when its Trigger section
+applies. If accepted, wait for glossary approval before building. If declined, build
+without it and do not ask again.
+
+Amend a row in place. Re-show the table only when the change cascades. LiveKit drops Omni
+and transport. Omni replaces ASR and changes fit. Full cloud removes the Memory row.
+Hybrid recalculates Memory for local slots. Otherwise just build.
+
+After self-hosting approval, run `platforms/readiness.md`, then discover and pin the exact
+Compatible LLM profile. If profile, memory fit, or placement changes, re-show the affected
+rows and wait for confirmation before writing files. During deployment, follow
+`platforms/deployment.md` §Per-slot reuse before starting services.
+
+## Stop only for
+
+Missing credentials. Still too vague after one follow-up. Conflict (Omni + LiveKit).
+Self-hosted on a host with no compatible local platform.
+
+## Anti-patterns
+
+Skip the Pipeline or Framework choice. Ask transport or deployment before proposing.
+Ask model slots separately. Offer choices without explaining trade-offs. Family names in
+the table. Write files in the proposal turn. Re-ask something already stated.

--- a/skills/create-voice-agent/references/models/asr.md
+++ b/skills/create-voice-agent/references/models/asr.md
@@ -1,0 +1,119 @@
+# ASR
+
+Nemotron ASR, Parakeet CTC / RNNT / TDT, and other models on the live Speech matrix.
+Docs first. Never invent the roster from memory.
+
+Do not use the LLM support matrix, `list-model-profiles`, or `NIM_MODEL_PROFILE` here.
+Jetson Thor uses Riva L4T models selected from its ARM64 quickstart, not Speech NIM
+deployment. See `platforms/jetson-thor.md`.
+
+## Streaming first
+
+Voice agents need partial transcripts as audio arrives. Always propose a **streaming** ASR
+model and a streaming `NIM_TAGS_SELECTOR` (`mode=str` or a streaming-only model such as
+Nemotron ASR Streaming).
+
+Prefer streaming even when the user also wants diarization or multilingual. Pick a matrix
+row that exposes streaming for that need. Do not default to offline (`mode=ofl`) or to an
+offline-only model (Parakeet TDT, Whisper, Canary, and anything the docs mark offline only).
+
+### If the user chooses offline
+
+Allow it only when they ask for offline by name, or for a capability that exists only on
+an offline profile. Before locking that row, tell them these limits in the proposal (or
+when they amend ASR):
+
+- Offline waits for the **full utterance or file**, then returns one complete transcript.
+  No partials while the user is still speaking.
+- Turn latency is higher. The agent cannot start thinking or speaking from interim text.
+- It fits **batch / file** transcription better than a live mic conversation.
+- Some offline-only models cannot be switched to streaming later without changing the
+  model. If they still want a live voice agent, keep a streaming ASR and use offline only
+  as a separate batch path.
+
+Do not silently swap a streaming proposal to offline. Disclose, then wait for confirm.
+
+## Discover
+
+| Step | Where | Why |
+| --- | --- | --- |
+| Disambiguation | [About ASR](https://docs.nvidia.com/nim/speech/latest/asr/) · [Deploy ASR models](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/index.html) | language, streaming vs offline, diarization, timestamps. Overlaps (Parakeet CTC English vs Nemotron ASR Streaming) resolved here |
+| Roster + tags + VRAM | [ASR support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html) | every model, `CONTAINER_ID`, `NIM_TAGS_SELECTOR`, GPU memory |
+| Confirm | `build.nvidia.com/nvidia/<slug>` | function id, card, languages |
+| Deploy copy | `build.nvidia.com/nvidia/<slug>/deploy` | image, docker run, env. Example: [nemotron-asr-streaming/deploy](https://build.nvidia.com/nvidia/nemotron-asr-streaming/deploy) |
+
+Index: [NVIDIA Speech NIM](https://docs.nvidia.com/nim/speech/latest/index.html).
+Resolve fixed locale versus automatic detection through `models/language-routing.md`.
+For domain word boosting, also follow `domain/speech-customization.md` and verify the
+locked model against the current customization docs.
+
+Near-duplicates that must not collapse:
+
+- Parakeet CTC English: more than one size (0.6b and 1.1b on the matrix)
+- Parakeet CTC locale containers (Spanish, Mandarin, Vietnamese, Taiwanese, …)
+- Parakeet RNNT Multilingual: different family, auto-detect multilingual
+- Nemotron ASR Streaming: separate English streaming-focused option
+
+If the user says “Parakeet” without size or decoder, open the docs disambiguation and
+propose one **streaming** concrete row. Do not pick silently.
+
+## Defaults (hints only)
+
+Re-check the matrix before the proposal table. Every default below is a streaming pick.
+
+| Need | Start from | Then open |
+| --- | --- | --- |
+| English streaming | Nemotron ASR Streaming | matrix + [deploy](https://build.nvidia.com/nvidia/nemotron-asr-streaming/deploy) |
+| English + diarization (still streaming) | Parakeet CTC English streaming profile with diarizer (1.1b unless VRAM needs 0.6b) | matrix + that slug’s `/deploy` |
+| One non-English locale | Matching Parakeet CTC locale, **streaming** profile | matrix language table |
+| Several languages, auto-detect | Parakeet RNNT Multilingual, **streaming** profile | matrix + [card](https://build.nvidia.com/nvidia/parakeet-1_1b-rnnt-multilingual-asr) |
+
+Offline profiles and offline-only models are never the default. Use them only after the
+disclosure above.
+
+An auto-detecting multilingual row does not become single-language because the request
+carries a locale. Resolve that distinction through `models/language-routing.md` before
+promising fixed-language recognition.
+
+## Sizing
+
+Planning estimates only. Authoritative GPU memory is the chosen row on the
+[ASR support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html).
+
+| Fact | Value |
+| --- | --- |
+| Nemotron ASR Streaming, `batch_size=32` | about 6 GB |
+| Nemotron ASR Streaming, `batch_size=64` | about 15 GB |
+| Self-hosted floor | compute capability 8.0+, ≥16 GB VRAM for the speech NIM |
+| Selection | `NIM_TAGS_SELECTOR` (not `NIM_MODEL_PROFILE`) |
+
+Batch size moves ASR memory by more than a factor of two, so on a shared GPU take the
+smallest documented streaming batch that satisfies the use case and write that tag
+explicitly. Read the pair off the matrix row for the locked language type.
+
+After the profile fits this GPU, check the combined stack in `preflight.md` §Deployment
+fit. If ASR does not fit beside the LLM, move ASR to another GPU or to the cloud.
+When ASR shares a GPU, verify measured fit through `platforms/deployment.md` §Shared-GPU
+memory gate.
+
+## Lock self-hosted
+
+1. From the matrix section: `CONTAINER_ID` + `NIM_TAGS_SELECTOR` for language, **streaming**
+   mode, and VRAM. Prefer `mode=str` (or the model’s streaming-only tags). Tag strings, not
+   LLM profile hashes. Use `mode=ofl` or offline-only containers only after the offline
+   disclosure and user confirm.
+2. Cross-check image and environment on `/deploy` using the precedence in
+   `models/catalog.md`.
+3. Apply the sizing floor above, then stack fit in `preflight.md`.
+4. Languages only from the matrix table. Do not invent a locale.
+5. Cloud: function id from the build page. Self-hosted: leave function id empty. Never
+   look up a speech function id in `/v1/models`.
+
+## Anti-patterns
+
+- Defaulting to offline ASR or an offline-only model for a voice agent.
+- Locking offline ASR without telling the user the live-conversation limits.
+- Treating “Parakeet” as one model.
+- Skipping docs.nvidia.com/nim/speech for a remembered build.nvidia.com slug.
+- Setting a function id on self-hosted ASR.
+- Inventing a locale not on the matrix language table.

--- a/skills/create-voice-agent/references/models/catalog.md
+++ b/skills/create-voice-agent/references/models/catalog.md
@@ -1,0 +1,45 @@
+# Model Catalog
+
+Exact ids for the proposal table. Never write them from memory. Open the file for the
+slot you are resolving.
+
+| Slot | Read | Discover first | Confirm on |
+| --- | --- | --- | --- |
+| Language / locale | `models/language-routing.md` | ASR + TTS language tables | selected framework docs MCP |
+| Cascaded LLM | `models/llm.md` | LLM support matrix + `/v1/models` | `build.nvidia.com/nvidia/<model>` |
+| Omni | `models/llm.md` | same, exclude from cascaded LLM | same |
+| ASR | `models/asr.md` | [Speech docs](https://docs.nvidia.com/nim/speech/latest/) → [ASR matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html) | `<slug>` and `<slug>/deploy` |
+| TTS | `models/tts.md` | [TTS matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html) | same pattern |
+
+Family browse: [NVIDIA Nemotron](https://developer.nvidia.com/topics/ai/nemotron#section-nvidia-nemotron-models).
+
+## Shared rules
+
+- Proposal table gets exact catalog ids. Family names alone are wrong. Those ids describe
+  the choice, and agent code uses the runtime ids resolved after startup.
+- Lock language routing before selecting ASR and TTS.
+- Model ids, voice ids, and function ids go in generated code or config. `.env` is secrets only.
+- LLM tools (`list-model-profiles`, `NIM_MODEL_PROFILE`, LLM support matrix) never apply to ASR or TTS.
+- Speech tools (`NIM_TAGS_SELECTOR`, Speech matrices, `/deploy`) never apply to the LLM.
+- For self-hosted Speech, the matrix owns profile fit and tags. The `/deploy` page owns
+  image URI and launch shape. Stop if they still conflict.
+- Shared-GPU placement uses the runtime budget in `preflight.md`, LLM controls in
+  `models/llm.md`, and the explicit TTS batch profile in `models/tts.md`. It remains
+  provisional until `platforms/deployment.md` §Shared-GPU memory gate passes.
+- Jetson Thor bypasses Speech NIM selection and follows `platforms/jetson-thor.md`.
+- If the user names a model outside these families, say so and wait. Do not substitute.
+
+## Where they live
+
+| Identifier | Who | Source |
+| --- | --- | --- |
+| Catalog slug | Proposal table | `build.nvidia.com/nvidia/<slug>`. Intent only, never agent code |
+| Container image | Self-hosted LLM | the self-hosted build page or NGC command that actually pulls |
+| `NIM_MODEL_PROFILE` | Self-hosted LLM | `list-model-profiles` on the assigned GPU |
+| Runtime model id | LLM (and listing checks) | `GET /v1/models` · cloud `https://integrate.api.nvidia.com/v1/models` |
+| Function id | Cloud ASR / TTS | build.nvidia.com model page. gRPC `grpc.nvcf.nvidia.com:443`. Empty when self-hosted |
+| `CONTAINER_ID` + `NIM_TAGS_SELECTOR` | Self-hosted ASR / TTS | Speech matrix, then `/deploy` |
+| Voice id | TTS | running service's documented voice-discovery API |
+
+Slug, image, and runtime model id are three separate strings (`models/llm.md` §Resolve
+three names). Agent code uses the runtime model id only.

--- a/skills/create-voice-agent/references/models/language-routing.md
+++ b/skills/create-voice-agent/references/models/language-routing.md
@@ -1,0 +1,112 @@
+# Language Routing
+
+Read for every build before locking input speech, the LLM, and TTS. This file maps the
+user's spoken language to supported model locales. Domain vocabulary remains in
+`domain/speech-customization.md`.
+
+## Lock the route
+
+Record:
+
+- input language and exact BCP-47 locale
+- fixed language or automatic detection
+- cascaded ASR or Omni model that supports that mode and language
+- response language, checked against the LLM's own supported languages
+- TTS model and locale. Exact voice remains pending runtime discovery
+
+Resolve locale codes from the selected platform's current source:
+
+| Platform | Language source |
+| --- | --- |
+| Cloud / workstation / DGX Spark | Speech NIM ASR and TTS matrices + model pages |
+| Jetson Thor | current Riva ARM64 Quick Start `config.sh` and model documentation |
+
+For Omni input, use the locked Omni model card and service documentation instead of the
+ASR matrix.
+
+For example, Hindi may resolve to `hi-IN` only when both selected speech paths list that
+exact locale. Do not invent a regional code from the language name.
+
+## Fixed or automatic
+
+Use a fixed locale when the user names one language. It is the predictable, low-latency
+default.
+
+A fixed locale is a request parameter, not a capability. On a multilingual auto-detecting
+model it is advisory, because the model still detects, so audio in another supported
+language comes back in that language. Only a single-language model turns a locale into a
+constraint. Check which kind the locked row is before promising fixed-language behaviour,
+and say so in the proposal when the honest answer is auto-detection.
+
+Use automatic detection only when the user requests several languages and the selected
+**streaming** ASR model explicitly supports detection for all of them. Disclose that
+detection and code-switching can add latency or errors. Never assume multilingual means
+arbitrary code-switching.
+
+For Omni, apply fixed or automatic behavior only when its model documentation supports
+the requested audio languages.
+
+If the user wants input in one language and replies in another, lock both sides
+separately and reflect the response language in `domain/agent-behavior.md`.
+
+## ASR
+
+Follow `models/asr.md` and require a streaming row that supports the locked locale or
+language set. The model card, matrix language table, and profile tags must agree.
+Jetson Thor instead uses the streaming Riva model enabled by `platforms/jetson-thor.md`.
+
+Omni bypasses ASR. Verify its supported audio languages and detection behavior from the
+locked Omni source. Do not apply an ASR locale or assume multilingual detection.
+
+Do not pass a locale merely because the framework exposes an enum for it. Query the
+framework documentation MCP for the current language argument and pass the exact form the
+selected NVIDIA service expects.
+
+## LLM
+
+The cascaded LLM carries its own supported-language list, separate from ASR and TTS coverage.
+A locale that ASR transcribes and TTS speaks is not automatically a language the LLM answers
+well, and this list is often shorter than people expect.
+
+Read the supported languages from the locked model's card or API reference and compare them
+with the approved response language. When the response language is outside that list, say so
+before building and offer the choice plainly: keep it and accept reduced quality, change the
+response language, or select a different LLM. Never let ASR and TTS coverage stand in for LLM
+coverage.
+
+For Omni, apply the same check to the response text on its locked source, in addition to the
+audio-language check above.
+
+## TTS
+
+Follow `models/tts.md` and require a TTS model that supports the response locale. After
+the service starts, query its documented voice-discovery API and choose only a returned
+voice compatible with that locale.
+
+On Jetson Thor, use only voices exposed by the selected Riva L4T service.
+
+If no returned voice matches, reopen the TTS row and ask for approval before changing the
+model, locale, or response language.
+
+For multilingual conversations, choose the matching approved voice per response locale.
+Do not send text in one language to a voice exposed only for another.
+
+## Generated project
+
+Keep supported locales, routing rules, and voice ids in code or checked-in configuration,
+not `.env`. The README must list the supported input and output languages and whether
+automatic detection is enabled.
+
+## Verify
+
+For every approved language:
+
+1. speak a short phrase and confirm cascaded ASR transcribes it, or Omni accepts it
+2. confirm the agent replies in the approved response language
+3. confirm TTS uses a discovered voice for that locale
+4. test one unsupported language and verify a clear fallback
+
+For automatic detection, also test consecutive turns in different languages and one
+code-switched turn only when the selected model claims that support.
+
+For language failures, use the Language section in `operations/troubleshoot.md`.

--- a/skills/create-voice-agent/references/models/llm.md
+++ b/skills/create-voice-agent/references/models/llm.md
@@ -1,0 +1,315 @@
+# LLM
+
+Cascaded Nemotron 3.5 Lightning (default), with Nemotron 3 Super / Ultra when named, plus
+Nemotron 3 Nano Omni for the Omni pipeline. Resolve before the proposal
+table. Self-hosted fit is mandatory. Cloud skips platform fit. Jetson Thor uses raw vLLM
+and follows `platforms/jetson-thor.md`. NIM profile selection below applies to workstation
+and DGX Spark.
+
+## Discover
+
+| Step | Where |
+| --- | --- |
+| Family browse | [NVIDIA Nemotron](https://developer.nvidia.com/topics/ai/nemotron#section-nvidia-nemotron-models) |
+| Confirm id / run | `build.nvidia.com/nvidia/<model>` · self-hosted: `?nim=self-hosted` |
+| Card / API | `…/<slug>/modelcard` · `docs.api.nvidia.com/nim/reference/nvidia-<slug>` |
+
+Examples: [Lightning cloud](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b) ·
+[self-hosted](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b?nim=self-hosted) ·
+[Super card](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard) ·
+[Super API](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-super-120b-a12b).
+
+**Omni** is the separate **Nemotron 3 Nano Omni** multimodal model (audio-native), not the
+cascaded text LLM and not a Lightning build. It is the only slot that keeps a Nano id.
+Exclude it from the cascaded LLM slot. Never interchange.
+
+Every card lists the languages the model supports, and that list is usually shorter than the
+speech coverage around it. Check the approved response language against it through
+`models/language-routing.md` §LLM before locking this slot.
+
+### Resolve three names
+
+The catalog slug, the container image, and the served model id are three different
+strings. Treating them as one causes `Access Denied` on pull and a wrong model id at
+request time.
+
+| Name | Source | Used by |
+| --- | --- | --- |
+| Container image | the self-hosted build page or NGC command that actually pulls | `compose.yaml` |
+| Profile / tags | `list-model-profiles` on the assigned GPU | `NIM_MODEL_PROFILE` |
+| Runtime model id | `GET /v1/models` after the service is healthy | agent code |
+
+The slug on `build.nvidia.com/nvidia/<slug>` records the proposal intent only. It is not
+proof of the image URI and not proof of the served id. Do not bake it into agent code
+until the listing returns a value. A raw vLLM card commonly passes
+`--served-model-name`, so the served id can be a short alias that matches neither the slug
+nor the repository name.
+
+Query the NIM port for self-hosted, or `https://integrate.api.nvidia.com/v1/models` for
+cloud. Drop `embed`, `guard`, and `vlm` entries. If nothing is up yet, use the cloud
+listing and re-check after start.
+
+## Reasoning (voice default: off)
+
+Model default is **on** (`enable_thinking: true` when omitted). That burns turn latency
+and can leak into TTS (`<think>`, silence, `redacted_thinking`).
+
+| Intake row | When |
+| --- | --- |
+| off (propose this) | normal voice agent |
+| on, budget 8192 | user asked hard multi-step / specialized. Warn if budget > 16384 |
+
+Verify on the locked model’s API ref, e.g.
+[Lightning](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-5-lightning-30b-a3b) ·
+[NIM reasoning](https://docs.nvidia.com/nim/large-language-models/latest/reasoning-model.html).
+
+The model's own build.nvidia.com page is the fastest check. Its prototype panel shows a
+runnable request for that exact model, including where the reasoning fields sit, e.g.
+[Lightning](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b). Read that example and the
+API reference before generating the request, because field names and nesting move between
+model generations.
+
+With an OpenAI-compatible SDK these provider fields travel in `extra_body`, which
+merges them into the top level of the request body. A raw HTTP call sets them at the
+top level directly. Passing `chat_template_kwargs` as a plain SDK keyword argument is
+the error, because the client rejects the unknown argument.
+
+```python
+# Off (voice default)
+extra_body = {"chat_template_kwargs": {"enable_thinking": False}}
+
+# On (table says so)
+extra_body = {
+    "chat_template_kwargs": {"enable_thinking": True},
+    "reasoning_budget": 8192,
+}
+```
+
+Prefer top-level `reasoning_budget` when the API lists it (some docs also nest it under
+`chat_template_kwargs`). When on, size completion tokens from the card's recommendation,
+because a thinking trace plus a spoken answer needs far more than a voice turn alone. Treat
+≥1024 as a floor rather than a target, and bound thinking with `reasoning_budget` instead of
+starving the answer. Pass `extra_body` the way the framework MCP documents. Do not
+invent the wrapper. Frameworks rarely accept a raw request dict, so see where the payload
+actually goes in `frameworks/pipecat.md` §Local LLM wiring or
+`frameworks/livekit.md` §NVIDIA models.
+
+Cloud still needs `enable_thinking` in `extra_body`. Sampling changes with the mode, and a
+card commonly gives separate values for reasoning, for reasoning off, and for tool calling,
+so take the set that matches the approved row rather than reusing one. Toggle = edit
+constants + restart, not mid-session, unless the framework docs say otherwise.
+
+### Reasoning parser
+
+A card's serve command is written for a reasoning-enabled endpoint, and its reasoning-off
+example changes only the request. The parser is a serve-time flag whose documented job is to
+move thinking out of `content` into a separate `reasoning_content` field. TTS reads
+`content`, so a parser left enabled with thinking off can deliver empty `delta.content`
+while the server reports success, and the agent goes mute with no error in any log.
+
+| Reasoning row | Serve flags |
+| --- | --- |
+| off (voice default) | omit the parser and its plugin file |
+| on | enable the parser the locked card names, and keep `reasoning_content` away from TTS |
+
+Dropping the parser is the one sanctioned removal from a card's launch command (§Serve
+flags). Parser names and plugin requirements are not shared across this family, so read the
+row for the exact model and server you actually run:
+
+| Locked model and server | Currently documented |
+| --- | --- |
+| Cascaded Lightning on vLLM | `--reasoning-parser nemotron_v3` (built-in, no plugin file) |
+| Omni NVFP4 on vLLM | `--reasoning-parser nemotron_v3` |
+
+Both add `--enable-auto-tool-choice --tool-call-parser qwen3_coder`. When a card names a
+separate parser-plugin file, it must be downloaded and present before the server starts.
+Confirm the parser and any plugin from the model card for the server you run, and never
+adapt a vLLM row for a different server such as SGLang.
+
+Prove the result on the streaming endpoint. `scripts/smoke.sh` asserts non-empty
+`delta.content` and empty or absent `delta.reasoning_content` (`output-contract.md`
+§Smoke before client). One non-streaming answer does not prove it.
+
+## Serve flags
+
+Every serve-time flag must trace to one of three sources: the locked model card, the memory
+controls in §Tight fit, or a fatal log line that names the flag. Nothing else belongs on the
+command line.
+
+Performance and scheduling flags are the usual trap. Reaching for eager mode, a scheduling
+toggle, or CUDA MPS variables to chase a slow or unstable first boot adds variables while the
+real cause is normally an engine build, a kernel compile, or the memory budget. Each
+speculative flag then has to be reverted, and a revert is indistinguishable from a fix.
+
+When a flag looks necessary, name the log line that requires it, change that one thing, and
+rerun `scripts/smoke.sh` before touching anything else.
+
+## Platform fit (self-hosted)
+
+Hardware first from `preflight.md`. Never propose model / precision / TP until verified
+for the probed GPU.
+
+### 1. Support matrix HTML
+
+Fetch HTML only (not UI dropdowns, not `.html.md`):
+
+`https://docs.nvidia.com/nim/large-language-models/latest/reference/support-matrix.html`
+
+Match rows via `data-model`, `data-precision`, `data-tp`, `data-gpus`. Normalize the
+probed name (`NVIDIA H100 80GB HBM3` → `NVIDIA-H100-80GB-HBM3`). Keep a row only when
+short name, precision, and SKU all match. No row → unsupported. Pick another precision,
+TP, model, or cloud. Do not guess a close SKU.
+
+| Model | Section |
+| --- | --- |
+| Lightning | [#nemotron-3-5-lightning-30b-a3b](https://docs.nvidia.com/nim/large-language-models/latest/reference/support-matrix.html#nemotron-3-5-lightning-30b-a3b) |
+| Super | [#nemotron-3-super-120b-a12b](https://docs.nvidia.com/nim/large-language-models/latest/reference/support-matrix.html#nemotron-3-super-120b-a12b) |
+| Ultra | [#nemotron-3-ultra-550b-a55b](https://docs.nvidia.com/nim/large-language-models/latest/reference/support-matrix.html#nemotron-3-ultra-550b-a55b) |
+
+“Verified GPUs” under a section is overall. It does not replace per-row `data-gpus`.
+
+### 2. `list-model-profiles` and `NIM_MODEL_PROFILE`
+
+Before proposal, use the support matrix to select a candidate profile and mark shared-GPU
+fit provisional. After the user approves self-hosting and container readiness passes, run
+`list-model-profiles` on that NIM for the probed GPU. Pin the exact result before
+generating Compose. This is mandatory on every workstation / DGX Spark NIM LLM
+deployment. Buckets:
+
+```bash
+docker run --rm --gpus=all <nim_llm_image> list-model-profiles
+```
+
+Replace `all` with the exact planned GPU assignment when the LLM is pinned. Copy
+`<nim_llm_image>` from the current self-hosted build page. Do not infer the image or tag.
+
+| Bucket | Action |
+| --- | --- |
+| Compatible | use it |
+| Low memory | apply the suggested `--max-model-len` / `NIM_MAX_MODEL_LEN` if the user accepts |
+| Incompatible | use lower precision on the same image, or a smaller LLM |
+
+Prefer the smallest Compatible precision that fits (nvfp4 > mxfp4 > w4a16 > fp8 > bf16)
+unless the user asked for a heavier one. On a local GPU under ~90 GB, prefer Compatible
+nvfp4 when listed. Do not default to a heavier precision if a lighter one is Compatible.
+
+Set `NIM_MODEL_PROFILE` in the launch environment to one of:
+
+- a description such as `vllm-nvfp4-tp1-pp1` (pattern:
+  `<backend>-<precision>-tp<N>-pp1`, backend `vllm` | `sglang` | `trtllm`)
+- the 64-char profile id from the listing
+- leave unset / `default` only when you intentionally want manifest auto-pick
+
+Never use `NIM_TAGS_SELECTOR` on the LLM. Cloud LLM skips this section. For same-image
+OOM or latency, re-run `list-model-profiles`, pin a lighter profile or shorter max length,
+update the launch command, then health-check. A different model id requires discovery
+again.
+
+On a shared GPU, never leave profile selection at `default`. Pin the exact Compatible
+profile and verify startup logs report the expected backend and precision. A profile being
+Compatible means the LLM can run on that GPU. It does not mean LLM + ASR + TTS fit
+together.
+
+Docs:
+[model profiles and selection](https://docs.nvidia.com/nim/large-language-models/latest/deployment/model-profiles-and-selection.html).
+
+### 3. Precision + weights (planning only)
+
+Matrix / container win over these hints.
+
+| GPU | Precision default |
+| --- | --- |
+| Blackwell | NVFP4 when supported by the locked model path |
+| Ada / Hopper (CC ≥ 8.9) | NVFP4 when Compatible, else the lightest Compatible profile (W4A16 for Lightning, FP8 for Super / Ultra) |
+| Ampere and older | W4A16 for Lightning, otherwise BF16 (large, often needs its own GPU) |
+
+Precision is a tag inside `NIM_MODEL_PROFILE` (e.g. `vllm-bf16-tp1-pp1`), not a separate
+env. The Compatible profile listing wins over this planning table. Lightning NVFP4 requires
+Blackwell (SM 10.0+), so Ampere and Hopper hosts use W4A16 rather than FP8. Read the row
+rather than assuming a precision exists.
+
+| Slot | Weights (est.) |
+| --- | --- |
+| Lightning NVFP4 | ~19 GB |
+| Lightning W4A16 | ~19 GB |
+| Lightning BF16 | ~63 GB |
+| Omni 30B NVFP4 | ~15 GB (ASR in-process) |
+
+The support matrix lists exact min VRAM per GPU per precision and TP; use it over these
+estimates. Super / Ultra: on one workstation GPU, say they will not fit. Offer Lightning
+local or that model in the cloud. Do not silently substitute.
+
+### 4. Tight fit
+
+Apply this section to every shared single-GPU layout, not only after an OOM.
+
+| Deployment path | Knobs | Source |
+| --- | --- | --- |
+| Workstation / DGX NIM | `NIM_MAX_MODEL_LEN`, documented runtime memory limit | current NIM environment and memory troubleshooting docs |
+| Raw vLLM, including Jetson Thor | `--gpu-memory-utilization`, `--max-model-len` | locked Hugging Face model card for the required flags, [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) for their meaning and current defaults |
+
+Both server paths fill their runtime budget with KV cache after weights and overhead. The
+documented default fraction is 0.9 or higher on each path, which can starve co-located
+speech even when quantized weights are small, so read the exact current default from the
+source in the table.
+
+On raw vLLM that fraction is per-instance and measured against total device memory. The
+reference states it does not account for memory another process already holds, so a
+co-located speech container does not lower it. Derive the fraction from the budget below
+rather than expecting vLLM to leave room.
+
+Before first start:
+
+1. re-read free VRAM immediately before launch, including other GPU processes
+2. calculate `LLM budget = current free VRAM - startup reserve` minus the reserve of every
+   speech slot placed on this GPU, which is TTS plus ASR for Cascaded and TTS alone for
+   Omni. Slots in the cloud or on another GPU take nothing from this budget
+3. reject co-location when that budget cannot hold the selected build's weights, runtime
+   overhead, and a usable KV cache. Move a slot instead, or take a lighter build, which
+   is a smaller Compatible profile on NIM and a lighter quantization from the locked card
+   on raw vLLM
+4. set the context to the smallest value that satisfies the approved use case, through
+   `NIM_MAX_MODEL_LEN` on NIM or `--max-model-len` on raw vLLM
+5. cap runtime memory so the server cannot exceed `LLM budget`, which as a fraction is no
+   higher than `LLM budget / total GPU memory`:
+   - NIM: pin the exact `NIM_MODEL_PROFILE`, then take exactly one control from the
+     selected image's current docs, either `--gpu-memory-utilization` passed through
+     `NIM_PASSTHROUGH_ARGS` or `NIM_KVCACHE_PERCENT` when that image documents it
+   - raw vLLM: pass `--gpu-memory-utilization` directly, or an absolute KV cache size
+     when the current reference documents one
+
+Never set both runtime memory controls. Do not copy either value from another image or
+model version.
+If the calculated cap leaves no usable KV cache, the layout does not fit. Do not keep
+lowering the cap to force co-location.
+
+On a shared single GPU the chosen control is **required in the generated `compose.yaml`**,
+not a troubleshooting step applied after an OOM. Derive its value from the budget above
+rather than reusing a number. Leaving the container default in place is what lets the LLM
+take the whole device and starve TTS and ASR.
+
+At deployment, verify the measured budget before each service starts. NIM uses
+`platforms/deployment.md` §Shared-GPU memory gate. Raw vLLM on Jetson Thor uses the
+unified-memory check in `platforms/jetson-thor.md` §Start and verify. Do not let TTS
+discover an invalid LLM budget through repeated OOM restarts.
+
+Sources:
+[environment variables](https://docs.nvidia.com/nim/large-language-models/latest/reference/environment-variables.html) ·
+[GPU memory troubleshooting](https://docs.nvidia.com/nim/large-language-models/latest/troubleshooting/memory.html) ·
+[vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/).
+
+Do not choose a knob from the pipeline name. Choose it from the actual server path.
+
+## Anti-patterns
+
+- Voice agent with reasoning left at model default (on).
+- Reasoning parser or plugin left enabled while the reasoning row is off.
+- Adding a serve flag the card does not list and no fatal log demands.
+- `chat_template_kwargs` passed as a plain SDK argument rather than through `extra_body`.
+  Reasoning flags in `.env`.
+- Reasoning on locally without the reasoning parser and plugin file the card requires.
+- Cascaded slot → omni model. Model ids in `.env`.
+- Propose from memory / Verified GPUs list alone. Click matrix UI or use `.html.md` for fit.
+- Override a failed matrix / `list-model-profiles` check. Guess a SKU. `NIM_TAGS_SELECTOR` on LLM.
+- Treat quantized weight size as total LLM VRAM or leave vLLM at its default memory budget
+  while co-locating speech.

--- a/skills/create-voice-agent/references/models/tts.md
+++ b/skills/create-voice-agent/references/models/tts.md
@@ -1,0 +1,88 @@
+# TTS
+
+Magpie and other TTS models on the live Speech matrix. Docs first. Never invent the
+roster from memory.
+
+Do not use the LLM support matrix, `list-model-profiles`, or `NIM_MODEL_PROFILE` here.
+Jetson Thor uses Riva L4T TTS selected from its ARM64 quickstart, not Magpie Speech NIM.
+See `platforms/jetson-thor.md`.
+
+## Discover
+
+| Step | Where | Why |
+| --- | --- | --- |
+| Roster + tags + VRAM | [TTS support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html) | every model, `CONTAINER_ID`, `NIM_TAGS_SELECTOR`, GPU memory |
+| Confirm | `build.nvidia.com/nvidia/<slug>` | function id, card, languages |
+| Deploy copy | `build.nvidia.com/nvidia/<slug>/deploy` | image, docker run, env. Example: [magpie-tts-multilingual/deploy](https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy) |
+| Voice discovery | [HTTP TTS API reference](https://docs.nvidia.com/nim/speech/latest/reference/api-references/tts/http-tts.html) | voice-list path and response shape. Currently `GET /v1/audio/list_voices` |
+
+Index: [NVIDIA Speech NIM](https://docs.nvidia.com/nim/speech/latest/index.html).
+Resolve response locale and multilingual routing through `models/language-routing.md`.
+For domain pronunciations, also follow `domain/speech-customization.md` and verify the
+locked model against the current customization docs.
+
+If the user says “Magpie” without a variant, open the matrix and propose one concrete row.
+Do not pick silently.
+
+## Defaults (hints only)
+
+| Need | Start from | Then open |
+| --- | --- | --- |
+| Default voice agent TTS | Magpie TTS Multilingual, `batch_size=8` | [#magpie-tts-multilingual](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html#magpie-tts-multilingual) + [deploy](https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy) |
+
+Re-check the matrix before the proposal table. After startup, choose only a locale and
+voice returned by the running service's documented voice-discovery API.
+
+## Sizing
+
+Planning estimates only. Authoritative GPU memory is the chosen row on the
+[TTS support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html).
+
+| Profile | Weights |
+| --- | --- |
+| Magpie TTS Multilingual, `batch_size=8` (default) | about 13 GB |
+| Magpie TTS Multilingual, `batch_size=32` | about 41 GB |
+| Magpie TTS Zeroshot, `batch_size=8` (default) | about 13 GB |
+| Magpie TTS Zeroshot, `batch_size=32` | about 41 GB |
+
+Self-hosted floor: compute capability 8.0+, ≥16 GB VRAM for the speech NIM. Selection is
+`NIM_TAGS_SELECTOR` (not `NIM_MODEL_PROFILE`).
+
+Batch size is the TTS memory profile, not only a throughput knob. On a shared single-GPU
+layout, select the smallest documented batch profile that satisfies the use case and
+write it explicitly into `NIM_TAGS_SELECTOR`. For Magpie TTS Multilingual that is
+currently `batch_size=8`, which is also the documented default. Write it anyway, so a
+future image default cannot silently change the reservation. Larger batches belong on a
+dedicated GPU unless the runtime budget proves they fit.
+
+After the profile fits this GPU, check the combined stack in `preflight.md` §Deployment
+fit. Reserve the matrix GPU memory plus startup and engine-build headroom. Verify measured
+free VRAM through `platforms/deployment.md` §Shared-GPU memory gate.
+
+## Lock self-hosted
+
+1. From the matrix section: `CONTAINER_ID` + `NIM_TAGS_SELECTOR` for language, batch size,
+   VRAM. On a shared GPU, choose the smallest supported batch profile and include the
+   batch tag explicitly. Tag strings, not LLM profile hashes.
+2. Cross-check image and environment on `/deploy` using the precedence in
+   `models/catalog.md`.
+3. Apply the sizing floor above, then stack fit in `preflight.md`.
+4. Languages only from the matrix. Do not invent a locale.
+5. Cloud: function id from the build page. Self-hosted: leave function id empty. Never
+   look up a speech function id in `/v1/models`.
+6. Voice id: after the TTS service is up, query its voice list and lock a voice from that
+   response before handover. Speech NIM currently serves `GET /v1/audio/list_voices`, while
+   raw Riva exposes
+   [`GetRivaSynthesisConfig`](https://docs.nvidia.com/nim/speech/latest/reference/api-references/tts/protos.html)
+   through its client instead. Confirm the path on the API reference above before calling
+   it, because a near miss such as `/v1/audio/voices` returns 404 and reads like a mute
+   service. Record the path in the README and smoke script, and never hardcode a voice the
+   service did not return.
+
+## Anti-patterns
+
+- Treating “Magpie” as one model without checking the matrix.
+- Skipping the TTS matrix for a remembered build.nvidia.com slug.
+- Leaving batch size implicit or selecting it without the combined runtime budget.
+- Setting a function id on self-hosted TTS.
+- Hardcoding a voice id before querying the running service.

--- a/skills/create-voice-agent/references/networking/remote-webrtc.md
+++ b/skills/create-voice-agent/references/networking/remote-webrtc.md
@@ -1,0 +1,108 @@
+# Remote WebRTC
+
+Read when the browser and Pipecat agent are on different machines or networks. Localhost
+testing does not prove remote media will work.
+
+## Choose the path
+
+| Situation | Path |
+| --- | --- |
+| Same machine or trusted LAN | direct WebRTC with STUN |
+| Remote GPU over SSH | tunnel signaling, then use reachable ICE candidates |
+| NAT or restrictive firewall | coturn as TURN relay |
+| UDP unavailable and TURN is not ready | WebSocket fallback |
+| LiveKit Cloud | use LiveKit's documented connectivity path, not this Pipecat setup |
+
+An SSH tunnel can carry HTTPS or WebSocket signaling. It does not make the remote GPU
+host's UDP media reachable. WebRTC still needs a direct ICE path or TURN.
+
+## Source of truth
+
+Read the current Pipecat
+[Small WebRTC ICE configuration](https://docs.pipecat.ai/api-reference/server/services/transport/small-webrtc)
+and [runner guide](https://docs.pipecat.ai/api-reference/server/utilities/runner/guide)
+before generating code.
+
+The development runner can add its default public STUN server, but it cannot inject a
+custom TURN server from `bot.py`. For coturn, generate a signaling server that creates
+`SmallWebRTCConnection` with the documented `ice_servers` configuration. Do not patch a
+TURN URL into the default runner and assume it is used.
+
+## coturn
+
+Run coturn on a host reachable from both browser and agent. Follow the current coturn and
+network-provider documentation for installation and hardening. Configure:
+
+- public DNS or IP advertised by the TURN server
+- authenticated, expiring credentials where possible
+- UDP and TCP TURN listeners
+- TLS TURN on a firewall-friendly port for restrictive networks
+- a relay port range opened in the host and cloud firewalls
+
+Do not ship a static coturn password, config, or compose file in this skill. Keep TURN
+credentials in `.env` placeholders and load them into the signaling layer. Keep public
+TURN URLs in generated code or config with other endpoints.
+
+Use `turn:` for UDP/TCP relay candidates and `turns:` for TLS according to the current
+deployment. Prefer direct or UDP relay candidates. TCP/TLS relay is a compatibility
+fallback and adds latency.
+
+## Generated project
+
+When custom TURN is selected, `output-contract.md` must produce:
+
+- `signaling_server.py` using the current documented `ice_servers` API
+- matching browser and server ICE configuration
+- TURN username and credential placeholders in `.env.example`
+- exact HTTPS signaling/client startup instructions in the README
+- a relay-only verification step that is disabled again after testing
+
+`signaling_server.py` owns the HTTPS listener, browser client route, ICE configuration,
+and WebRTC session creation. Keep pipeline construction in `bot.py` as an importable
+factory when the current Pipecat docs support that shape. Do not start the default runner
+and the custom signaling server as competing listeners.
+
+For custom TURN, the README startup order is:
+
+1. start or verify coturn
+2. start `signaling_server.py`
+3. open the HTTPS client URL served by that process
+
+Do not start `bot.py` as a second process unless the current Pipecat architecture
+explicitly requires it and the README documents how the processes communicate.
+
+Generate a coturn Compose service only when this project owns the TURN deployment, and
+derive it from current coturn deployment documentation. Otherwise document the external
+TURN endpoint. Do not duplicate infrastructure the user already has.
+
+## Browser security
+
+Remote microphone access requires a secure browser context. Serve the client and signaling
+endpoint over HTTPS with a valid certificate. `localhost` is the development exception.
+Do not tell the user to bypass browser security warnings for production.
+
+## WebSocket fallback
+
+Keep WebSocket available when intake selected both transports. It is a useful fallback
+when corporate networks block UDP, but it is not a TURN replacement for WebRTC.
+
+For an SSH-only development path, forward the agent's HTTP/WebSocket port and use the
+WebSocket transport. Do not claim that an HTTP tunnel makes WebRTC media remote-safe.
+
+## Verify
+
+1. Direct LAN WebRTC succeeds.
+2. A remote browser receives ICE candidates.
+3. Test through a network where direct peer-to-peer traffic is unavailable.
+4. Confirm the selected candidate type is `relay` during the TURN test.
+5. Confirm bidirectional audio, not only signaling.
+6. Return to normal ICE policy after the relay-only test.
+7. Complete the spoken exchange in `operations/run.md`.
+
+## Anti-patterns
+
+- Exposing only the signaling port and assuming media uses it.
+- Putting coturn credentials in source code.
+- Using the default Pipecat runner while claiming custom TURN is configured.
+- Forcing relay-only mode for every production user.
+- Treating WebSocket and TURN as the same transport mechanism.

--- a/skills/create-voice-agent/references/operations/iterate.md
+++ b/skills/create-voice-agent/references/operations/iterate.md
@@ -1,0 +1,92 @@
+# Iterate
+
+Use for changes to an existing working agent. Preserve the working baseline, change one
+layer, then repeat the spoken exchange.
+
+If the agent is already broken, start with `operations/troubleshoot.md`. Do not mix a
+repair with an enhancement.
+
+## 1. Read the current project
+
+Read the agent file, dependency file, `.env.example`, and any deployment instructions.
+Identify the current framework, pipeline, model ids, endpoints, and platform before
+proposing a change.
+
+Never overwrite `.env` or read secrets into the response.
+
+## 2. Route the change
+
+| Change | Reopen | Approval |
+| --- | --- | --- |
+| Prompt, persona, response style | `domain/agent-behavior.md` + framework docs MCP | no new intake table |
+| Reasoning | `models/llm.md` | confirm when turning on |
+| LLM, ASR, TTS, language, or voice | matching model file + `models/language-routing.md` when relevant | show changed row and dependent rows |
+| Domain glossary, boosting, or pronunciation | `domain/speech-customization.md` | show and confirm every changed term |
+| Transport or turn handling | selected framework file + docs MCP | confirm user-visible behavior |
+| Logs or latency metrics | `operations/observability.md` + framework docs MCP | no new intake table |
+| Cloud / self-hosted / GPU placement | `preflight.md` + `platforms/deployment.md` | confirm deployment row |
+| Cascaded / Omni | `intake.md` + selected framework files | confirm all changed rows |
+| Pipecat / LiveKit | `intake.md` + both framework files | full framework confirmation |
+| Hardware platform | `preflight.md` + routed platform guide | rerun probe and deployment fit |
+
+Do not repeat the full intake for a local change. Reopen only the affected row and
+anything it changes downstream.
+
+## 3. Revalidate dependencies
+
+- Re-query the framework documentation MCP before changing framework imports, classes,
+  settings, or pipeline structure.
+- Rediscover model ids and deployment instructions. Do not reuse a remembered id, image,
+  profile, or tag.
+- Recheck credentials only when the change adds a provider, framework, or model source.
+- Keep healthy local services running unless their model, profile, tags, or endpoint must
+  change.
+
+## Cascading changes
+
+- LLM swap: workstation / DGX NIM reruns the support matrix and
+  `list-model-profiles`. Cloud rechecks model id/API. Jetson Thor reopens the vLLM model
+  card. Then revisit reasoning and stack fit.
+- ASR swap: keep streaming first and recheck language, tags, and deployment fit.
+- TTS or language change: restart TTS when required, then query its voice-discovery API
+  again.
+- Cascaded to Omni:
+  - copy current `nvidia_omni_multimodal_service.py` and
+    `audio_only_smart_turn_strategy.py`
+  - remove ASR from agent wiring and add the Omni turn and initial-mute strategies
+  - replace local `llm` + `asr` Compose services with `omni`, retaining `tts`
+  - recalculate Omni + TTS fit
+- Omni to cascaded:
+  - add streaming ASR and the documented text LLM service
+  - remove Omni-only turn strategies and imports
+  - replace local `omni` with `llm` + `asr`, retaining `tts`
+  - remove unmodified copied Omni files when they are no longer imported
+  - preserve and disclose any user-modified Omni file
+- Deployment change: update code constants, generated Compose, and README through
+  `output-contract.md`. `.env` remains secrets only.
+
+## 4. Apply the smallest change
+
+Prefer a documented runtime setting update when the framework supports it. Otherwise
+restart only the affected agent or model service. Rebuild the pipeline when its framework
+or shape changes.
+
+Do not regenerate unrelated files, reset user edits, or replace working services.
+
+## 5. Verify
+
+1. Check readiness for every changed local service.
+2. Update `scripts/smoke.sh` for the new shape and run it.
+3. Start the agent.
+4. Verify the changed behavior.
+5. Complete the full spoken exchange in `operations/run.md`.
+6. If verification fails, use `operations/troubleshoot.md` and keep the failure scoped to
+   this change.
+
+## Anti-patterns
+
+- Editing framework APIs from memory.
+- Changing several layers before testing.
+- Treating an enhancement as permission to rewrite the project.
+- Changing an approved model or deployment silently.
+- Declaring success without a spoken exchange.

--- a/skills/create-voice-agent/references/operations/observability.md
+++ b/skills/create-voice-agent/references/operations/observability.md
@@ -1,0 +1,84 @@
+# Observability
+
+Apply to every generated project. Logs must show where one spoken turn failed and where
+latency was spent without exposing secrets or private audio.
+
+## Use documented hooks
+
+Query the selected framework documentation MCP for its current logging, observer, metrics,
+and error hooks. Use those APIs rather than intercepting internal frames or inventing
+framework methods.
+
+## Structured events
+
+Emit machine-readable key-value or JSON logs to stdout. Every event should include:
+
+- timestamp, level, and stable event name
+- pipeline (`cascaded` or `omni`)
+- transport label
+- stage (`asr`, `omni`, `llm`, `tts`, or transport)
+- per-turn correlation id when a turn exists
+- endpoint label and model id for model requests
+- duration in milliseconds for completed timed events
+
+An endpoint label identifies `cloud`, `llm-local`, `asr-local`, `tts-local`, or
+`omni-local`. Do not log credentials, signed URLs, authorization headers, raw audio, or
+endpoint query strings. Transcripts and reply text are off by default. Enable them only
+with explicit user approval.
+
+## Startup
+
+Log:
+
+1. application and framework version
+2. approved pipeline, transport, models, and local/cloud placement
+3. each service readiness check and selected model id
+4. transport initialization and client connection
+5. agent-ready only after every required dependency is ready
+
+Keep Compose service logs on stdout/stderr. Put
+`docker compose logs --timestamps <service>` and the generated service names in the
+README.
+
+## Turn timings
+
+Capture monotonic timestamps and emit durations for:
+
+| Pipeline point | Event |
+| --- | --- |
+| user speech | start and completed turn |
+| streaming ASR | first partial and final transcript |
+| LLM / Omni | request start, first token, response complete |
+| TTS | request start, first audio, audio complete |
+| output transport | first audio sent and turn complete |
+
+At minimum report end-of-user-turn to first assistant audio and full turn duration.
+Cascaded runs must separate ASR, LLM, and TTS. Omni runs replace ASR + LLM with one Omni
+stage but still report request-to-first-token and request completion.
+
+Use monotonic time for durations and wall-clock time only for log timestamps. Do not infer
+server compute time when only client-side timing is available. Label it as observed
+latency.
+
+## Exceptions
+
+Log the full traceback for unexpected exceptions, including background tasks and startup
+failures. Add stage, endpoint label, model id, and turn id as context, then preserve the
+original exception.
+
+Expected transient failures may retry only when the framework or provider documents that
+behavior. Log each retry and the terminal failure. Never catch an exception only to print
+its message and continue with a silent broken stage.
+
+## Handover
+
+The README must state:
+
+- how to enable the project's documented debug mode
+- how to view agent and Compose service logs
+- which latency events prove each pipeline stage ran
+- that transcript logging can contain sensitive data
+- when to open `operations/troubleshoot.md`
+
+Before handover, trace one spoken exchange under one turn id and confirm every expected
+stage event appears in order.

--- a/skills/create-voice-agent/references/operations/run.md
+++ b/skills/create-voice-agent/references/operations/run.md
@@ -1,0 +1,97 @@
+# Run
+
+The last step. Start the stack, prove audio flows in both directions, and leave the user
+able to do it without you.
+
+Do not declare success because a process started. A voice agent can come up cleanly and
+still be deaf or mute, so the finish line is a spoken exchange, not a running port.
+
+## Order
+
+Services first, agent last. An agent pointed at a NIM that is still loading fails in a way
+that reads like a model or credential problem, which sends the user chasing the wrong bug.
+
+Cloud runs have no services to start, so they go straight to smoke and then the agent.
+
+## Cloud
+
+The user copies `.env.example` to `.env` and fills in their own key. Never do this for
+them, and never write a real key to disk.
+
+Then sync dependencies. Anything missing from `.env` surfaces as an authentication failure
+rather than a crash, so read the error before assuming the pipeline is wrong.
+
+## Self-hosted
+
+Start or reuse local model services and wait for readiness exactly as
+`platforms/deployment.md` or the selected platform guide defines. Use the generated Compose
+services and commands in the project README. Move on only after every local slot is ready.
+
+A speech service's first start can sit at `starting` for a long time while it downloads
+models and builds an engine. Read its logs rather than restarting it. See
+`platforms/deployment.md` §First boot takes much longer.
+
+## Smoke
+
+Run `scripts/smoke.sh` before the agent starts: on self-hosted or hybrid, once every local
+service is healthy; on cloud, as soon as dependencies are installed, since there are no
+local services to wait on. It proves the locked model answers on the streaming endpoint, the
+locked voice speaks and is transcribed back, and the agent's own services construct. Cloud
+and hybrid layouts run it against their configured endpoints. A silent connect failure in the browser is far more
+expensive to diagnose than this script, so do not skip it to save a minute.
+
+Fix whatever it reports through `operations/troubleshoot.md` and run it again. Only a
+passing run earns a client connection.
+
+## Connect
+
+Pipecat's runner serves a client at `/client`. Use `localhost` when the browser and agent
+are on the same machine, and the host address when they are not. For LiveKit, follow
+`frameworks/livekit.md` §Connect and verify: open the LiveKit project that matches `.env`
+`LIVEKIT_URL`, refresh Agents, and select the worker. A worker's local HTTP or health port
+is never a client URL.
+
+When the transport row said both, `GET /status` lists what actually registered, and the
+client can switch between them. If `/status` names only one transport, the runner was
+started with `-t` when it should not have been. See `frameworks/pipecat.md`.
+
+For remote Pipecat browsers, NAT, coturn, or a separate GPU host, follow
+`networking/remote-webrtc.md`. For LiveKit, use its current connectivity docs.
+
+## Prove it works
+
+Speak and verify the selected pipeline:
+
+- Cascaded: transcript appears → LLM reply is generated → TTS speaks it back.
+- Omni: user audio produces an Omni reply → TTS speaks it back. A user transcription is
+  optional.
+
+The spoken reply must also pass `domain/agent-behavior.md`. Trace the exchange under one
+turn id and confirm the stage events in `operations/observability.md`.
+
+The first failed stage identifies the broken slot.
+Use `operations/troubleshoot.md` for the symptom-first path.
+
+## Stop
+
+Interrupt the agent, then use the generated README to stop the Compose services you
+started. Leaving them running holds the GPU and ports, which can make a later start fail
+to bind.
+
+## Hand over
+
+Leave the user with five things, written down rather than implied.
+
+- How to start, check health and logs, and stop it through the generated README.
+- Where the model ids and endpoints live in the project, which is the code, not `.env`.
+- Which credentials `.env` needs, and that it is theirs to fill.
+- `operations/troubleshoot.md` as the debugging entry point.
+- `operations/iterate.md` for future changes.
+
+## Anti-patterns
+
+- Starting the agent before the services report ready.
+- Opening a client before `scripts/smoke.sh` passes.
+- Treating a running process as a working agent.
+- Writing a real credential into `.env` on the user's behalf.
+- Leaving the stack running with no stop instructions.

--- a/skills/create-voice-agent/references/operations/troubleshoot.md
+++ b/skills/create-voice-agent/references/operations/troubleshoot.md
@@ -1,0 +1,174 @@
+# Troubleshoot
+
+Use after `operations/run.md` fails to complete a spoken exchange. Diagnose the first
+broken stage. Do not change multiple layers at once.
+
+## Method
+
+1. Read the generated agent code and structured events from
+   `operations/observability.md`.
+2. Confirm every required local service is ready.
+3. Trace one turn in order:
+
+```text
+cascaded: client → transport → turn detection → ASR → LLM → TTS → transport → client
+omni:      client → transport → turn detection → Omni → TTS → transport → client
+```
+
+4. Query the selected framework's documentation MCP before changing framework APIs.
+5. Make one minimal fix, restart the affected process, and repeat `operations/run.md`.
+
+Do not add a serve flag the model card does not list unless a fatal log names it
+(`models/llm.md` §Serve flags). A speculative flag has to be reverted later, and the revert
+looks exactly like a fix.
+
+## Quick index
+
+| Symptom | Check first |
+| --- | --- |
+| Agent does not start | traceback, missing package, credential |
+| Local model service is unhealthy | locked image/profile/tags, memory, platform guide |
+| Speech service stuck starting on first boot | download and engine-build logs, cache mount |
+| LLM is healthy but TTS / ASR OOM | LLM profile, context, runtime memory cap, TTS batch |
+| Smoke fails constructing a service | API-key argument, `extra_body` shape, framework file |
+| Agent runs and stays mute with no error | reasoning parser enabled while reasoning is off |
+| Browser does not connect | framework client path, microphone permission, transport |
+| User speech is not detected | input audio frames, VAD, end-of-turn |
+| No transcript (cascaded) | streaming ASR endpoint and language |
+| Wrong input or reply language | `models/language-routing.md` |
+| No reply | LLM/Omni endpoint, model id, request error |
+| Reply text exists but no audio | TTS readiness, voice id, output transport |
+| Reply is verbose or speaks markup/internal data | `domain/agent-behavior.md` |
+| Domain term is wrong | approved glossary, model support, boost or IPA wiring |
+| Slow response | stage timings, reasoning, ASR mode, model fit |
+| Cannot interrupt | VAD, user-turn strategy, interruption frames |
+
+## Startup and services
+
+- Docker, Compose, in-container GPU, or cache-path failure: rerun
+  `platforms/readiness.md` before changing model configuration.
+- Authentication or image-pull failure: re-check `preflight.md` credentials. Never print
+  a secret.
+- Wrong workstation / DGX NIM LLM profile: rerun `list-model-profiles` and follow
+  `models/llm.md`. Cloud checks model id/API. Jetson Thor checks its vLLM model card and
+  serve flags.
+- Wrong workstation / DGX Speech tags: reopen the ASR or TTS matrix and locked `/deploy`
+  page. Jetson Thor checks its Riva `config.sh`.
+- Speech service still `starting` or `unhealthy` on first boot: read the logs before
+  changing anything. Model download and TensorRT engine building routinely take 15 to 30
+  minutes or more, and a restart discards that work. See `platforms/deployment.md` §First
+  boot takes much longer. Treat it as a failure only on process exit, a fatal log such as
+  CUDA OOM, or stalled progress past the documented window.
+- Speech HTTP ready but deaf or mute: query `GetRivaSpeechRecognitionConfig` or
+  `GetRivaSynthesisConfig` and compare the loaded model, language, and voice with the lock.
+  On Speech NIM TTS, also call the voice-list path from its current TTS API reference and
+  confirm the locked voice is actually returned. A wrong or near-miss path returns 404 or
+  an empty list, which looks like a mute service.
+- OOM on workstation / DGX: stop the failing service. Compare actual per-process GPU use
+  with the budget in `preflight.md`. Verify the LLM loaded the pinned quantization profile,
+  then reduce its documented runtime memory cap or `NIM_MAX_MODEL_LEN`. Confirm TTS uses
+  the smallest approved explicit batch profile. Restart one service at a time through the
+  memory gate in `platforms/deployment.md`, or move one slot to cloud. Do not silently
+  change the approved model.
+- LLM fails with no available KV cache blocks: its cap is too low for that profile. Do not
+  reduce it again. Use a smaller Compatible profile, raise the cap only when speech
+  reserves still fit, or move a slot to another GPU or cloud.
+- OOM on Jetson Thor: lower `--max-model-len` first, then the memory fraction, and restart
+  vLLM. Follow `platforms/jetson-thor.md`.
+- vLLM will not start on Thor while the host looks like it has memory: compare Linux free
+  memory with available memory. The startup check has been observed to read free memory, so
+  page cache left by downloads and engine builds can block it. Reclaim cache rather than
+  shrinking the model configuration. See `platforms/jetson-thor.md` §Host memory at startup.
+- vLLM on Thor sits silent for a long first boot: look for `nvcc` and `cicc` compile
+  output, which is the NVFP4 kernel compile and not a hang. See `platforms/jetson-thor.md`
+  §First boot compiles kernels.
+- Riva on Thor cannot read its models: assert where `riva_init.sh` actually wrote the
+  repository and whether it is root-owned, then check that the Enterprise variables are all
+  set or all unset. See `platforms/jetson-thor.md` §Model path and credentials.
+- Reply text never reaches TTS and no log shows an error: the reasoning parser is splitting
+  output into `reasoning_content` while thinking is off. Omit the parser and its plugin,
+  then reassert streaming `delta.content` through `scripts/smoke.sh`. See `models/llm.md`
+  §Reasoning parser.
+
+## Input and transport
+
+First confirm the client has microphone permission and the agent receives audio frames.
+Then confirm VAD sees speech and emits a completed user turn.
+
+- Pipecat: check `/status`, the selected transport, and the runner flags in
+  `frameworks/pipecat.md`.
+- LiveKit: check worker connection, room/participant events, and the current Agents
+  console flow from the LiveKit docs MCP.
+- Pipecat ICE, TURN, NAT, browser, or one-way-audio issue: follow
+  `networking/remote-webrtc.md` before changing network configuration.
+
+## Cascaded pipeline
+
+If VAD sees speech but no transcript appears:
+
+1. verify the ASR service independently
+2. confirm the agent points at its gRPC endpoint
+3. confirm the locked profile is streaming
+4. confirm its language matches the request
+
+If a transcript appears but no reply follows, inspect the LLM request and response. Check
+the base URL, exact model id, authentication, and reasoning payload from `models/llm.md`.
+
+If only domain terms fail, reopen `domain/speech-customization.md`. Confirm the exact
+phrase, approved score, locked model support, and framework wiring before changing models.
+
+## Language
+
+- Wrong input language: inspect the cascaded ASR locale/tags or the Omni model's supported
+  audio languages.
+- Correct transcript, wrong reply language: inspect the locked response locale and system
+  instruction.
+- Correct reply text, wrong voice: inspect the TTS locale and running service's
+  voice-discovery result.
+- Works in one language only: verify every advertised language exists on both input and
+  TTS paths. Multilingual ASR or Omni does not imply multilingual TTS.
+
+## Omni pipeline
+
+Confirm the project copied the current upstream
+`nvidia_omni_multimodal_service.py` and instantiates `NvidiaOmniMultimodalService`.
+Confirm it also copied `audio_only_smart_turn_strategy.py`. Do not replace either with a
+stock text-only service or transcription-dependent Smart Turn strategy.
+
+If speech produces no request, trace input audio, user-start, and user-stop frames into
+the service. If the first greeting races microphone input, confirm
+`MuteUntilFirstBotCompleteUserMuteStrategy` is active and compare the greeting against the
+current upstream pipeline.
+
+If TTS receives JSON or transcript metadata, verify structured-response and
+`emit_transcriptions` settings because the upstream service should emit only the response
+field. If it receives reasoning, keep reasoning off through `models/llm.md`. Return to
+`frameworks/omni.md` before changing the pipeline.
+
+## TTS and return audio
+
+If reply text exists:
+
+1. verify TTS readiness independently
+2. query the running platform's voice-discovery API and confirm the configured voice
+3. confirm TTS emits audio frames
+4. confirm the output transport sends them to the client
+
+Do not debug ASR when reply text already exists. The failure is downstream.
+For a wrong domain pronunciation, verify the approved IPA and current TTS customization
+format before changing the voice.
+
+## Latency and interruption
+
+Measure each stage before tuning. Check ASR finalization, LLM/Omni time to first token,
+TTS time to first audio, and transport delay separately.
+
+Keep reasoning off unless approved. Never switch streaming ASR to offline to fix
+accuracy. For VAD, end-of-turn, or interruption changes, query the framework docs MCP and
+change one setting at a time.
+
+## Stop when
+
+- The required documentation MCP is unavailable and the fix needs framework API changes.
+- The locked model/profile is unsupported on the probed hardware.
+- A proposed fix changes an approved model, deployment, or framework choice.

--- a/skills/create-voice-agent/references/output-contract.md
+++ b/skills/create-voice-agent/references/output-contract.md
@@ -1,0 +1,159 @@
+# Output Contract
+
+Read after approval, container readiness, exact local profile pinning, and any required
+row reconfirmation. The generated project must be runnable and repeatable without
+re-reading this skill.
+
+Write in two passes, because some values only exist once the services answer. First write
+everything needed to start them: dependencies, secret placeholders, Compose, and cache
+paths. Then start the services, resolve the runtime model id and TTS voice, and finalize
+the agent file, `scripts/smoke.sh`, and the README with those real values. No placeholder
+model, voice, endpoint, or command may survive the second pass.
+
+## Always write
+
+| File | Purpose |
+| --- | --- |
+| `bot.py` or `agent.py` | selected framework pipeline |
+| `pyproject.toml` | dependencies resolved from current framework docs |
+| `.env.example` | secret placeholders only |
+| `scripts/smoke.sh` | proves the stack before any client connects |
+| `README.md` | setup, start, verify, stop, logs, and troubleshooting |
+
+Also write:
+
+- `compose.yaml` when any model service is self-hosted or the project owns coturn
+- `speech_glossary.json` when speech customization is approved
+- `signaling_server.py` when custom TURN is required for Pipecat WebRTC
+- `nvidia_omni_multimodal_service.py` and `audio_only_smart_turn_strategy.py` from the
+  current upstream blueprint when the pipeline is Omni
+
+## Generated Compose
+
+The skill ships no static Compose file. Generate `compose.yaml` from current authoritative
+deployment instructions:
+
+| Platform | Source |
+| --- | --- |
+| Workstation / DGX Spark NIM | each locked model's build.nvidia.com self-hosted page |
+| Workstation / DGX Omni | locked model's current build.nvidia.com or Hugging Face run docs |
+| Jetson Thor LLM | locked Hugging Face model card and the current [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) |
+| Jetson Thor Speech | current Riva ARM64 Quick Start |
+| Project-owned coturn | current coturn deployment documentation |
+
+Translate each current launch command into one Compose service. Preserve its image,
+command, environment, mounts, shared-memory or IPC settings, ports, and GPU requirements
+except for the approved profile/tags, host ports, cache paths, and GPU placement this skill
+explicitly locks. Use current health checks from the same source.
+
+For a shared single-GPU NIM layout, Compose must pin the exact LLM profile, approved
+context length, exactly one documented runtime memory-control path, and explicit TTS batch
+profile. These are required entries, not optional tuning. Do not rely on auto-selected LLM
+precision, default vLLM memory utilization, or the TTS container default. The memory-control
+value comes from the budget in `preflight.md` §Deployment fit, so do not reuse a number from
+another build. The same requirement applies to a shared-GPU raw vLLM layout such as Jetson
+Thor, where `--gpu-memory-utilization` and `--max-model-len` are the equivalent required
+entries. If free VRAM measured at startup differs from the budget, update Compose before
+starting rather than proceeding with a stale value. Document `platforms/deployment.md`
+§Shared-GPU memory gate in the README.
+
+Preserve the documented model cache or export mount for every speech service. First boot
+downloads models and can build engines, and that work must survive container replacement.
+
+| Platform / pipeline | Service names |
+| --- | --- |
+| Workstation / DGX Spark NIM cascaded | `llm`, `tts`, `asr` |
+| Workstation / DGX Omni | `omni`, `tts` |
+| Jetson Thor cascaded | `llm`, `riva` (ASR + TTS enabled) |
+| Jetson Thor Omni | `omni`, `riva` (TTS enabled, ASR disabled) |
+
+For a hybrid deployment, generate only the services assigned locally. Cloud slots remain
+agent configuration and do not get placeholder Compose services.
+
+For a multi-GPU workstation, follow `platforms/deployment.md` §Scaling across GPUs. DGX
+Spark and Jetson Thor use their platform guides. In Compose, use `device_ids` or `count`,
+never both. A multi-GPU LLM service must expose the exact topology required by its
+compatible profile.
+
+Compose may read secret values such as `NVIDIA_API_KEY` and `HF_TOKEN` from the user
+environment or `.env`. Keep model ids, endpoints, profiles, tags, ports, and GPU placement
+in `compose.yaml` or agent code, not `.env`.
+
+For Jetson Thor, mount the external Riva `model_repository` produced by the one-time
+Quick Start initialization. Do not rebuild it during normal `docker compose up`.
+
+Validate before handover:
+
+```bash
+docker compose config --quiet
+```
+
+Then start one service at a time and wait for readiness. Do not rely on Compose startup
+order alone.
+
+## README
+
+Write the locked choices and exact commands for this project:
+
+1. framework, pipeline, platform, transport, language route, per-slot local/cloud
+   placement, container image, pinned profile, runtime model id, and discovered TTS voice
+2. prerequisites and required credentials
+3. one-time setup, including Riva initialization when applicable
+4. dependency installation
+5. service startup in the required order
+6. health and model-id checks, then `scripts/smoke.sh`
+7. agent start command and client connection path
+8. spoken-exchange acceptance test
+9. log commands, stop commands, and links to troubleshooting
+
+Item 3 must warn that a speech service's first boot downloads models and can build an
+engine, that this commonly takes far longer than later starts, which log line shows
+progress, and which cache path keeps the result.
+
+Do not leave placeholders such as “start the services” or “use the deploy page.” Resolve
+those instructions while building and persist the resulting commands in the README.
+
+## Smoke before client
+
+The check list below is fixed by this contract. Plan it in the first pass and do not reduce
+it later. The second pass only fills in resolved values: take the LLM model string from that
+placement's `/v1/models` and the voice from the TTS voice query in `models/tts.md`, then
+write both into `bot.py` or `agent.py` in place of anything carried over from the proposal
+table.
+
+Generate `scripts/smoke.sh` from the same resolved endpoints. Include only the checks that
+apply to the approved pipeline and deployment: cloud slots probe their configured cloud
+endpoints instead of local service health. It must exit non-zero on the first failure so the
+user never debugs this from a browser:
+
+1. `/v1/models` returns the exact served id the agent uses
+2. Cascaded: one **streaming** chat completion with reasoning off, asserting non-empty
+   `delta.content` and empty or absent `delta.reasoning_content`. A non-streaming answer
+   still passes while a reasoning parser routes every token away from TTS
+   (`models/llm.md` §Reasoning parser)
+3. Omni: endpoint readiness and one minimal audio request, and no LLM or ASR checks
+4. TTS voice query, then one sentence synthesized in the approved locale using a voice that
+   query actually returned
+5. Cascaded: ASR configuration from the running service, asserting the loaded model and
+   language rather than HTTP readiness alone
+6. Cascaded: feed the synthesized sentence back through streaming ASR, which is the only
+   check that proves both speech directions before a microphone is involved
+7. in-process construction of the same services the agent builds, using the same classes
+   and settings, which is what catches a missing API-key argument or a misplaced reasoning
+   payload
+
+Use the agent's own settings, including per-slot cloud endpoints on a hybrid layout. Print
+no secrets. Run it after the services are healthy and before the runner starts. A passing
+run is still not a working agent, so the spoken exchange in `operations/run.md` remains the
+bar.
+
+## Verify the generated project
+
+Re-read this section after generation.
+
+- No real secret is written to disk.
+- `compose.yaml`, when generated, parses and exposes only the intended GPUs.
+- Every local service reaches readiness.
+- `scripts/smoke.sh` passes.
+- The documented agent command starts successfully.
+- A new terminal can follow the README to complete a spoken exchange.

--- a/skills/create-voice-agent/references/platforms/deployment.md
+++ b/skills/create-voice-agent/references/platforms/deployment.md
@@ -1,0 +1,222 @@
+# Deployment
+
+Read after the table is approved. Turns the Deployment row into running endpoints the
+agent code can call. Model ids stay in code. `.env` is secrets only.
+
+Choose the platform path first:
+
+| Host class | Deployment source |
+| --- | --- |
+| `workstation` | current build.nvidia.com instructions for every self-hosted slot |
+| `dgx_spark` | NIM path in `platforms/dgx-spark.md`, after GB10 support verification |
+| `jetson_thor` | vLLM + Riva L4T path in `platforms/jetson-thor.md` (not NIM) |
+| `unsupported_edge` | cloud. Local NIM/vLLM path is unsupported |
+| `no_gpu` | cloud |
+
+For workstation and DGX Spark NIM slots, take the image, launch command, ports, and
+environment from the locked model's self-hosted page, then apply the verified profile or
+tags from `models/llm.md`, `models/asr.md`, or `models/tts.md`. Persist the result as the
+generated `compose.yaml` defined by `output-contract.md`.
+
+## Source of truth per slot
+
+| Slot | Cloud | Self-hosted deploy copy |
+| --- | --- | --- |
+| Cascaded LLM | model page + `/v1/models` | `build.nvidia.com/nvidia/<slug>?nim=self-hosted` |
+| ASR | model page (function id) | `build.nvidia.com/nvidia/<slug>/deploy` + ASR matrix tags |
+| TTS | model page (function id) | `build.nvidia.com/nvidia/<slug>/deploy` + TTS matrix tags |
+| Omni | omni model page | follow `frameworks/omni.md` and that model’s build / HF run docs |
+
+Examples: [Lightning self-hosted](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b?nim=self-hosted) ·
+[ASR deploy](https://build.nvidia.com/nvidia/nemotron-asr-streaming/deploy) ·
+[TTS deploy](https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy).
+
+Never invent a `docker run` or image tag from memory. Apply the Speech source precedence
+in `models/catalog.md`.
+
+## Cloud
+
+No containers. Wire:
+
+- LLM: `https://integrate.api.nvidia.com/v1` + the id `/v1/models` returns for the locked
+  model
+- ASR / TTS: `grpc.nvcf.nvidia.com:443` + function ids from each model’s build page
+- `NVIDIA_API_KEY` in `.env`
+
+## Hybrid
+
+Lock and wire each slot independently:
+
+| Slot placement | `compose.yaml` | Agent configuration |
+| --- | --- | --- |
+| Local | include only that service | mapped host endpoint. Self-hosted speech function id is empty |
+| Cloud | omit that service | cloud endpoint and locked model or function id |
+
+Start and health-check only the local slots, preserving their relative startup order.
+Probe cloud authentication and the locked model or speech configuration before starting
+the agent. The generated README must label every slot as local or cloud and include only
+the local Compose commands.
+
+For LiveKit, configure STT, LLM, and TTS independently through the current plugin APIs.
+Do not assume that selecting one cloud slot moves the full pipeline to cloud.
+
+## Workstation / DGX Spark NIM
+
+1. Confirm the host clears `preflight.md` §Deployment fit (or move overflowing slots to
+   cloud).
+2. Pass `platforms/readiness.md` before pulling images or weights.
+3. `docker login nvcr.io` with username `$oauthtoken` and password `NVIDIA_API_KEY`.
+4. For each self-hosted slot, open that slug’s build page (table above) and take the
+   current image, run command, ports, and env.
+5. Translate each command into the matching service in `compose.yaml` through
+   `output-contract.md`.
+6. Overlay locked selection from the slot file:
+   - LLM: pinned Compatible `NIM_MODEL_PROFILE`, max length, exactly one documented
+     runtime memory-control path, and reasoning passthrough from `models/llm.md`
+   - ASR / TTS: streaming `NIM_TAGS_SELECTOR` / `CONTAINER_ID` from the matrix and an
+     explicit TTS batch profile
+7. Clear §Shared-GPU memory gate, then start **one Compose service at a time**. Wait
+   until that service is ready and the gate passes again before the next. Do not start
+   LLM + ASR + TTS in one operation.
+8. Cascaded startup order: LLM → TTS → ASR. Omni startup order: Omni → TTS. Skip any
+   cloud slot.
+9. Record the host ports and base URLs the build page actually published. Do not assume
+   18000 / 50151 / 50152 unless that page says so.
+10. Resolve the runtime model id and TTS voice, write them and the recorded endpoints into
+    the agent, then run `scripts/smoke.sh` (`output-contract.md` §Smoke before client).
+11. Start the agent only after every local slot is ready and smoke passes
+    (`operations/run.md`).
+
+Jetson Thor skips the numbered path above and its shared-GPU memory gate, because
+`platforms/jetson-thor.md` defines the equivalent unified-memory check. §Service health
+checks, §First boot takes much longer, and §Per-slot reuse still apply to it.
+
+### Shared-GPU memory gate
+
+Do not treat LLM readiness as permission to start speech. This gate covers workstation and
+DGX Spark layouts. Jetson Thor uses the unified-memory check in
+`platforms/jetson-thor.md` §Start and verify instead.
+
+Before the first service starts, re-measure free VRAM and confirm the arithmetic in
+`preflight.md` §Deployment fit still passes, with the LLM memory control already present in
+`compose.yaml`. Then after each service becomes ready:
+
+1. confirm logs show the locked profile, precision, context, and speech tags
+2. record per-process GPU use and free VRAM with `nvidia-smi`
+3. compare free VRAM with every remaining slot's matrix reserve plus startup headroom
+4. start the next service only when that measured gate passes
+
+If the LLM consumes the speech reserve, stop it and reduce its documented runtime memory
+budget or context before starting TTS. If TTS leaves too little for ASR, use a smaller
+approved TTS batch profile or move a slot. Do not leave an unhealthy service in a restart
+loop while bringing up the next slot.
+
+After every assigned service is healthy and the measured gate passes, update the README
+deployment status from `provisional co-location` to `self-hosted, co-located`. The agent
+is still not complete until `operations/run.md` passes a spoken exchange.
+
+### Service health checks
+
+Use the health path from the build / NIM docs for that service. Common patterns:
+
+| Slot | Often |
+| --- | --- |
+| LLM | `GET …/v1/health/ready` and `GET …/v1/models` (record the served id) |
+| ASR / TTS | HTTP readiness, then the documented configuration or voice query |
+
+HTTP readiness proves the process is up. It does not prove the expected speech profile is
+loaded. Query the running service with the current NVIDIA client or deploy-page
+procedure. ASR uses the speech-recognition configuration API. TTS uses the synthesis
+configuration API or, on Speech NIM, the documented voice-list endpoint in its current TTS
+API reference. The current gRPC RPC names are `GetRivaSpeechRecognitionConfig` and
+`GetRivaSynthesisConfig`. Confirm both against the running platform's docs, then confirm
+the locked model, language, and TTS voice before reuse or handover. Record the endpoint you
+actually used in the README and smoke script.
+
+For the LLM, compare the served model against the approved model. A different id string
+can still be the right model, but agent code must carry the exact served id.
+
+### First boot takes much longer
+
+A speech NIM's first start downloads models and can then build a TensorRT engine for this
+GPU, which commonly runs 15 to 30 minutes or more with health reporting `starting` or a
+temporary `unhealthy`. That is not a failure. Watch the logs for download or engine-build
+progress and let it finish.
+
+Declare failure only when the process exits, the logs show a fatal error such as CUDA OOM,
+or progress stops well past the documented startup window. Do not change profiles, shrink
+batch size, or restart the service just because first boot is slow, because a restart
+throws away partial work. Keep the documented cache mount so later starts reuse the
+downloaded models and the built engine and come up quickly.
+
+### Per-slot reuse
+
+Before starting anything: `docker ps`, hit health on ports already in use, and run the
+speech gRPC configuration query when applicable. Keep a container that already matches
+the locked image + profile/tags + model id. Replace only a missing, unhealthy, or wrong
+slot. Stop/remove **that** container, update its generated Compose service from the
+current source when needed, then start that service alone.
+Tell the user which slots will be reused or replaced.
+Never tear down healthy slots to fix one mismatch.
+
+### Why this order
+
+Intake decides language, framework, and pipeline. After that the deploy is the same ordered
+run every time, and each step above exists because skipping it produced a failure that
+looked like something else:
+
+| Step | Guards against |
+| --- | --- |
+| Resolve image, profile, and served id separately | pull denied, wrong model id |
+| Write Compose with the memory control already set | the LLM taking the GPU and starving speech |
+| Start one slot at a time through the memory gate | an OOM restart loop hiding the real budget |
+| Allow a long first boot | killing a healthy engine build |
+| Resolve the voice, finalize settings, run smoke | silent connect failures in the browser |
+| Start the agent and speak | a running process that is deaf or mute |
+
+## Scaling across GPUs
+
+This section covers slot placement on a multi-GPU workstation or DGX system. It does not
+apply to single-GPU DGX Spark or Jetson Thor, and it does not define replica autoscaling.
+
+List GPU UUIDs and current free memory with `nvidia-smi`. Prefer UUIDs for stable
+assignments. Plan from each GPU's free memory, not the sum:
+
+| Available GPUs | Default placement |
+| --- | --- |
+| One GPU that fits | LLM + ASR + TTS, with tight-fit knobs when required |
+| Two GPUs | LLM on one, ASR + TTS on the other |
+| Three GPUs | one slot per GPU |
+
+Any GPU hosting more than one service needs its own runtime budget and the Shared-GPU
+memory gate above. When ASR and TTS share a device, reserve both selected matrix
+footprints plus startup and engine-build headroom before approving that placement.
+
+Translate each slot's current build.nvidia.com command through `output-contract.md`, then
+set its Compose GPU reservation to the selected device ids. Follow current
+[Docker Compose GPU support](https://docs.docker.com/compose/how-tos/gpu-support/).
+`capabilities: [gpu]` is required. `device_ids` and `count` are mutually exclusive.
+
+The locked `NIM_MODEL_PROFILE` decides tensor parallelism. A `tp2` profile must see both
+required GPUs. Do not split one LLM across GPUs unless the support matrix and
+`list-model-profiles` return that topology as Compatible.
+
+Start and verify one slot at a time. Confirm from inside each container that it sees only
+the intended GPU set, then check host `nvidia-smi` to confirm memory landed on the planned
+device. Keep agent endpoint constants aligned with the resulting host ports.
+
+## Agent configuration
+
+- Cloud: use the URLs and function ids in §Cloud.
+- Workstation / DGX: use the host ports mapped from each live deploy page.
+- Jetson Thor: use the vLLM / Riva mappings in `platforms/jetson-thor.md`.
+- Self-hosted speech has empty function ids. Omni has no ASR.
+
+## Anti-patterns
+
+- Shipping a remembered image tag, `docker run`, or Compose recipe instead of generating it
+  from the locked model's current build.nvidia.com instructions.
+- Applying workstation / DGX NIM instructions to Jetson Thor.
+- Starting all local NIMs together or assuming fixed ports.
+- Applying `NIM_TAGS_SELECTOR` to LLM or `NIM_MODEL_PROFILE` to ASR / TTS.
+- Killing every container because one slot was wrong.

--- a/skills/create-voice-agent/references/platforms/dgx-spark.md
+++ b/skills/create-voice-agent/references/platforms/dgx-spark.md
@@ -1,0 +1,53 @@
+# DGX Spark
+
+Read when `preflight.md` classifies the target as `dgx_spark`. DGX Spark uses the
+self-hosted NIM workflow in `platforms/deployment.md`, subject to the support matrix for
+the locked model and profile.
+
+## Before proposing
+
+1. Confirm the machine is DGX Spark / GB10 from DMI and `nvidia-smi`.
+2. Use unified memory reported as available by the probe, not the advertised 128 GB.
+3. Verify every local slot:
+   - LLM: DGX Spark appears in the matching model × precision row in the LLM support
+     matrix. Use that row as the proposal candidate. Run `list-model-profiles` after
+     approval and container readiness to pin the exact Compatible profile.
+   - ASR / TTS: the chosen model and profile support DGX Spark in the Speech matrices.
+4. Build the runtime budget from available unified memory. Reserve the selected speech
+   profiles, OS, framework, CUDA, startup, and engine overhead before assigning the
+   remainder to LLM weights and KV cache. Use exactly one memory-control path from
+   `models/llm.md` §Tight fit.
+5. Mark provisional co-location until `platforms/deployment.md` §Shared-GPU memory gate
+   passes.
+6. If any slot is unsupported or the full layout does not fit, move that slot to NVIDIA
+   cloud and show the hybrid layout in the proposal. Do not substitute a different model
+   silently.
+
+## Deploy
+
+When a slot's locked source is a Hugging Face card rather than a NIM page, check that card for
+a DGX Spark container before using its generic install line. Cards in this family have named a
+separate container for DGX Spark and Jetson Thor. Harvest the rest of that card through
+`platforms/jetson-thor.md` §What to take from the card, which applies to any raw vLLM slot.
+
+Follow `platforms/deployment.md` for each approved local slot, including its shared
+GPU memory gate.
+
+If startup reports low memory, follow the compatible profile's `--max-model-len` guidance
+or move a speech slot to cloud.
+
+## Verify
+
+- LLM readiness succeeds, `/v1/models` serves the approved model, and its exact served id
+  is what the agent uses.
+- ASR configuration matches the lock and accepts a streaming transcription request.
+- TTS configuration matches the lock and returns audio for the approved voice.
+- `scripts/smoke.sh` passes before the agent starts.
+- A full spoken exchange succeeds before handover (`operations/run.md`).
+
+## Anti-patterns
+
+- Assuming every NIM supports GB10 because another model does.
+- Reusing a workstation image or profile without matrix verification.
+- Budgeting against advertised unified memory instead of current available memory.
+- Starting all model services concurrently on first load.

--- a/skills/create-voice-agent/references/platforms/jetson-thor.md
+++ b/skills/create-voice-agent/references/platforms/jetson-thor.md
@@ -1,0 +1,290 @@
+# Jetson Thor
+
+Read when `preflight.md` classifies the target as `jetson_thor`.
+
+Jetson Thor does **not** use the workstation / DGX NIM deployment path. Run the LLM with
+vLLM from Hugging Face weights and serve speech with the Riva Speech Skills L4T stack.
+Orin-class Jetsons are unsupported.
+
+## Source of truth
+
+Before generating or running the Thor speech deployment, read the current
+[NVIDIA Riva Quick Start Guide](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/quick-start-guide.html).
+Use it as the authority for:
+
+- supported Jetson / JetPack versions
+- NGC access, licensing, disk, power-mode, and container-runtime prerequisites
+- the current ARM64 Quick Start release and setup flow
+- Riva service ports and `config.sh` fields
+- ASR / TTS deployment and readiness instructions
+
+Follow the current guide, then apply the voice-agent choices below.
+Pass `platforms/readiness.md`, then generate the Thor services through
+`output-contract.md`. Do not ship a static Thor Compose recipe.
+
+## Platform stack
+
+| Pipeline | LLM | Speech |
+| --- | --- | --- |
+| Cascaded | [NVIDIA Nemotron 3.5 Lightning NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4) with vLLM | Riva streaming ASR + Riva TTS |
+| Omni | [Nemotron 3 Nano Omni Reasoning NVFP4](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4) with vLLM | Riva TTS only (Omni performs ASR) |
+
+This changes the model table. Do not present workstation NIM images, NIM profiles,
+`NIM_TAGS_SELECTOR`, Magpie NIM, or speech function ids as the Thor deployment.
+Resolve the exact Riva ASR / TTS models from the downloaded ARM64 Quick Start `config.sh`
+and disclose the platform-specific substitutions before build. Lock supported locales
+through `models/language-routing.md`.
+
+## Prerequisites
+
+- Jetson Thor with the JetPack release supported by the current Riva guide
+- Docker Engine and Docker Compose
+- NGC CLI configured with `NVIDIA_API_KEY`
+- `HF_TOKEN` with access to the locked Nemotron Hugging Face repository
+- Disk capacity required by the current Riva Quick Start plus the selected models and
+  compiled engines
+
+Use the versions compatible with the installed JetPack release. Resolve the current Riva
+ARM64 Quick Start release from the guide and NGC resource:
+
+`nvidia/riva/riva_quickstart_arm64`
+
+Do not copy an x86 Riva or NIM image onto Thor.
+
+## One-time Riva model build
+
+Follow the current Riva Quick Start to download the JetPack-compatible ARM64 bundle. Keep
+its model repository outside the generated project so it survives project rebuilds.
+
+1. Open the downloaded `config.sh`.
+2. Cascaded: enable ASR and TTS. Choose a streaming ASR profile and the required language.
+3. Omni: disable ASR and enable TTS only.
+4. Set the ASR / TTS languages and models available in that `config.sh`.
+5. Clear §Model path and credentials before running anything.
+6. Run `riva_init.sh` once. It downloads the selected models and compiles TensorRT engines
+   into the resolved model repository.
+7. Do not run `riva_start.sh` when the generated deployment will start Riva itself.
+
+Initialization commonly takes 30 to 60 minutes. Preserve the resulting model repository and
+mount it into the Riva service.
+
+### Model path and credentials
+
+Three `config.sh` behaviours each cost a full re-initialization when missed. Check all three
+before running `riva_init.sh`.
+
+**The tegra path can override `riva_model_loc`.** On the tegra branch the script has been
+observed to resolve the model repository under the current working directory instead of the
+value set in `config.sh`, without warning. Read the path handling in the release you actually
+downloaded, then assert where the models landed after initialization rather than trusting the
+configured value. Mount the resolved path, not the intended one.
+
+**Reusing an existing Quick Start carries root ownership.** `riva_init.sh` runs as root, so an
+existing `model_repository` is root-owned. Copying that tree into a new Quick Start directory
+carries the ownership across and the container user may not be able to read it. Re-initialize
+into a fresh path, or mount the original repository where it already lives.
+
+**Enterprise credentials are all three or none.** Setting `RIVA_API_KEY` and `RIVA_EULA`
+switches the Quick Start onto its Enterprise path, which then requires `RIVA_API_NGC_ORG`.
+Two of the three fails during initialization in a way that reads like a bad key. Set all three
+when the current guide documents Enterprise use for this release, otherwise leave all three
+unset and use the standard NGC flow.
+
+## LLM model source
+
+Thor reads two sources, and neither one replaces the other:
+
+| Source | Authority over |
+| --- | --- |
+| Locked Hugging Face model card | vLLM container/version, installation, parser files, request format, and which flags this model requires |
+| [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) | what each serve flag means, its exact spelling, and its current default |
+
+| Pipeline | Hugging Face repository id |
+| --- | --- |
+| Cascaded | `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4` |
+| Omni | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4` |
+
+Read the relevant card immediately before generating the deployment. Do not reuse the
+cascaded launch command for Omni. Omni has model-specific vLLM and audio requirements.
+
+### What to take from the card
+
+Work through the card's vLLM section and record every item below. Skimming it for the launch
+command is how the platform-specific pieces get missed.
+
+| Item | Why it matters |
+| --- | --- |
+| Platform-specific container | The card links a separate vLLM container for Jetson Thor and DGX Spark. Use that, not the generic install line written for a workstation |
+| Minimum vLLM version | The card pins a floor. An older build can accept every flag and still fail on this quantization |
+| Linked cookbook | Fuller deployment guidance than the card's own summary |
+| Parser plugin file | A separate download that must exist before the server starts, and only when reasoning is on |
+| Required environment variables | The NVFP4 kernel path is enabled by environment variables rather than flags |
+| Default context length | The repository configuration carries its own default, so omitting the context flag inherits it |
+| Sampling settings | The card gives different values for reasoning on, reasoning off, and tool calling |
+| Supported response languages | Compare against the approved response language (`models/language-routing.md` §LLM) |
+
+The card's hardware-compatibility summary field is not the deployment authority here. Its
+vLLM section is, because that is where the platform container is named.
+
+A card launch command is an example, not a memory budget for this device. The cascaded
+card's example passes no GPU memory fraction and serves a very long context, so copying it
+verbatim leaves the vLLM default in place and sizes the KV cache for a device that is not
+also running Riva. Treat memory and context as values you calculate, in §Memory and
+context flags.
+
+Authenticate with `HF_TOKEN`. vLLM can download the repository directly from the Hub, so
+a separate model download is not required unless the model card instructs it. Verify
+access with `hf auth whoami`. Use `hf auth login` when authentication is missing.
+
+## LLM with vLLM
+
+Use the current vLLM image/version required by the locked model card and serve the exact
+Hugging Face repository id above. Generate the launch command from that card's current
+deployment guidance, then translate it into the generated `llm` or `omni` Compose service.
+Thor uses raw vLLM, so:
+
+- `HF_TOKEN` supplies model access.
+- `NIM_MODEL_PROFILE` and `list-model-profiles` do not apply.
+- The Omni repository name does not enable reasoning by itself.
+- Reasoning off has two halves. In agent requests set
+  `extra_body.chat_template_kwargs.enable_thinking` to `false`. In the serve command omit the
+  reasoning parser and its plugin, because the card's command assumes reasoning on and a
+  parser left in place is what makes a Thor agent go mute with no error in any log
+  (`models/llm.md` §Reasoning parser).
+- Take the flags this model requires from the current card, and each flag's meaning and
+  current default from the vLLM `serve` CLI reference. Add nothing the card does not list
+  unless a fatal log names it (`models/llm.md` §Serve flags).
+- Confirm `/v1/models` serves the locked model before starting the agent, and put its
+  exact served id in the agent rather than the Hugging Face repository name.
+- The framework client traps are the same as any local endpoint. Follow
+  `frameworks/pipecat.md` §Local LLM wiring or `frameworks/livekit.md` §NVIDIA models.
+
+### Memory and context flags
+
+`--gpu-memory-utilization` and `--max-model-len` are **required in the generated Compose
+service** on Thor, because vLLM and Riva share one device. They are not tuning applied
+after an OOM.
+
+The memory fraction is per-instance and measured against total device memory. The reference
+states it does not account for memory another process already holds, so a running Riva does
+not lower it and vLLM will not leave room on its own. Calculate the fraction with the
+arithmetic in `models/llm.md` §Tight fit, treating the Riva configuration you selected plus
+startup headroom as memory the LLM cannot have.
+
+Set the context to the smallest length that satisfies the approved use case rather than the
+card's example length. KV cache grows with context, and a voice turn is short. The
+repository configuration also carries its own default context, so omitting the flag inherits
+that default instead of something small. When the
+current reference documents an absolute KV cache size such as `--kv-cache-memory-bytes`,
+prefer it over a fraction here, since an absolute budget is easier to reconcile with Riva
+than a fraction of a device both services share.
+
+Raise either value only after the complete vLLM + Riva stack is stable.
+
+### First boot compiles kernels
+
+The NVFP4 path uses FlashInfer kernels that the card enables through environment variables.
+On first boot those kernels can be compiled on the device, which has been observed to run
+around 45 minutes before the server answers. Rising `nvcc` and `cicc` compile output is the
+progress signal, so read the logs instead of treating the wait as a hang.
+
+Mount a persistent cache for the compiled kernels alongside the Hugging Face cache, so later
+starts skip the compile. Resolve the current cache location from the vLLM and FlashInfer
+documentation for the version the card pins. Without that mount every container replacement
+pays the compile again. No serve flag shortens a kernel compile.
+
+### Host memory at startup
+
+vLLM's startup check has been observed to read Linux **free** memory rather than **available**
+memory on this platform. Page cache counts against it, so a host with plenty of reclaimable
+memory can still fail to start once model downloads and engine builds have filled the cache.
+
+Read both numbers before starting vLLM. When free memory is the blocker, reclaim page cache
+or restart the host rather than lowering the model configuration. This failure and a real
+device OOM look alike and their fixes are opposite, so confirm which one the log describes
+before changing the memory budget.
+
+## Riva services
+
+Use the L4T Riva Speech image compatible with the Quick Start and mount the generated model
+repository. Riva serves ASR and TTS through one gRPC endpoint. Read
+`riva_speech_api_port` from the current Quick Start `config.sh` and map that port in the
+generated `riva` Compose service.
+
+| Service | Project endpoint |
+| --- | --- |
+| LLM OpenAI-compatible API | mapped port from the generated vLLM service |
+| Riva ASR + TTS gRPC | port from the current `riva_speech_api_port` |
+
+Function ids are empty. For cascaded mode, never hand over while the shared Riva gRPC
+endpoint is unavailable. For TTS, discover and use a voice exposed by the running Riva
+service rather than a Magpie voice id.
+
+For approved domain terms, follow the Jetson Thor branch in
+`domain/speech-customization.md`. Use Riva request-time word boosting and pronunciation
+only when the selected ARM64 Quick Start model supports them.
+
+### Language on the Quick Start ASR
+
+The streaming ASR model a Quick Start release offers may be a multilingual auto-detecting
+model. On that kind of model a requested locale is advisory and does not restrict
+recognition, so Hindi audio returns Devanagari and English audio returns English on the same
+stream.
+
+Say this in the proposal instead of presenting a fixed locale as a guarantee, and say plainly
+when the release contains no single-language model for the requested locale. Resolve what the
+selected release actually offers through `models/language-routing.md`.
+
+## Resource sharing
+
+Thor shares unified memory and one GPU between vLLM and Riva. Do not prescribe CPU
+pinning or fixed compute splits. Start from the compute and scheduling defaults supported by
+the current vLLM, Riva, and JetPack releases. Memory is the exception, because §Memory and
+context flags sets those values explicitly. If measured contention causes audio glitches,
+consult the current platform guidance before applying CUDA MPS tuning.
+
+If the stack still OOMs with the calculated budget in place, lower `--max-model-len` first,
+then the memory fraction, before changing the approved model.
+
+## Start and verify
+
+Assert each result. Do not read a step as done because the previous one produced output.
+
+1. Start the generated vLLM Compose service. Wait for `/v1/models` and confirm it returns
+   the locked served id.
+2. Send one streaming chat completion with reasoning off. Assert non-empty `delta.content`
+   and empty or absent `delta.reasoning_content`.
+3. Measure available unified memory. Start Riva only when the remaining budget covers the
+   selected Quick Start configuration plus startup headroom. Otherwise stop vLLM and lower
+   `--max-model-len` or the memory fraction.
+4. Start the generated `riva` service. Query `GetRivaSynthesisConfig` and assert the loaded
+   TTS model plus a voice the service actually returned.
+5. Cascaded only: query `GetRivaSpeechRecognitionConfig` and assert the loaded ASR model and
+   language.
+6. Cascaded only: synthesize one sentence in the approved locale and feed that audio back
+   through streaming ASR. This is the only check that proves both speech directions on the
+   shared Riva endpoint before a microphone is involved.
+7. Run `scripts/smoke.sh`.
+8. Start the framework agent.
+9. Complete a spoken exchange (`operations/run.md`).
+
+Riva's first start after initialization can still spend a long time loading and building
+before it reports ready. Treat it like the first-boot window in `platforms/deployment.md`
+and read the logs rather than restarting.
+
+## Anti-patterns
+
+- Following build.nvidia.com NIM launch instructions on Thor.
+- Using `NIM_MODEL_PROFILE` or Speech `NIM_TAGS_SELECTOR` on the Thor stack.
+- Running `riva_start.sh` after the generated deployment already owns Riva startup.
+- Selecting offline ASR for a live voice agent.
+- Starting from a Magpie NIM voice id instead of querying Riva voices.
+- Copying a card launch command verbatim, which leaves the vLLM memory default in place and
+  sizes the context for a device that is not also running Riva.
+- Keeping the reasoning parser while the reasoning row is off.
+- Adding eager mode, scheduling toggles, or CUDA MPS variables to chase a slow first boot.
+- Mounting the `riva_model_loc` you configured without asserting where the models landed.
+- Copying a root-owned `model_repository` into a new Quick Start directory.
+- Setting some of `RIVA_API_KEY`, `RIVA_EULA`, and `RIVA_API_NGC_ORG` but not all three.
+- Presenting a fixed locale as single-language recognition on an auto-detecting model.
+- Treating unified 128 GB memory as entirely available to vLLM.

--- a/skills/create-voice-agent/references/platforms/readiness.md
+++ b/skills/create-voice-agent/references/platforms/readiness.md
@@ -1,0 +1,94 @@
+# Container Readiness
+
+Run after self-hosting is approved. `preflight.md` proves the host has a GPU. This file
+proves containers can use it.
+
+Complete every check in this file before post-approval `list-model-profiles` or any large
+image or model pull. Profile discovery may pull the selected NIM image, so storage and
+cache checks are part of this gate.
+
+## 1. Docker
+
+Require all three commands to succeed:
+
+```bash
+docker version
+docker info
+docker compose version
+```
+
+`docker version` must show a reachable server, not only a client. Stop on daemon,
+permission, or Compose-plugin errors. Report the failing layer. Do not silently add
+`sudo` or change Docker configuration.
+
+## 2. NVIDIA Container Toolkit
+
+Follow the current
+[NVIDIA Container Toolkit sample workload](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/sample-workload.html).
+Its Docker check is:
+
+```bash
+docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi
+```
+
+This intentionally pulls a small image when it is not cached. Require the container output
+to list the same intended GPU devices seen on the host. A working host `nvidia-smi` alone
+does not pass this check.
+
+If the command fails, stop before NIM, vLLM, or Riva pulls. Point to NVIDIA Container
+Toolkit installation or Docker runtime configuration based on the actual error.
+
+## 3. Storage and cache paths
+
+Get Docker's storage root with:
+
+```bash
+docker info --format '{{.DockerRootDir}}'
+```
+
+Check free space on that filesystem and every host path that the generated
+`compose.yaml` will mount. These include the locked NIM cache, Hugging Face cache, and
+Jetson Thor Riva `model_repository` when applicable.
+
+For each host-mounted cache:
+
+1. resolve the exact path from the approved deployment source
+2. create it only when it does not exist and the parent is approved
+3. require it to be a directory and writable by the host account and container user
+   required by the source launch command
+4. check free space before pulling
+
+Do not replace an existing cache, change ownership recursively, or delete files to make
+space. Report the required path and available space when the check fails.
+
+## 4. Credentials and registry
+
+Reconfirm the required keys from `preflight.md` without printing them. Use the current
+build.nvidia.com login instructions for NGC. A registry authentication failure is a hard
+stop before model pulls.
+
+## 5. Jetson Thor
+
+When the routed platform is Jetson Thor, also require:
+
+- the JetPack release supported by the current Riva ARM64 Quick Start
+- NGC CLI authentication
+- `hf auth whoami` access to the locked Nemotron repository
+- a writable parent path with enough space for the external Riva `model_repository`
+
+The repository itself is produced later by the one-time `riva_init.sh` step. Require it to
+exist before starting the generated `riva` service, not before generating the project.
+
+## Pass condition
+
+Proceed to exact local profile discovery, `output-contract.md`, and the routed deployment
+guide only when:
+
+- Docker daemon and Compose are reachable
+- a container can see every assigned NVIDIA GPU
+- all required host-mounted paths are writable
+- Docker storage and model caches have enough free space
+- required registries and model sources can authenticate
+- Jetson Thor prerequisites above pass when applicable
+
+Record the commands, expected GPU assignment, and cache paths in the generated README.

--- a/skills/create-voice-agent/references/preflight.md
+++ b/skills/create-voice-agent/references/preflight.md
@@ -1,0 +1,161 @@
+# Preflight
+
+Sections 1-3 are step 0 of `intake.md` and run before the first word to the user. They
+establish host class and base credentials. Section 4 runs during proposal after pipeline,
+framework, and candidate models are known.
+
+Per-slot footprints and knobs live in `models/llm.md`, `models/asr.md`, and
+`models/tts.md`. Section 4 combines them into self-hosted, cloud, or hybrid placement.
+
+| Output | Feeds |
+| --- | --- |
+| Host class | which platform guide applies |
+| Usable VRAM | later deployment fit |
+| Compute capability | LLM precision planning (`models/llm.md`) |
+| Deployment row | intake proposal |
+| A blocking credential, if any | halts everything before the table |
+
+## 1. Probe the host
+
+Collect the operating system, GPU inventory, machine identity, system RAM, and free disk.
+Failures on a machine without a GPU are expected and are not errors.
+
+`nvidia-smi` is the detection method. Ask it for everything in one query, including
+`compute_cap`, because compute capability is what decides the precision:
+
+```bash
+nvidia-smi --query-gpu=index,name,memory.total,memory.free,compute_cap --format=csv,noheader
+```
+
+A non-zero exit or empty output means no usable NVIDIA GPU.
+
+Report usable VRAM as `memory.free`, not nameplate `memory.total`. Add VRAM across GPUs
+only when the user intends to pin slots to separate devices.
+
+Detect the operating system first, for example with `uname -s`. Self-hosted NIM models
+require Linux, so on macOS or Windows the deployment is cloud. The identity paths below
+exist only on Linux; their absence on other systems is expected, not an error.
+
+On Linux, read the machine identity from `/sys/class/dmi/id/product_name` and
+`/proc/device-tree/model`, which is the only reliable way to tell DGX Spark and Jetson Thor
+apart from a generic host.
+
+Re-probe if the user says they will run on a different machine from the one hosting the
+agent.
+
+## 2. Classify the host
+
+| Signal | Host class |
+| --- | --- |
+| OS is macOS or Windows | `no_gpu`, cloud only (NIM needs Linux) |
+| `nvidia-smi` fails or names no GPU | `no_gpu`, cloud is the only option |
+| DMI product name contains GB10 or Spark | `dgx_spark`, see `platforms/dgx-spark.md` |
+| Device tree model names Jetson Thor | `jetson_thor`, see `platforms/jetson-thor.md` |
+| x86_64 with an NVIDIA GPU | `workstation` |
+| aarch64 with a GPU that is not Thor | `unsupported_edge`, cloud only |
+
+Name the GPU to the user exactly as `nvidia-smi` reports it, for example
+`NVIDIA RTX 6000 Ada Generation`. Warn when system RAM is under 32 GiB or free disk is
+under 50 GiB, because NIM images are large.
+
+## 3. Check the credentials
+
+`NVIDIA_API_KEY` is needed on every path, for cloud inference, for pulling NIM images from
+`nvcr.io`, and for model discovery. Check it now.
+
+The rest depend on choices intake has not made yet, so check them the moment the table's
+shape is known, and before writing anything.
+
+| Also required | When |
+| --- | --- |
+| `HF_TOKEN` | local raw vLLM pulls from Hugging Face, including Jetson Thor and any workstation / DGX Omni path whose locked source is Hugging Face |
+| `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` | any LiveKit run, cloud or self-hosted |
+
+Check the shell environment first, then `.env`. A key exported in the shell counts even
+when there is no `.env` file at all. Parse `.env`, never source it. Count a key as missing
+when it is absent, empty, or still carries a placeholder such as `your-key-here`,
+`changeme`, or `API_KEY_REQUIRED`.
+
+When a key is missing, stop. Name it, say how to get it, and wait for the user to confirm
+it is set. Ask for every missing key in one message rather than one at a time.
+
+| Key | Where the user gets it |
+| --- | --- |
+| `NVIDIA_API_KEY` | https://build.nvidia.com/settings/api-keys, starts with `nvapi-`, shown once |
+| `HF_TOKEN` | Hugging Face settings, access tokens, read access is enough |
+| `LIVEKIT_*` | the `lk cloud auth` browser flow, or project settings, API keys, create key |
+
+Fetch the LiveKit steps from the LiveKit documentation MCP before answering, because that
+console flow changes. Self-hosted LiveKit is an override the user has to ask for by name.
+
+Write the keys into `.env.example` as placeholders. Never write a real value to disk, and
+never put model ids or endpoints in `.env`, which holds secrets only.
+
+## 4. Deployment fit
+
+During proposal, set the intake **Deployment** row from usable VRAM. Model weights are
+planning hints, not service footprints. Authoritative speech VRAM comes from the selected
+matrix profiles. The LLM support matrix supplies the proposal candidate. Post-approval
+`list-model-profiles` confirms the exact profile. Runtime memory also includes KV cache,
+activations, CUDA graphs, and engine overhead.
+
+For `no_gpu` or `unsupported_edge`, set Deployment to cloud and skip local fit.
+Jetson Thor uses `platforms/jetson-thor.md`. DGX Spark uses
+`platforms/dgx-spark.md` and available unified memory. Neither uses a fixed workstation
+VRAM threshold.
+
+For a workstation, build a runtime budget before approving co-location:
+
+1. select a candidate Compatible LLM quantization profile from the support matrix.
+   Post-approval `list-model-profiles` pins the exact profile
+2. reserve the selected ASR matrix GPU memory
+3. reserve the selected TTS batch profile GPU memory
+4. reserve GPU memory for the framework, CUDA, service startup, and engine build
+5. give only the remainder to the LLM runtime, including weights and KV cache
+
+That budget is a hard gate, and the arithmetic must pass before anything starts:
+
+```text
+llm_weights + llm_kv_and_activations + tts_vram + asr_vram + startup_overhead
+    <= free VRAM measured now
+```
+
+Omni omits the ASR term, so its stack is Omni + TTS. Hybrid counts only the slots assigned
+to this GPU, because cloud slots consume no local VRAM. If the sum does not fit, change the
+profile, the TTS batch profile, or the placement. Do not start the stack and let the last
+service discover the shortfall as an OOM.
+
+Recalculate whenever profile, context length, TTS batch size, or slot placement changes.
+
+Weight estimates alone can support only `provisional co-location`, never the final
+`self-hosted, co-located` status. Before generating Compose, lock the LLM profile and
+memory controls from `models/llm.md` plus the TTS batch profile from `models/tts.md`.
+Require the Shared-GPU memory gate in `platforms/deployment.md`.
+
+| Fit result | Deployment row |
+| --- | --- |
+| Runtime budgets fit one GPU with startup headroom | self-hosted, provisional co-location |
+| Slots fit only when pinned across GPUs | self-hosted, show placement (`platforms/deployment.md` §Scaling across GPUs) |
+| Only some slots fit | hybrid, name each cloud slot |
+| No local layout fits | cloud |
+
+Use a Compatible NVFP4 profile when available. Otherwise, use the next compatible precision from `models/llm.md`. Do not apply a heavier-precision estimate after selecting NVFP4.
+
+For every shared single-GPU layout, use the controls in `models/llm.md` (profile, context,
+runtime memory cap) and `models/tts.md` (explicit batch profile). Re-read this section
+whenever a slot moves GPU or to cloud, or the user asks why something will not fit.
+
+Host GPU detection is not container readiness. After self-hosting is approved and before
+pulling an image, require Docker, Compose, NVIDIA Container Toolkit, in-container GPU
+visibility, and writable cache paths through `platforms/readiness.md`.
+
+## Anti-patterns
+
+- Asking whether to use cloud or self-hosted before probing.
+- Offering a deployment choice on a machine with no GPU.
+- Routing unsupported ARM64 edge hardware to workstation NIM images.
+- Reporting nameplate VRAM instead of what is actually free.
+- Approving co-location from model weights without budgeting KV cache and service startup.
+- Leaving the LLM runtime memory cap or TTS batch profile implicit on a shared GPU.
+- Generating files before checking credentials.
+- Treating an `.env.example` placeholder as a real key.


### PR DESCRIPTION
## Summary

Adds the `create-voice-agent` skill: a guided, docs-grounded workflow that builds a working NVIDIA voice agent in an empty project, from intake through a verified spoken exchange.

- **Pipelines & frameworks:** Cascaded (streaming ASR → text LLM → TTS) and Omni (audio-in LLM → TTS); Pipecat (both shapes) and LiveKit (cascaded only), with agent code resolved from each framework's docs MCP rather than shipped templates.
- **Models (resolved from live NVIDIA docs, never hardcoded):** cascaded LLM defaults to Nemotron 3.5 Lightning (Super/Ultra when named), Nemotron 3 Nano Omni for the Omni pipeline, Nemotron/Parakeet streaming ASR, and Magpie TTS. Catalog slug vs container image vs runtime served id kept distinct; reasoning off by default with the model's correct serve-time parser.
- **Deployment:** host probe + classification (macOS/Windows and no-GPU route to NVIDIA cloud, since self-hosted NIM needs Linux); cloud, workstation, DGX Spark, and Jetson Thor paths; shared-GPU memory gate and per-slot budgeting before co-location; cloud skips readiness/profile-pinning/Compose.
- **Handover & quality:** two-pass output contract (agent code, pyproject, `.env.example`, compose, `smoke.sh`, README) with no surviving placeholders; `scripts/smoke.sh` proves the stack before any client connects; structured observability; LiveKit CLI preflight + explicit connect/verify steps ending at the LiveKit project URL. Success requires a real spoken exchange, not just a running process.

## Test plan

- [x] Exercised the skill end to end on macOS against NVIDIA cloud with LiveKit (cascaded): intake → proposal → build → smoke → spoken exchange.
- [x] `scripts/smoke.sh` passes (LLM streaming with reasoning off, ASR streaming config, TTS voice discovery, TTS→ASR round-trip).
- [ ] Reviewer: sanity-check model IDs / links resolve on build.nvidia.com and the NIM support matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive guidance for creating and refining NVIDIA voice agents.
  * Supports cascaded and Omni pipelines with Pipecat and LiveKit.
  * Added workflows for intake, model and language selection, deployment, iteration, troubleshooting, and handover.
  * Added platform guidance for cloud, self-hosted, DGX Spark, Jetson Thor, and remote WebRTC deployments.
  * Added speech customization, observability, readiness checks, smoke testing, and secure credential-handling requirements.
  * Requires approval before generating files and successful spoken-exchange verification during handover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->