### PR TITLE
Update and align skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Nemotron ASR Streaming NIM to version 1.3.1.
 - Updated Parakeet CTC 1.1B ASR NIM to version 1.5.3.
 - Updated Magpie TTS Multilingual NIM to version 1.10.0 and `nvidia-riva-client` to version 2.27.0.
+- Renamed the Magpie Multilingual Compose services to `magpie-multilingual-tts-service` and `magpie-multilingual-tts-service-perf`.
 - Updated Chatterbox TTS Multilingual NIM to version 1.1.0 and documented its available model profiles.
 - Standardized the self-hosted Nemotron 3.5 Lightning served model ID with NVIDIA Cloud across NIM and single-GPU vLLM deployments.
 - Consolidated on-prem deployment recipes under `<example>/server` for scaling-oriented stacks and universal `<example>/single-gpu` for supported one-GPU deployments on workstations, DGX Spark, and Jetson Thor. Renamed `generic-assistant/workstation-perf` to `generic-assistant/server-perf`.

--- a/benchmarking_tools/scaling-perf/README.md
+++ b/benchmarking_tools/scaling-perf/README.md
@@ -88,8 +88,9 @@ scaling configuration:
 - `nemotron-asr-streaming-english`:
   `NIM_TAGS_SELECTOR=type=en-US,mode=str,batch_size=128`, GPU `0`, alias
   `nemotron-asr-streaming-english`
-- `tts-service`: `NIM_TAGS_SELECTOR=name=magpie-tts-multilingual,batch_size=64`,
-  GPU `1`, alias `tts-service`
+- `magpie-multilingual-tts-service-perf`:
+  `NIM_TAGS_SELECTOR=name=magpie-tts-multilingual,batch_size=64`, GPU `1`, alias
+  `magpie-multilingual-tts-service`
 - app env: `UVICORN_WORKERS=200`,
   `USE_SILERO_VAD_TURN_DETECTION=true`, `SILERO_VAD_STOP_SECS=0.5`,
   `AUDIO_OUT_10MS_CHUNKS=40`

--- a/docker/docker-compose.chatterbox-tts.yaml
+++ b/docker/docker-compose.chatterbox-tts.yaml
@@ -2,7 +2,7 @@
 #
 # Opt-in alternate to Magpie (shared ports 50151/9000. Only one TTS can run):
 #   docker compose --profile <recipe>/server --profile chatterbox-tts \
-#     up -d --scale tts-service=0
+#     up -d --scale magpie-multilingual-tts-service=0
 # Omitting --profile chatterbox-tts leaves Chatterbox running and holding the
 # ports. Stop it before Magpie can bind again:
 #   docker compose --profile chatterbox-tts stop chatterbox-tts-service

--- a/docker/docker-compose.magpie-tts.yaml
+++ b/docker/docker-compose.magpie-tts.yaml
@@ -1,4 +1,4 @@
-x-tts-service: &tts-service-base
+x-magpie-multilingual-tts-service: &magpie-multilingual-tts-service-base
     image: nvcr.io/nim/nvidia/magpie-tts-multilingual:1.10.0
     user: "0:0"
     ports:
@@ -29,14 +29,14 @@ x-tts-service: &tts-service-base
         max-size: "50m"
         max-file: "5"
 
-x-tts-service-env: &tts-service-env
+x-magpie-multilingual-tts-service-env: &magpie-multilingual-tts-service-env
   NGC_API_KEY: ${NVIDIA_API_KEY:-not-needed}
   NIM_HTTP_API_PORT: "9000"
   NIM_GRPC_API_PORT: "50051"
 
 services:
-  tts-service:
-    <<: *tts-service-base
+  magpie-multilingual-tts-service:
+    <<: *magpie-multilingual-tts-service-base
     profiles:
       - generic-assistant/server
       - multilingual-assistant/server
@@ -44,7 +44,7 @@ services:
       - omni-assistant-subagents/server
       - frontend-backend-agent/server
     environment:
-      <<: *tts-service-env
+      <<: *magpie-multilingual-tts-service-env
       NIM_TAGS_SELECTOR: name=magpie-tts-multilingual,batch_size=8
     deploy:
       resources:
@@ -54,12 +54,12 @@ services:
               device_ids: ['0']
               capabilities: [gpu]
 
-  tts-service-perf:
-    <<: *tts-service-base
+  magpie-multilingual-tts-service-perf:
+    <<: *magpie-multilingual-tts-service-base
     profiles:
       - generic-assistant/server-perf
     environment:
-      <<: *tts-service-env
+      <<: *magpie-multilingual-tts-service-env
       NIM_TAGS_SELECTOR: name=magpie-tts-multilingual,batch_size=64
     deploy:
       resources:
@@ -71,7 +71,7 @@ services:
     networks:
       default:
         aliases:
-          - tts-service
+          - magpie-multilingual-tts-service
 
 volumes:
   tts_cache:

--- a/docker/docker-compose.magpie-zeroshot-tts.yaml
+++ b/docker/docker-compose.magpie-zeroshot-tts.yaml
@@ -3,7 +3,7 @@
 #
 # Opt-in alternate (shared ports 50151/9000. Only one TTS can run):
 #   docker compose --profile <recipe>/server --profile magpie-zeroshot-tts \
-#     up -d --scale tts-service=0
+#     up -d --scale magpie-multilingual-tts-service=0
 # Omitting --profile magpie-zeroshot-tts leaves Zeroshot running and holding the
 # ports. Stop it before Magpie can bind again:
 #   docker compose --profile magpie-zeroshot-tts stop magpie-zeroshot-tts-service

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -39,7 +39,7 @@ For NVIDIA's current model and deployment support details, see the [TTS support 
 TTS runs one of these ways, and the repo wires the right one per profile:
 
 - **Cloud (NVCF)**: no local GPU. Magpie Multilingual and Chatterbox appear in the Services tab (no Compose change). Magpie Zeroshot has no cloud function.
-- **Magpie TTS Multilingual (default server recipe)**: started by `*/server` recipes as `tts-service` ([`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml)). Universal `*/single-gpu` recipes use NeMo-Speech.cpp.
+- **Magpie TTS Multilingual (default server recipe)**: started by `*/server` recipes as `magpie-multilingual-tts-service` ([`docker-compose.magpie-tts.yaml`](../../docker/docker-compose.magpie-tts.yaml)). Universal `*/single-gpu` recipes use NeMo-Speech.cpp.
 - **Opt-in local TTS (Chatterbox or Magpie Zeroshot)**: both are listed in Compose but do **not** start with the default recipe. They share Magpie Multilingual's host ports (`50151` / `9000`), so only one of Magpie Multilingual, Chatterbox, or Zeroshot can run at a time. Enable the opt-in profile and scale Magpie off:
 
   | Alternate | Compose profile | Catalog key | Compose file |
@@ -50,7 +50,7 @@ TTS runs one of these ways, and the repo wires the right one per profile:
   ```bash
   # Example: Magpie Zeroshot on the server recipe (same pattern for Chatterbox)
   docker compose --profile generic-assistant/server --profile magpie-zeroshot-tts \
-    up -d --scale tts-service=0
+    up -d --scale magpie-multilingual-tts-service=0
   ```
 
   Then select the matching catalog key in the Services tab (or `defaults.tts`). Omitting the opt-in profile leaves that sidecar running and holding the ports—stop it before Magpie Multilingual can bind again (`docker compose --profile <profile> stop <service>`, then recipe `up -d`).
@@ -111,13 +111,13 @@ The active voice is the `voice_id` in the catalog entry. The client UI includes 
 - **Magpie Zeroshot**: languages listed in [Supported languages](#supported-languages); built-in voices across locales are `Magpie-ZeroShot-Multilingual.Female` (default) and `Magpie-ZeroShot-Multilingual.Male` ([model card](https://build.nvidia.com/nvidia/magpie-tts-zeroshot/modelcard)).
 - **Chatterbox**: **one default speaker per locale**.
 
-To change the **default**, edit `voice_id` in the example's `services.cloud.yaml` / `services.local.yaml`. For a local Magpie NIM, point the entry at the sidecar (`tts-service:50051` or `magpie-zeroshot-tts-service:50051`) under the active recipe section. See [Configure Services](configure-services.md).
+To change the **default**, edit `voice_id` in the example's `services.cloud.yaml` / `services.local.yaml`. For a local Magpie NIM, point the entry at the sidecar (`magpie-multilingual-tts-service:50051` or `magpie-zeroshot-tts-service:50051`) under the active recipe section. See [Configure Services](configure-services.md).
 
 ```yaml
 tts:
   magpie-multilingual-tts:
     name: "Magpie TTS Multilingual"
-    server: "grpc.nvcf.nvidia.com:443"   # cloud. Local entries use the sidecar host:port (e.g. tts-service:50051)
+    server: "grpc.nvcf.nvidia.com:443"   # cloud. Local entries use the sidecar host:port (e.g. magpie-multilingual-tts-service:50051)
     voice_id: "Magpie-Multilingual.EN-US.Aria"
     model: "magpie-tts-multilingual"
     function_id: "877104f7-e885-42b9-8de8-f6e4c6303969"

--- a/skills/configure-pipeline/SKILL.md
+++ b/skills/configure-pipeline/SKILL.md
@@ -37,6 +37,7 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
 
 3. Validate:
    - Multilingual prompts must use multilingual-capable ASR and TTS from the active catalog (e.g. `parakeet-rnnt`, `nemotron-asr-streaming-multilingual`, `magpie-multilingual-tts`, `magpie-zeroshot-tts`, `chatterbox-multilingual-tts`). Verify the keys exist before referencing them.
+   - Every TTS catalog entry must set `synthesis_mode` explicitly. Use `stitched` for Magpie Multilingual and Magpie Zeroshot, and `per_sentence` for Chatterbox.
    - Local catalog endpoints must use Compose service names (`nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `parakeet-ctc-asr:50052`, `parakeet-rnnt-asr:50052`, `magpie-multilingual-tts-service:50051`, `magpie-zeroshot-tts-service:50051`, `chatterbox-tts-service:50051`, `nvidia-llm:8000`, `nvidia-llm-vllm:8000`, `nvidia-llm-vllm-omni:8002`, `nemo-speech:50051`, `nemo-speech-multilingual:50051`, `nemo-speech-tts:50051`, `booking-server:8001`). Host-run backends auto-rewrite to the matching `localhost` ports.
    - Alternate local ASR/TTS use Compose profiles (`parakeet-ctc-asr`, `parakeet-rnnt-asr`, `chatterbox-tts`, `magpie-zeroshot-tts`) and share ports with the default. Scale the default off (e.g. `--scale magpie-multilingual-tts-service=0` or `--scale nemotron-asr-streaming-multilingual=0`). Stop `chatterbox-tts-service` or `magpie-zeroshot-tts-service` before returning to Magpie Multilingual.
    - A `*/server` recipe that colocates the default ASR, LLM, and TTS on one GPU needs about 80 GB of VRAM. This does not apply to `*/single-gpu` recipes, which use the memory-fit procedure in the `deploy` skill.
@@ -68,7 +69,8 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
 ## Limitations
 
 - Does not deploy the stack or change profiles. Use `deploy` (and its per-example references) for that.
-- Source code or `Dockerfile` changes require an image rebuild (`--build`). Out of scope here.
+- `NvidiaWordTTSService` is a source-level opt-in, not an `.env` or service-catalog setting. When word-level input streaming and timestamp-based context commits are requested, change only the service import and constructor in the example's `pipeline.py` as documented in `docs/how-to/configure-tts.md#word-level-input-streaming-and-timestamps`, then restart the example service.
+- Other source customization is out of scope. Dependency or `Dockerfile` changes require an image rebuild (`--build`).
 - UI-only ad-hoc service / prompt overrides (saved in `localStorage`) are intentionally not persisted. This skill writes only to repo files.
 
 ## Troubleshooting

--- a/skills/configure-pipeline/SKILL.md
+++ b/skills/configure-pipeline/SKILL.md
@@ -36,10 +36,10 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
    - `<example-package>/prompts.yaml`: built-in prompt presets and prompt content for the active example.
 
 3. Validate:
-   - Multilingual prompts must use multilingual-capable ASR and TTS from the active catalog (e.g. `parakeet-rnnt`, `nemotron-asr-streaming-multilingual`, `magpie-multilingual-tts`, `chatterbox-multilingual-tts`). Verify the keys exist before referencing them.
-   - Local catalog endpoints must use Compose service names (`nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `parakeet-ctc-asr:50052`, `parakeet-rnnt-asr:50052`, `tts-service:50051`, `chatterbox-tts-service:50051`, `nvidia-llm:8000`, `nvidia-llm-vllm:8000`, `nvidia-llm-vllm-omni:8002`, `nemo-speech:50051`, `nemo-speech-multilingual:50051`, `nemo-speech-tts:50051`, `booking-server:8001`). Host-run backends auto-rewrite to the matching `localhost` ports.
-   - Alternate local ASR/TTS use Compose profiles (`parakeet-ctc-asr`, `parakeet-rnnt-asr`, `chatterbox-tts`) and share ports with the default. Scale the default off (e.g. `--scale tts-service=0` or `--scale nemotron-asr-streaming-multilingual=0`). Stop an opt-in alternate before returning to the default if it still holds the shared ports.
-   - Server local Compose runs ASR/TTS and NIM LLM on GPU `0` by default. Single-GPU deployments are supported only when at least 80 GB of VRAM is available.
+   - Multilingual prompts must use multilingual-capable ASR and TTS from the active catalog (e.g. `parakeet-rnnt`, `nemotron-asr-streaming-multilingual`, `magpie-multilingual-tts`, `magpie-zeroshot-tts`, `chatterbox-multilingual-tts`). Verify the keys exist before referencing them.
+   - Local catalog endpoints must use Compose service names (`nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `parakeet-ctc-asr:50052`, `parakeet-rnnt-asr:50052`, `magpie-multilingual-tts-service:50051`, `magpie-zeroshot-tts-service:50051`, `chatterbox-tts-service:50051`, `nvidia-llm:8000`, `nvidia-llm-vllm:8000`, `nvidia-llm-vllm-omni:8002`, `nemo-speech:50051`, `nemo-speech-multilingual:50051`, `nemo-speech-tts:50051`, `booking-server:8001`). Host-run backends auto-rewrite to the matching `localhost` ports.
+   - Alternate local ASR/TTS use Compose profiles (`parakeet-ctc-asr`, `parakeet-rnnt-asr`, `chatterbox-tts`, `magpie-zeroshot-tts`) and share ports with the default. Scale the default off (e.g. `--scale magpie-multilingual-tts-service=0` or `--scale nemotron-asr-streaming-multilingual=0`). Stop `chatterbox-tts-service` or `magpie-zeroshot-tts-service` before returning to Magpie Multilingual.
+   - A `*/server` recipe that colocates the default ASR, LLM, and TTS on one GPU needs about 80 GB of VRAM. This does not apply to `*/single-gpu` recipes, which use the memory-fit procedure in the `deploy` skill.
 
 4. Apply and verify using `references/apply-changes.md`.
 
@@ -48,7 +48,7 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
 - `.env` changes: compose re-apply.
 - YAML catalog changes (`prompts.yaml`, `services.*.yaml`, `examples_registry.yaml`): compose restart of the example service. `./src` and `./examples_registry.yaml` are bind-mounted, so no rebuild needed.
 - Preserve unrelated keys, comments, and entries while editing.
-- Alternate local ASR/TTS use Compose profiles where needed (`parakeet-ctc-asr`, `parakeet-rnnt-asr`, `chatterbox-tts`). Magpie TTS uses `tts-service`.
+- Alternate local ASR/TTS use Compose profiles where needed (`parakeet-ctc-asr`, `parakeet-rnnt-asr`, `chatterbox-tts`, `magpie-zeroshot-tts`). Magpie Multilingual uses `magpie-multilingual-tts-service`. Magpie Zeroshot uses `magpie-zeroshot-tts-service`.
 - Per-example slot defaults live in `examples_registry.yaml` `defaults`. The catalog file ordering only affects UI listings. The actual default is whatever `defaults` declares.
 
 ## Examples
@@ -62,7 +62,7 @@ Edit the runtime configuration of the voice agent (built-in catalogs, prompts, f
 
 1. Add the prompt to the active example's `prompts.yaml`.
 2. To make it the per-example default, update `examples_registry.yaml` `defaults.prompt` for that example to the new prompt key.
-3. Ensure the active example's catalog has multilingual-capable ASR (`parakeet-rnnt` or `nemotron-asr-streaming-multilingual`) and TTS (`magpie-multilingual-tts` or `chatterbox-multilingual-tts`).
+3. Ensure the active example's catalog has multilingual-capable ASR (`parakeet-rnnt` or `nemotron-asr-streaming-multilingual`) and TTS (`magpie-multilingual-tts`, `magpie-zeroshot-tts`, or `chatterbox-multilingual-tts`).
 4. Compose restart of the example service and refresh browser.
 
 ## Limitations

--- a/skills/configure-pipeline/references/apply-changes.md
+++ b/skills/configure-pipeline/references/apply-changes.md
@@ -49,7 +49,7 @@ docker compose --profile omni-assistant/server up -d
 docker compose --profile omni-assistant-subagents/server up -d
 docker compose --profile frontend-backend-agent/server up -d
 
-# Multi-GPU performance benchmark (recommended for scaling)
+# Multi-GPU performance benchmark only
 docker compose --profile generic-assistant/server-perf up -d
 
 # Universal one-GPU path (workstation, DGX Spark, or Jetson Thor)

--- a/skills/configure-pipeline/references/apply-changes.md
+++ b/skills/configure-pipeline/references/apply-changes.md
@@ -15,7 +15,8 @@ The catalog stores Compose DNS endpoints. The backend rewrites them to `localhos
 | --- | --- |
 | `http://nvidia-llm:8000/v1` | `http://localhost:18000/v1` |
 | `http://nvidia-llm-vllm:8000/v1` | `http://localhost:18000/v1` |
-| `tts-service:50051` | `localhost:50151` |
+| `magpie-multilingual-tts-service:50051` | `localhost:50151` |
+| `magpie-zeroshot-tts-service:50051` | `localhost:50151` |
 | `chatterbox-tts-service:50051` | `localhost:50151` |
 | `nemotron-asr-streaming-english:50052` | `localhost:50152` |
 | `nemotron-asr-streaming-multilingual:50052` | `localhost:50152` |
@@ -24,6 +25,8 @@ The catalog stores Compose DNS endpoints. The backend rewrites them to `localhos
 | `nemo-speech:50051` | `localhost:50051` |
 | `nemo-speech-multilingual:50051` | `localhost:50051` |
 | `nemo-speech-tts:50051` | `localhost:50051` |
+
+Use the exact Compose service name for each local endpoint. Model-specific TTS and ASR names let Compose define alternatives that share host ports.
 
 Cloud catalog entries use NVCF endpoints (`grpc.nvcf.nvidia.com:443`, `https://integrate.api.nvidia.com/v1`, `wss://grpc.nvcf.nvidia.com/v1/realtime`) and are not rewritten.
 
@@ -45,6 +48,9 @@ docker compose --profile multilingual-assistant/server up -d
 docker compose --profile omni-assistant/server up -d
 docker compose --profile omni-assistant-subagents/server up -d
 docker compose --profile frontend-backend-agent/server up -d
+
+# Multi-GPU performance benchmark (recommended for scaling)
+docker compose --profile generic-assistant/server-perf up -d
 
 # Universal one-GPU path (workstation, DGX Spark, or Jetson Thor)
 docker compose --profile generic-assistant/single-gpu up -d
@@ -82,10 +88,10 @@ docker compose --profile generic-assistant/single-gpu --profile tracing --profil
 
 - The selected recipe profile matches the example and hardware you want active.
 - `examples_registry.yaml` `defaults` references catalog keys that actually exist for that example.
-- Multilingual prompt selection is paired with multilingual-capable ASR (`parakeet-rnnt` by default, or `nemotron-asr-streaming-multilingual` when opted in) and TTS (`magpie-multilingual-tts` or `chatterbox-multilingual-tts`) in the active catalog.
+- Multilingual prompt selection is paired with multilingual-capable ASR (`parakeet-rnnt` by default, or `nemotron-asr-streaming-multilingual` when opted in) and TTS (`magpie-multilingual-tts`, `magpie-zeroshot-tts`, or `chatterbox-multilingual-tts`) in the active catalog.
 - If `ENABLE_TRACING=true` with `phoenix:4317`, the `phoenix` service is started through the `tracing` profile.
 - Compose-managed local entries use service DNS names, not `localhost`.
-- ASR/TTS image variants use their Compose service DNS names (for example `nemotron-asr-streaming-english:50052`, `nemotron-asr-streaming-multilingual:50052`, `tts-service:50051`).
+- Local catalog endpoints must match the exact Compose service name. Do not replace model-specific names with generic role names.
 
 ## Verify
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 - Preserve existing `.env`. Create it only if missing.
 - Use `configure-pipeline` for `.env`, catalog, or prompt changes.
 - Every deployment specifies **exactly one recipe profile** (plus optional observability profiles). `docker compose up` with no profile is a no-op.
-- Recipe profile names are `<example>` for cloud-only deployments, `<example>/server` for NIM deployments, and `<example>/single-gpu` for the NeMo-Speech.cpp and vLLM stack. `generic-assistant/server-perf` is the scaling benchmark profile. Each profile is a complete, self-contained recipe. Never combine two recipes.
+- Recipe profile names are `<example>` for cloud-only deployments, `<example>/server` for NIM deployments, and `<example>/single-gpu` for the NeMo-Speech.cpp and vLLM stack. `generic-assistant/server-perf` is a benchmark-only scaling profile, not a normal UI deployment. Each profile is a complete, self-contained recipe. Never combine two recipes.
 - Generic, Multilingual, Omni, and Frontend/Backend single-GPU recipes support compatible workstations, DGX Spark, and Jetson Thor. Omni Assistant Subagents is documented for workstations and DGX Spark only. Do not infer that a recipe fits from the platform name. Complete the memory-fit procedure below first.
 - Selector modes (`all`, or a single `<example>` such as `generic-assistant`) remain host-native only (`uv run`) and have no compose profile.
 - Observability profiles (`tracing`, `turn`) compose orthogonally with any recipe.
@@ -142,7 +142,7 @@ Apply only what step 1 indicates. Never silently change values. See `docs/how-to
 | Omni Assistant Subagents, single GPU (workstation, DGX Spark) | `omni-assistant-subagents/single-gpu` |
 | Frontend/Backend Agent, single GPU (workstation, DGX Spark, Jetson Thor) | `frontend-backend-agent/single-gpu` |
 | Generic Cascaded NIM stack | `generic-assistant/server` |
-| Generic Cascaded NIM performance benchmark (recommended for scaling) | `generic-assistant/server-perf` |
+| Generic Cascaded NIM performance benchmark (benchmark-only) | `generic-assistant/server-perf` |
 | Multilingual Cascaded NIM stack (recommended for scaling) | `multilingual-assistant/server` |
 | Omni Assistant NIM stack (recommended for scaling) | `omni-assistant/server` |
 | Omni Assistant Subagents NIM stack (recommended for scaling) | `omni-assistant-subagents/server` |

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -123,7 +123,7 @@ The cascaded Lightning support matrix is fixed in its compose file:
 - Ada/Hopper workstation: BF16 checkpoint with online FP8 quantization.
 - Older compute capabilities are unsupported. Use cloud services.
 
-Device placement (which GPU each sidecar uses) is **not** an `.env` knob. `device_ids` are hardcoded to `['0']`. To move a service to GPU `N`, edit `device_ids: ['N']` under `deploy.resources.reservations.devices` in the service's Compose file. Server files include `docker/docker-compose.nemotron-asr.yaml`, `docker/docker-compose.magpie-tts.yaml`, `docker/docker-compose.nemotron35-lightning-nim.yaml`, and `docker/docker-compose.nemotron3-omni-nim.yaml`. Single-GPU files include `docker/docker-compose.nemo-speech-cpp.yaml`, `docker/docker-compose.nemotron35-lightning.yaml`, and `docker/docker-compose.nemotron3-omni.yaml`. A tensor-parallel LLM (`tp=N`) needs `N` GPUs. List every index it uses and keep those GPUs free of ASR and TTS. Each target index must appear in the step 1 readout. With only one GPU you cannot split. Keep everything on GPU 0, or run the cloud-only profile so ASR, TTS, and LLM use NVCF instead.
+Device placement is **not** an `.env` knob. Standard `*/server` sidecars default to GPU `0`. The four-GPU `generic-assistant/server-perf` recipe places ASR on GPU `0`, TTS on GPU `1`, and the tensor-parallel LLM on GPUs `2` and `3`. To move a service, edit `device_ids` under `deploy.resources.reservations.devices` in its Compose file. Server files include `docker/docker-compose.nemotron-asr.yaml`, `docker/docker-compose.magpie-tts.yaml`, `docker/docker-compose.magpie-zeroshot-tts.yaml`, `docker/docker-compose.chatterbox-tts.yaml`, `docker/docker-compose.nemotron35-lightning-nim.yaml`, and `docker/docker-compose.nemotron3-omni-nim.yaml`. Single-GPU files include `docker/docker-compose.nemo-speech-cpp.yaml`, `docker/docker-compose.nemotron35-lightning.yaml`, and `docker/docker-compose.nemotron3-omni.yaml`. A tensor-parallel LLM (`tp=N`) needs `N` GPUs. List every index it uses and keep those GPUs free of ASR and TTS. Each target index must appear in the step 1 readout. With only one GPU you cannot split. Keep everything on GPU 0, or run the cloud-only profile so ASR, TTS, and LLM use NVCF instead.
 
 Apply only what step 1 indicates. Never silently change values. See `docs/how-to/configure-llm.md` (VRAM & hardware support) for the full reasoning.
 
@@ -141,7 +141,8 @@ Apply only what step 1 indicates. Never silently change values. See `docs/how-to
 | Omni Assistant, single GPU (workstation, DGX Spark, Jetson Thor) | `omni-assistant/single-gpu` |
 | Omni Assistant Subagents, single GPU (workstation, DGX Spark) | `omni-assistant-subagents/single-gpu` |
 | Frontend/Backend Agent, single GPU (workstation, DGX Spark, Jetson Thor) | `frontend-backend-agent/single-gpu` |
-| Generic Cascaded NIM stack (recommended for scaling) | `generic-assistant/server` |
+| Generic Cascaded NIM stack | `generic-assistant/server` |
+| Generic Cascaded NIM performance benchmark (recommended for scaling) | `generic-assistant/server-perf` |
 | Multilingual Cascaded NIM stack (recommended for scaling) | `multilingual-assistant/server` |
 | Omni Assistant NIM stack (recommended for scaling) | `omni-assistant/server` |
 | Omni Assistant Subagents NIM stack (recommended for scaling) | `omni-assistant-subagents/server` |
@@ -175,7 +176,7 @@ curl -k https://localhost:${PIPELINE_APP_PORT:-7860}/api/ice-servers \
   || curl http://localhost:${PIPELINE_APP_PORT:-7860}/api/ice-servers
 ```
 
-App service names follow the active example. Server recipes use `generic-assistant-server`, `multilingual-assistant-server`, `omni-assistant-server`, `omni-assistant-subagents-server`, and `frontend-backend-agent-server`. Single-GPU recipes use `generic-assistant-single-gpu`, `multilingual-assistant-single-gpu`, `omni-assistant-single-gpu`, `omni-assistant-subagents-single-gpu`, and `frontend-backend-agent-single-gpu`. Their speech sidecars are `nemo-speech`, `nemo-speech-multilingual`, and `nemo-speech-tts`.
+App service names follow the active example. Server recipes use `generic-assistant-server`, `generic-assistant-server-perf`, `multilingual-assistant-server`, `omni-assistant-server`, `omni-assistant-subagents-server`, and `frontend-backend-agent-server`. Single-GPU recipes use `generic-assistant-single-gpu`, `multilingual-assistant-single-gpu`, `omni-assistant-single-gpu`, `omni-assistant-subagents-single-gpu`, and `frontend-backend-agent-single-gpu`. Their speech sidecars are `nemo-speech`, `nemo-speech-multilingual`, and `nemo-speech-tts`.
 
 ## References
 

--- a/skills/deploy/references/frontend-backend-agent-deploy.md
+++ b/skills/deploy/references/frontend-backend-agent-deploy.md
@@ -15,7 +15,7 @@ docker compose --profile frontend-backend-agent/single-gpu up -d
 | Recipe profile | App service | Sidecars |
 | --- | --- | --- |
 | `frontend-backend-agent` | `frontend-backend-agent` | `booking-server` |
-| `frontend-backend-agent/server` | `frontend-backend-agent-server` | `booking-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `tts-service` |
+| `frontend-backend-agent/server` | `frontend-backend-agent-server` | `booking-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `magpie-multilingual-tts-service` |
 | `frontend-backend-agent/single-gpu` | `frontend-backend-agent-single-gpu` | `booking-server`, `nvidia-llm-vllm-lightning`, `nemo-speech` |
 
 Tear down with the same recipe used at `up` time.
@@ -30,7 +30,7 @@ docker compose --profile <recipe> down
 - Server app logs: `docker compose logs --tail 200 frontend-backend-agent-server`.
 - Single-GPU app logs: `docker compose logs --tail 200 frontend-backend-agent-single-gpu`.
 - Booking server logs: `docker compose logs --tail 200 booking-server`.
-- Server local service logs: `docker compose logs --tail 200 nvidia-llm nemotron-asr-streaming-english tts-service`.
+- Server local service logs: `docker compose logs --tail 200 nvidia-llm nemotron-asr-streaming-english magpie-multilingual-tts-service`.
 
 ## Limits
 

--- a/skills/deploy/references/generic-deploy.md
+++ b/skills/deploy/references/generic-deploy.md
@@ -4,7 +4,7 @@ Use this reference from the `deploy` skill when deploying the generic voice pipe
 
 ## When to use
 
-Pinning a Docker Compose deployment to the Generic Cascaded example. Use `generic-assistant` for cloud, `generic-assistant/server` for the NIM stack, `generic-assistant/server-perf` for the multi-GPU benchmark stack, or `generic-assistant/single-gpu` for vLLM and NeMo-Speech.cpp. Selector modes are host-native only and are not exposed as Compose profiles.
+Pinning a Docker Compose deployment to the Generic Cascaded example. Use `generic-assistant` for cloud, `generic-assistant/server` for the NIM stack, `generic-assistant/server-perf` only for the multi-GPU scaling benchmark, or `generic-assistant/single-gpu` for vLLM and NeMo-Speech.cpp. Selector modes are host-native only and are not exposed as Compose profiles.
 
 Per-example catalogs at `src/examples/generic/services.{cloud,local}.yaml` are auto-selected on container startup because the registry resolves the example for the active recipe.
 
@@ -22,6 +22,8 @@ docker compose --profile <recipe> up -d
 | `generic-assistant/server` | `generic-assistant-server` | `nvidia-llm`, `nemotron-asr-streaming-english`, `magpie-multilingual-tts-service` |
 | `generic-assistant/server-perf` | `generic-assistant-server-perf` | `nvidia-llm-perf`, `nemotron-asr-streaming-english-perf`, `magpie-multilingual-tts-service-perf` |
 | `generic-assistant/single-gpu` | `generic-assistant-single-gpu` | `nvidia-llm-vllm-lightning`, `nemo-speech` |
+
+`generic-assistant/server-perf` requires the documented four-GPU layout and runs 200 Uvicorn workers for load testing. Do not use it for normal browser UI sessions. Follow `benchmarking_tools/scaling-perf/README.md`.
 
 Tear down with the same recipe used at `up` time:
 

--- a/skills/deploy/references/generic-deploy.md
+++ b/skills/deploy/references/generic-deploy.md
@@ -4,7 +4,7 @@ Use this reference from the `deploy` skill when deploying the generic voice pipe
 
 ## When to use
 
-Pinning a Docker Compose deployment to the Generic Cascaded example. Use `generic-assistant` for cloud, `generic-assistant/server` for the NIM stack, or `generic-assistant/single-gpu` for vLLM and NeMo-Speech.cpp. Selector modes are host-native only and are not exposed as Compose profiles.
+Pinning a Docker Compose deployment to the Generic Cascaded example. Use `generic-assistant` for cloud, `generic-assistant/server` for the NIM stack, `generic-assistant/server-perf` for the multi-GPU benchmark stack, or `generic-assistant/single-gpu` for vLLM and NeMo-Speech.cpp. Selector modes are host-native only and are not exposed as Compose profiles.
 
 Per-example catalogs at `src/examples/generic/services.{cloud,local}.yaml` are auto-selected on container startup because the registry resolves the example for the active recipe.
 
@@ -19,7 +19,8 @@ docker compose --profile <recipe> up -d
 | Recipe profile | App service | Sidecars from `docker/` |
 | --- | --- | --- |
 | `generic-assistant` | `generic-assistant` | none (cloud NVCF) |
-| `generic-assistant/server` | `generic-assistant-server` | `nvidia-llm`, `nemotron-asr-streaming-english`, `tts-service` |
+| `generic-assistant/server` | `generic-assistant-server` | `nvidia-llm`, `nemotron-asr-streaming-english`, `magpie-multilingual-tts-service` |
+| `generic-assistant/server-perf` | `generic-assistant-server-perf` | `nvidia-llm-perf`, `nemotron-asr-streaming-english-perf`, `magpie-multilingual-tts-service-perf` |
 | `generic-assistant/single-gpu` | `generic-assistant-single-gpu` | `nvidia-llm-vllm-lightning`, `nemo-speech` |
 
 Tear down with the same recipe used at `up` time:
@@ -34,6 +35,7 @@ docker compose --profile <recipe> down
 - Container status: `docker compose ps`.
 - Cloud app logs: `docker compose logs --tail 200 generic-assistant`.
 - Server app logs: `docker compose logs --tail 200 generic-assistant-server`.
+- Performance server app logs: `docker compose logs --tail 200 generic-assistant-server-perf`.
 - Single-GPU app logs: `docker compose logs --tail 200 generic-assistant-single-gpu`.
 
 ## Local LLM NIM profiles

--- a/skills/deploy/references/omni-assistant-deploy.md
+++ b/skills/deploy/references/omni-assistant-deploy.md
@@ -26,7 +26,7 @@ docker compose --profile omni-assistant/single-gpu up -d
 | Recipe profile | App service | Sidecars from `docker/` |
 | --- | --- | --- |
 | `omni-assistant` | `omni-assistant` | none (cloud NVCF) |
-| `omni-assistant/server` | `omni-assistant-server` | `nvidia-llm-omni`, `tts-service` |
+| `omni-assistant/server` | `omni-assistant-server` | `nvidia-llm-omni`, `magpie-multilingual-tts-service` |
 | `omni-assistant/single-gpu` | `omni-assistant-single-gpu` | `nvidia-llm-vllm-omni`, `nemo-speech-tts` |
 
 Tear down with the same recipe used at `up` time.
@@ -35,14 +35,14 @@ Tear down with the same recipe used at `up` time.
 
 - UI at `https://<host>:7860/` by default, or `http://<host>:7860/` when `PIPELINE_TLS=false`.
 - Cloud app logs: `docker compose logs --tail 200 omni-assistant`.
-- Server app and NIM logs: `docker compose logs --tail 200 omni-assistant-server nvidia-llm-omni tts-service`.
+- Server app and NIM logs: `docker compose logs --tail 200 omni-assistant-server nvidia-llm-omni magpie-multilingual-tts-service`.
 - Single-GPU app and sidecar logs: `docker compose logs --tail 200 omni-assistant-single-gpu nvidia-llm-vllm-omni nemo-speech-tts`.
 - Server NIM health: `curl -f http://localhost:18002/v1/health/ready`.
 - Single-GPU vLLM health: `curl -f http://localhost:8002/health`.
 
 ## GPU memory & device placement
 
-Omni handles ASR inside the model, so there is no separate ASR NIM. The `server` recipe uses `nvidia-llm-omni` and `tts-service`. The single-GPU recipe uses `nvidia-llm-vllm-omni` and `nemo-speech-tts`.
+Omni handles ASR inside the model, so there is no separate ASR NIM. The `server` recipe uses `nvidia-llm-omni` and `magpie-multilingual-tts-service`. The single-GPU recipe uses `nvidia-llm-vllm-omni` and `nemo-speech-tts`.
 
 For the VRAM, `--gpu-memory-utilization`, and device-placement matrix, see [VRAM & hardware support](../../../docs/how-to/configure-llm.md#vram--hardware-support).
 
@@ -51,5 +51,5 @@ For the VRAM, `--gpu-memory-utilization`, and device-placement matrix, see [VRAM
 - **`pull access denied` / `unauthorized`** -> NGC login was not done or expired. See the root `deploy` skill.
 - **Omni vLLM stuck on first-run model download** -> initial download of `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4` from Hugging Face requires `HF_TOKEN` in `.env`. Allow up to 30 minutes on first start.
 - **`No available memory for the cache blocks` on startup** -> `--gpu-memory-utilization` is too **low** for this GPU, leaving no room for the KV cache after the weights. Raise it and give the LLM a dedicated GPU. Do not lower it.
-- **True out-of-memory (CUDA OOM) during model load** -> the fraction collides with another process on the same GPU. Lower `--gpu-memory-utilization` or `--max-model-len`, or move `tts-service` to a separate GPU.
+- **True out-of-memory (CUDA OOM) during model load** -> the fraction collides with another process on the same GPU. Lower `--gpu-memory-utilization` or `--max-model-len`, or move `magpie-multilingual-tts-service` to a separate GPU.
 - **Tear-down leaves orphan services after a service rename** -> rerun `up` or `down` with `--remove-orphans`.

--- a/skills/deploy/references/omni-assistant-subagents-deploy.md
+++ b/skills/deploy/references/omni-assistant-subagents-deploy.md
@@ -28,7 +28,7 @@ docker compose --profile omni-assistant-subagents/single-gpu up -d
 | Recipe profile | App service | Sidecars from `docker/` |
 | --- | --- | --- |
 | `omni-assistant-subagents` | `omni-assistant-subagents` | none (cloud NVCF) |
-| `omni-assistant-subagents/server` | `omni-assistant-subagents-server` | `nvidia-llm-omni`, `tts-service` |
+| `omni-assistant-subagents/server` | `omni-assistant-subagents-server` | `nvidia-llm-omni`, `magpie-multilingual-tts-service` |
 | `omni-assistant-subagents/single-gpu` | `omni-assistant-subagents-single-gpu` | `nvidia-llm-vllm-omni`, `nemo-speech-tts` |
 
 Tear down with the same recipe used at `up` time.

--- a/skills/deploy/references/platform-deployment.md
+++ b/skills/deploy/references/platform-deployment.md
@@ -19,11 +19,11 @@ Required `.env` keys:
 Recipes: `generic-assistant/server`, `multilingual-assistant/server`, `omni-assistant/server`, `omni-assistant-subagents/server`, `frontend-backend-agent/server`.
 
 Services depend on the recipe:
-- `generic-assistant/server`: `generic-assistant-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `tts-service`
-- `multilingual-assistant/server`: `multilingual-assistant-server`, `nvidia-llm`, `nemotron-asr-streaming-multilingual`, `tts-service`
-- `omni-assistant/server`: `omni-assistant-server`, `nvidia-llm-omni`, `tts-service`
-- `omni-assistant-subagents/server`: `omni-assistant-subagents-server`, `nvidia-llm-omni`, `tts-service`
-- `frontend-backend-agent/server`: `frontend-backend-agent-server`, `booking-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `tts-service`
+- `generic-assistant/server`: `generic-assistant-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `magpie-multilingual-tts-service`
+- `multilingual-assistant/server`: `multilingual-assistant-server`, `nvidia-llm`, `nemotron-asr-streaming-multilingual`, `magpie-multilingual-tts-service`
+- `omni-assistant/server`: `omni-assistant-server`, `nvidia-llm-omni`, `magpie-multilingual-tts-service`
+- `omni-assistant-subagents/server`: `omni-assistant-subagents-server`, `nvidia-llm-omni`, `magpie-multilingual-tts-service`
+- `frontend-backend-agent/server`: `frontend-backend-agent-server`, `booking-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `magpie-multilingual-tts-service`
 
 Requires enough GPU VRAM for the selected local NIM services. Single-GPU hosts are valid when capacity is sufficient. Multi-GPU hosts may split speech sidecars and LLM across devices. For the user-facing VRAM, memory-knob, and device-placement matrix, see [VRAM & hardware support](../../../docs/how-to/configure-llm.md#vram--hardware-support).
 

--- a/skills/upgrade-pipecat/SKILL.md
+++ b/skills/upgrade-pipecat/SKILL.md
@@ -65,6 +65,10 @@ signatures, trust the actual installed/new source; use the MCP for intent and mi
 - **Examples are the unit of work**: 5 examples (`generic`, `multilingual`, `omni_assistant`,
   `omni_assistant_subagents`, `frontend_backend_agent`), each with its own `pipeline.py`. One agent per example + one
   cross-cutting agent for `src/examples/shared/` and `src/server.py`.
+- **Custom service subclasses require parent-API review**: explicitly inspect
+  `src/examples/shared/nvidia_word_tts.py` (`NvidiaWordTTSService`) and
+  `src/examples/omni_assistant/nvidia_omni_multimodal_service.py`. Diff their upstream parent services before
+  validating overrides, lifecycle methods, settings, frames, and private compatibility contracts.
 - **Server + client move together (RTVI contract)**: the RTVI wire protocol couples the Python server to the
   `@pipecat-ai/*` client packages, so they must be upgraded in lockstep. Bump `client/package.json` to versions
   compatible with the target `pipecat-ai`, migrate `client/src/` RTVI usage (renamed events/messages), and gate

--- a/skills/upgrade-pipecat/workflows/01-explore-discover.md
+++ b/skills/upgrade-pipecat/workflows/01-explore-discover.md
@@ -137,6 +137,9 @@ Server: `src/examples/shared/` plumbing (`pipeline_utils.py`, `prewarm.py`, `aud
 `src/server.py` (runner/transport/serializer); each `src/examples/*/pipeline.py`; `pyproject.toml`/`uv.lock`
 pins+extras; every `from pipecat*` import; custom subclasses of
 `FrameProcessor`/`BaseUserMuteStrategy`/`BaseTextFilter`/`PipelineWorker`/`BaseWorker`.
+Always inspect custom service subclasses against their new parent implementations, especially
+`src/examples/shared/nvidia_word_tts.py` (`NvidiaWordTTSService`) and
+`src/examples/omni_assistant/nvidia_omni_multimodal_service.py`.
 Client: `client/package.json` `@pipecat-ai/*` deps; every `@pipecat-ai/*` import in `client/src/**` and where
 RTVI is used (client init/transport setup, RTVI event/message handlers, providers/hooks). Note files for the
 change matrix.

--- a/skills/upgrade-pipecat/workflows/03-gap-analysis-loop.md
+++ b/skills/upgrade-pipecat/workflows/03-gap-analysis-loop.md
@@ -30,7 +30,9 @@ and cite the `source_url`.
 **Cross-cutting** (one agent): shared plumbing (`src/examples/shared/`), `src/server.py` wiring,
 `Nvidia{LLM,STT,TTS}Service`+`*Settings`, `turns.*`+`audio.turn.smart_turn.*`, all `frames.frames` imports,
 extras + every dependency change (bump/rename/removed-if-folded-in) in `pyproject.toml`/`uv.lock`, dead imports
-(`ruff` F401/F811). Report PASS/GAP.
+(`ruff` F401/F811). Explicitly validate `NvidiaWordTTSService` and the custom Omni multimodal service against
+their upgraded parent classes, including overridden lifecycle methods, settings, emitted frames, and private
+compatibility contracts. Report PASS/GAP.
 
 **Client** (one agent): every `@pipecat-ai/*` import in `client/src/**` resolves; RTVI usage (events, messages,
 providers/hooks, transport setup) matches the renamed client APIs from the notes; `client/package.json` versions

--- a/src/examples/frontend_backend_agent/README.md
+++ b/src/examples/frontend_backend_agent/README.md
@@ -43,7 +43,7 @@ This example runs with **Cloud**, **Server** (NIM, recommended for scaling), and
    | Recipe profile | App service | Sidecars |
    | --- | --- | --- |
    | `frontend-backend-agent` | `frontend-backend-agent` | `booking-server` |
-   | `frontend-backend-agent/server` | `frontend-backend-agent-server` | `booking-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `tts-service` |
+   | `frontend-backend-agent/server` | `frontend-backend-agent-server` | `booking-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `magpie-multilingual-tts-service` |
    | `frontend-backend-agent/single-gpu` | `frontend-backend-agent-single-gpu` | `booking-server`, `nvidia-llm-vllm-lightning`, `nemo-speech` |
 
 4. Open the UI at `https://localhost:7860/`. Keep TLS enabled for browser UI testing. `PIPELINE_TLS=false` serves plain HTTP for headless performance and API testing. For plain-HTTP browser testing, see [browser access](../../../docs/06-troubleshooting.md#browser-access).

--- a/src/examples/frontend_backend_agent/services.local.yaml
+++ b/src/examples/frontend_backend_agent/services.local.yaml
@@ -24,7 +24,7 @@ server:
   tts:
     magpie-multilingual-tts:
       name: "Magpie TTS"
-      server: "tts-service:50051"
+      server: "magpie-multilingual-tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       model: "magpie-tts-multilingual"
       function_id: ""

--- a/src/examples/generic/README.md
+++ b/src/examples/generic/README.md
@@ -6,7 +6,7 @@ Generic cascaded voice pipeline using Pipecat's built-in NVIDIA services (`Nvidi
 
 ## Running the example
 
-This example runs with **Cloud**, **Server** (NIM, recommended for scaling), and universal **Single GPU** profiles. The single-gpu profile covers workstations, DGX Spark, and Jetson Thor. See the [Getting Started guide](../../../docs/01-getting-started.md) for prerequisites and hardware detail. Run commands from the repository root.
+This example runs with **Cloud**, **Server** (NIM), **Performance Server** (NIM, recommended for scaling), and universal **Single GPU** profiles. The performance profile uses the dedicated four-GPU layout documented in the [scaling benchmark](../../../benchmarking_tools/scaling-perf/README.md#reproducing-the-best-scaling-setup). The single-gpu profile covers workstations, DGX Spark, and Jetson Thor. See the [Getting Started guide](../../../docs/01-getting-started.md) for prerequisites and hardware detail. Run commands from the repository root.
 
 1. Create your `.env` from the template and set your NVIDIA API key:
 
@@ -26,8 +26,9 @@ This example runs with **Cloud**, **Server** (NIM, recommended for scaling), and
 3. Deploy the profile that matches your hardware:
 
    ```bash
-   docker compose --profile generic-assistant up -d              # Cloud (no local GPU)
-   docker compose --profile generic-assistant/server up -d  # Server (NIM, recommended for scaling)
+   docker compose --profile generic-assistant up -d             # Cloud (no local GPU)
+   docker compose --profile generic-assistant/server up -d      # Server (NIM)
+   docker compose --profile generic-assistant/server-perf up -d # Four-GPU performance benchmark
 
    # One GPU (incl. DGX Spark and Jetson Thor). Download speech weights once, as your user:
    bash scripts/download-nemo-speech-models.sh
@@ -37,7 +38,8 @@ This example runs with **Cloud**, **Server** (NIM, recommended for scaling), and
    | Recipe profile | App service | Sidecars |
    | --- | --- | --- |
    | `generic-assistant` | `generic-assistant` | none (cloud NVCF) |
-   | `generic-assistant/server` | `generic-assistant-server` | `nvidia-llm`, `nemotron-asr-streaming-english`, `tts-service` |
+   | `generic-assistant/server` | `generic-assistant-server` | `nvidia-llm`, `nemotron-asr-streaming-english`, `magpie-multilingual-tts-service` |
+   | `generic-assistant/server-perf` | `generic-assistant-server-perf` | `nvidia-llm-perf`, `nemotron-asr-streaming-english-perf`, `magpie-multilingual-tts-service-perf` |
    | `generic-assistant/single-gpu` | `generic-assistant-single-gpu` | `nvidia-llm-vllm-lightning`, `nemo-speech` |
 
    > Lightning selects its platform and precision recipe automatically.
@@ -47,9 +49,10 @@ This example runs with **Cloud**, **Server** (NIM, recommended for scaling), and
 5. Clean up when you are done by tearing down with the same profile you started with:
 
    ```bash
-   docker compose --profile generic-assistant down              # Cloud (no local GPU)
-   docker compose --profile generic-assistant/server down  # Server
-   docker compose --profile generic-assistant/single-gpu down   # One GPU (incl. DGX Spark and Jetson Thor)
+   docker compose --profile generic-assistant down             # Cloud (no local GPU)
+   docker compose --profile generic-assistant/server down      # Server
+   docker compose --profile generic-assistant/server-perf down # Four-GPU performance benchmark
+   docker compose --profile generic-assistant/single-gpu down  # One GPU (incl. DGX Spark and Jetson Thor)
    ```
 
 To run host-native without Docker, set `selection: generic-assistant` in [`examples_registry.yaml`](../../../examples_registry.yaml), then run `uv run python3 src/server.py`.

--- a/src/examples/generic/README.md
+++ b/src/examples/generic/README.md
@@ -6,7 +6,7 @@ Generic cascaded voice pipeline using Pipecat's built-in NVIDIA services (`Nvidi
 
 ## Running the example
 
-This example runs with **Cloud**, **Server** (NIM), **Performance Server** (NIM, recommended for scaling), and universal **Single GPU** profiles. The performance profile uses the dedicated four-GPU layout documented in the [scaling benchmark](../../../benchmarking_tools/scaling-perf/README.md#reproducing-the-best-scaling-setup). The single-gpu profile covers workstations, DGX Spark, and Jetson Thor. See the [Getting Started guide](../../../docs/01-getting-started.md) for prerequisites and hardware detail. Run commands from the repository root.
+This example runs with **Cloud**, **Server** (NIM), benchmark-only **Performance Server** (NIM), and universal **Single GPU** profiles. The performance profile uses the dedicated four-GPU layout documented in the [scaling benchmark](../../../benchmarking_tools/scaling-perf/README.md#reproducing-the-best-scaling-setup). It runs 200 Uvicorn workers for load testing and is not intended for normal browser UI sessions. The single-gpu profile covers workstations, DGX Spark, and Jetson Thor. See the [Getting Started guide](../../../docs/01-getting-started.md) for prerequisites and hardware detail. Run commands from the repository root.
 
 1. Create your `.env` from the template and set your NVIDIA API key:
 
@@ -28,7 +28,7 @@ This example runs with **Cloud**, **Server** (NIM), **Performance Server** (NIM,
    ```bash
    docker compose --profile generic-assistant up -d             # Cloud (no local GPU)
    docker compose --profile generic-assistant/server up -d      # Server (NIM)
-   docker compose --profile generic-assistant/server-perf up -d # Four-GPU performance benchmark
+   docker compose --profile generic-assistant/server-perf up -d # Four-GPU benchmark only
 
    # One GPU (incl. DGX Spark and Jetson Thor). Download speech weights once, as your user:
    bash scripts/download-nemo-speech-models.sh
@@ -51,7 +51,7 @@ This example runs with **Cloud**, **Server** (NIM), **Performance Server** (NIM,
    ```bash
    docker compose --profile generic-assistant down             # Cloud (no local GPU)
    docker compose --profile generic-assistant/server down      # Server
-   docker compose --profile generic-assistant/server-perf down # Four-GPU performance benchmark
+   docker compose --profile generic-assistant/server-perf down # Four-GPU benchmark only
    docker compose --profile generic-assistant/single-gpu down  # One GPU (incl. DGX Spark and Jetson Thor)
    ```
 

--- a/src/examples/generic/services.local.yaml
+++ b/src/examples/generic/services.local.yaml
@@ -32,7 +32,7 @@ server:
   tts:
     magpie-multilingual-tts:
       name: "Magpie TTS"
-      server: "tts-service:50051"
+      server: "magpie-multilingual-tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       model: "magpie-tts-multilingual"
       function_id: ""

--- a/src/examples/multilingual/README.md
+++ b/src/examples/multilingual/README.md
@@ -39,7 +39,7 @@ This example runs with **Cloud**, **Server** (NIM, recommended for scaling), and
    | Recipe profile | App service | Sidecars |
    | --- | --- | --- |
    | `multilingual-assistant` | `multilingual-assistant` | none (cloud NVCF) |
-   | `multilingual-assistant/server` | `multilingual-assistant-server` | `nvidia-llm`, `nemotron-asr-streaming-multilingual`, `tts-service` |
+   | `multilingual-assistant/server` | `multilingual-assistant-server` | `nvidia-llm`, `nemotron-asr-streaming-multilingual`, `magpie-multilingual-tts-service` |
    | `multilingual-assistant/single-gpu` | `multilingual-assistant-single-gpu` | `nvidia-llm-vllm-lightning`, `nemo-speech-multilingual` |
 
 4. Open the UI at `https://localhost:7860/`. Keep TLS enabled for browser UI testing. `PIPELINE_TLS=false` serves plain HTTP for headless performance and API testing. For plain-HTTP browser testing, see [browser access](../../../docs/06-troubleshooting.md#browser-access).

--- a/src/examples/multilingual/services.local.yaml
+++ b/src/examples/multilingual/services.local.yaml
@@ -15,7 +15,7 @@ server:
   tts:
     magpie-multilingual-tts:
       name: "Magpie TTS"
-      server: "tts-service:50051"
+      server: "magpie-multilingual-tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       model: "magpie-tts-multilingual"
       function_id: ""

--- a/src/examples/omni_assistant/README.md
+++ b/src/examples/omni_assistant/README.md
@@ -39,7 +39,7 @@ This example runs with **Cloud**, **Server** (Omni NIM + NIM TTS, recommended fo
    | Recipe profile | App service | Shared sidecars pulled from `docker/` |
    | --- | --- | --- |
    | `omni-assistant` | `omni-assistant` | none (cloud NVCF) |
-   | `omni-assistant/server` | `omni-assistant-server` | `nvidia-llm-omni`, `tts-service` |
+   | `omni-assistant/server` | `omni-assistant-server` | `nvidia-llm-omni`, `magpie-multilingual-tts-service` |
    | `omni-assistant/single-gpu` | `omni-assistant-single-gpu` | `nvidia-llm-vllm-omni`, `nemo-speech-tts` |
 
    > The single-GPU recipe uses the Omni vLLM sidecar and takes TTS from the on-device NeMo-Speech.cpp `nemo-speech-tts` service instead of the NIM sidecars. Jetson Thor (128 GB unified memory) fits the 30B Omni NVFP4 model. Follow the [Jetson Thor guide](../../../docs/03-jetson-thor.md). Orin-class Jetson hardware is not supported because the models do not fit.

--- a/src/examples/omni_assistant/services.local.yaml
+++ b/src/examples/omni_assistant/services.local.yaml
@@ -14,7 +14,7 @@ server:
   tts:
     magpie-multilingual-tts:
       name: "Magpie TTS"
-      server: "tts-service:50051"
+      server: "magpie-multilingual-tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       model: "magpie-tts-multilingual"
       function_id: ""

--- a/src/examples/omni_assistant_subagents/README.md
+++ b/src/examples/omni_assistant_subagents/README.md
@@ -39,7 +39,7 @@ This example runs with **Cloud**, **Server** (Omni NIM + NIM TTS, recommended fo
    | Recipe profile | App service | Shared sidecars pulled from `docker/` |
    | --- | --- | --- |
    | `omni-assistant-subagents` | `omni-assistant-subagents` | none (cloud NVCF) |
-   | `omni-assistant-subagents/server` | `omni-assistant-subagents-server` | `nvidia-llm-omni`, `tts-service` |
+   | `omni-assistant-subagents/server` | `omni-assistant-subagents-server` | `nvidia-llm-omni`, `magpie-multilingual-tts-service` |
    | `omni-assistant-subagents/single-gpu` | `omni-assistant-subagents-single-gpu` | `nvidia-llm-vllm-omni`, `nemo-speech-tts` |
 
 4. Open the UI at `https://localhost:7860/`. Keep TLS enabled for browser UI testing. `PIPELINE_TLS=false` serves plain HTTP for headless performance and API testing. For plain-HTTP browser testing, see [browser access](../../../docs/06-troubleshooting.md#browser-access).

--- a/src/examples/omni_assistant_subagents/services.local.yaml
+++ b/src/examples/omni_assistant_subagents/services.local.yaml
@@ -11,7 +11,7 @@ server:
   tts:
     magpie-multilingual-tts:
       name: "Magpie TTS"
-      server: "tts-service:50051"
+      server: "magpie-multilingual-tts-service:50051"
       voice_id: "Magpie-Multilingual.EN-US.Aria"
       model: "magpie-tts-multilingual"
       function_id: ""

--- a/src/examples_registry.py
+++ b/src/examples_registry.py
@@ -160,7 +160,7 @@ def _rewrite_entry_for_host_runtime(entry: dict) -> dict:
             out[field] = (
                 value.replace("magpie-zeroshot-tts-service:50051", "localhost:50151")
                 .replace("chatterbox-tts-service:50051", "localhost:50151")
-                .replace("tts-service:50051", "localhost:50151")
+                .replace("magpie-multilingual-tts-service:50051", "localhost:50151")
                 .replace("nemotron-asr-streaming-english:50052", "localhost:50152")
                 .replace("nemotron-asr-streaming-multilingual:50052", "localhost:50152")
                 .replace("parakeet-ctc-asr:50052", "localhost:50152")

--- a/src/server.py
+++ b/src/server.py
@@ -107,7 +107,11 @@ _SPEECH_READY_ENDPOINTS = {
         9001,
     ),
     "tts": (
-        ("tts-service", "chatterbox-tts-service", "magpie-zeroshot-tts-service"),
+        (
+            "magpie-multilingual-tts-service",
+            "chatterbox-tts-service",
+            "magpie-zeroshot-tts-service",
+        ),
         50051,
         50151,
         9000,

--- a/src/utils.py
+++ b/src/utils.py
@@ -226,7 +226,7 @@ _HOST_RUNTIME_PORT_OVERRIDES: dict[tuple[str, int], int] = {
     ("nvidia-llm", 8000): 18000,
     ("nvidia-llm-omni", 8000): 18002,
     ("nvidia-llm-vllm", 8000): 18000,
-    ("tts-service", 50051): 50151,
+    ("magpie-multilingual-tts-service", 50051): 50151,
     ("chatterbox-tts-service", 50051): 50151,
     ("magpie-zeroshot-tts-service", 50051): 50151,
     ("nemotron-asr-streaming-english", 50052): 50152,

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -407,7 +407,7 @@ llm:
         try:
 
             def reachable(endpoint: str) -> bool:
-                return endpoint in {"tts-service:50051", "localhost:50151"}
+                return endpoint in {"magpie-multilingual-tts-service:50051", "localhost:50151"}
 
             with patch("utils.is_endpoint_reachable", side_effect=reachable):
                 tts = build_services_api_response()["tts"]
@@ -487,6 +487,14 @@ llm:
 
         self.assertEqual(rewritten["llm"]["omni"]["base_url"], "http://localhost:18002/v1")
 
+    def test_host_runtime_rewrites_magpie_multilingual_tts_endpoint(self) -> None:
+        entry = {"server": "magpie-multilingual-tts-service:50051"}
+
+        with patch.dict(os.environ, {"APP_RUNTIME": ""}):
+            rewritten = utils._rewrite_local_runtime_endpoints({"tts": {"magpie": entry}})
+
+        self.assertEqual(rewritten["tts"]["magpie"]["server"], "localhost:50151")
+
     def test_registry_host_runtime_rewrites_omni_endpoints(self) -> None:
         with patch.dict(os.environ, {"APP_RUNTIME": ""}):
             nim = examples_registry._rewrite_entry_for_host_runtime({"base_url": "http://nvidia-llm-omni:8000/v1"})
@@ -496,6 +504,14 @@ llm:
 
         self.assertEqual(nim["base_url"], "http://localhost:18002/v1")
         self.assertEqual(vllm["base_url"], "http://localhost:8002/v1")
+
+    def test_registry_host_runtime_rewrites_magpie_multilingual_tts_endpoint(self) -> None:
+        with patch.dict(os.environ, {"APP_RUNTIME": ""}):
+            rewritten = examples_registry._rewrite_entry_for_host_runtime(
+                {"server": "magpie-multilingual-tts-service:50051"}
+            )
+
+        self.assertEqual(rewritten["server"], "localhost:50151")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
This PR aligns repository deployment guidance, Compose service naming, and agent skills with current Magpie, Chatterbox, and scaling behavior.

Changes
Renames the default Magpie Compose services:
tts-service → magpie-multilingual-tts-service
tts-service-perf → magpie-multilingual-tts-service-perf
Updates catalogs, runtime endpoint rewrites, readiness checks, tests, READMEs, and skills to use the new names.
Documents generic-assistant/server-perf as a four-GPU benchmark-only profile, not a normal browser UI deployment.
Adds server-perf to Generic Assistant deployment documentation.
Requires explicit TTS synthesis_mode values:
stitched for Magpie
per_sentence for Chatterbox
Makes the optional NvidiaWordTTSService source-level integration discoverable through configure-pipeline.
Extends Pipecat upgrade guidance to review custom service subclasses and their parent API contracts.
Compatibility note
Existing automation using docker compose logs tts-service or --scale tts-service=0 must use magpie-multilingual-tts-service instead. Catalog keys remain unchanged.

Validation
412 unit tests passed
12 subtests passed
Pipecat eval smoke passed
Pipecat eval suite passed, 2 of 2 scenarios
Ruff lint and formatting passed
All Compose profiles validated
Client production build passed through the Docker build stage
Confirmed no tracked legacy standalone tts-service references remain