### PR TITLE
fix(perf): use compatible BF16 Lightning profile

### DIFF
--- a/benchmarking_tools/scaling-perf/README.md
+++ b/benchmarking_tools/scaling-perf/README.md
@@ -83,7 +83,7 @@ scaling configuration:
 
 - Generic Assistant inherits the existing `nemotron-lightning` default from
   [`examples_registry.yaml`](../../examples_registry.yaml)
-- `nvidia-llm`: `NIM_TAGS_SELECTOR=precision=fp8,tp=2`, GPUs `2,3`, alias
+- `nvidia-llm`: `NIM_TAGS_SELECTOR=precision=bf16,tp=2`, GPUs `2,3`, alias
   `nvidia-llm`
 - `nemotron-asr-streaming-english`:
   `NIM_TAGS_SELECTOR=type=en-US,mode=str,batch_size=128`, GPU `0`, alias

--- a/docker/docker-compose.nemotron35-lightning-nim.yaml
+++ b/docker/docker-compose.nemotron35-lightning-nim.yaml
@@ -38,7 +38,7 @@ services:
       - frontend-backend-agent/server
     environment:
       <<: *nim-llm-env
-      NIM_TAGS_SELECTOR: ${NIM_TAGS_SELECTOR:-precision=fp8,tp=1}
+      NIM_TAGS_SELECTOR: ${NIM_TAGS_SELECTOR:-precision=bf16,tp=1}
     deploy:
       resources:
         reservations:

--- a/docker/docker-compose.nemotron35-lightning-nim.yaml
+++ b/docker/docker-compose.nemotron35-lightning-nim.yaml
@@ -53,7 +53,7 @@ services:
       - generic-assistant/server-perf
     environment:
       <<: *nim-llm-env
-      NIM_TAGS_SELECTOR: "precision=fp8,tp=2"
+      NIM_TAGS_SELECTOR: "precision=bf16,tp=2"
     deploy:
       resources:
         reservations:

--- a/skills/deploy/references/server.md
+++ b/skills/deploy/references/server.md
@@ -10,7 +10,7 @@ Needs enough workstation GPU VRAM for the selected NIM services. One GPU is vali
 
 ## Precision
 
-`NIM_TAGS_SELECTOR` defaults to `precision=fp8,tp=1`. That default is not universal. The NIM restart-loops with `Could not match a profile in manifest` when the GPU has no profile at that precision. Blackwell (for example RTX PRO 5000, `compute_cap` 12.0) has **no** `fp8` profile.
+`NIM_TAGS_SELECTOR` defaults to `precision=bf16,tp=1`. That default is not universal. The NIM restart-loops with `Could not match a profile in manifest` when the GPU has no profile at that precision or insufficient memory.
 
 1. List profiles on GPU 0. Read the image tag from the recipe compose file rather than assuming `:latest` (`docker/docker-compose.nemotron35-lightning-nim.yaml` for cascaded, `docker/docker-compose.nemotron3-omni-nim.yaml` for Omni):
 

--- a/skills/deploy/references/server.md
+++ b/skills/deploy/references/server.md
@@ -30,7 +30,7 @@ docker run --rm --gpus '"device=0"' -e NGC_API_KEY="$NVIDIA_API_KEY" \
 
 3. Set in `.env`, preserving other keys: `NIM_TAGS_SELECTOR=precision=<compatible-precision>,tp=1`.
 
-This applies to `*/server` only. `generic-assistant/server-perf` pins `precision=fp8,tp=2` as a literal in its Compose service (`nvidia-llm-perf`) and ignores the `.env` `NIM_TAGS_SELECTOR`. It targets a Hopper-class four-GPU host and does not fit a Blackwell workstation (no `fp8` profile). To retune it, edit the literal in the compose file, not `.env`.
+This applies to `*/server` only. `generic-assistant/server-perf` pins `precision=bf16,tp=2` as a literal in its Compose service (`nvidia-llm-perf`) and ignores the `.env` `NIM_TAGS_SELECTOR`. It targets a Hopper-class four-GPU host. On Blackwell, prefer a compatible `nvfp4` profile. To retune it, edit the literal in the compose file, not `.env`.
 
 Device placement is **not** an `.env` knob. Standard `*/server` sidecars default to GPU `0`. `generic-assistant/server-perf` places ASR on `0`, TTS on `1`, tensor-parallel LLM on `2` and `3`. To move a service, edit `device_ids` under `deploy.resources.reservations.devices` in its Compose file:
 


### PR DESCRIPTION
## Summary
- switch the standard Lightning server default from FP8 TP1 to BF16 TP1 for H100-class deployment compatibility
- switch the Lightning `server-perf` selector from the unavailable FP8 TP2 profile to BF16 TP2
- align scaling benchmark and deployment guidance with both compatible profiles
- retain NVFP4 as the preferred Blackwell-specific option

## Test plan
- [x] Run `docker compose --profile generic-assistant/server config --quiet`
- [x] Run `docker compose --profile generic-assistant/server-perf config --quiet`
- [x] Verify Lightning profile references use BF16 TP1/TP2 as appropriate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance deployment guidance to use BF16 precision with tensor parallelism across two GPUs.
  * Updated default inference and performance configurations to use BF16 precision.
  * Improved profile matching guidance to account for insufficient memory.
  * Updated server performance examples for Hopper hardware.
  * Added a compatible NVFP4 profile recommendation for Blackwell hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->