### PR TITLE
fix: make nemo-speech model files readable by the sidecar

### DIFF
--- a/scripts/download-nemo-speech-models.sh
+++ b/scripts/download-nemo-speech-models.sh
@@ -109,4 +109,6 @@ tar -xf "${DEST}/magpie-tts/magpie_tts_multilingual_357m.nemo" \
   nemo_nano_codec_22khz_1.89kbps_21.5fps.decoder.f16.gguf \
   --local-dir "${DEST}/nano-codec"
 
+chmod -R a+rX "${DEST}"
+
 echo "Models ready at ${DEST}"


### PR DESCRIPTION
## Summary

After downloading NeMo-Speech.cpp weights, make the model directory world-readable/traversable so the sidecar (UID 1000) can load ASR GGUFs and iterate the Magpie TTS tokenizer dir.

On Jetson Thor the host user is often not UID 1000 and `extracted/` can be mode `700`, which produces:

```text
failed to initialize TTS service: MagpieTTS warmup tokenization failed:
filesystem error: directory iterator cannot open directory:
Permission denied [/models/magpie-tts/extracted]
```

ASR can still load; TTS init fails; `nemo-speech` restart-loops. DGX Spark typically does not hit this because the host user is already UID 1000.

## Related Issue

SQA: Jetson Thor `generic-assistant/single-gpu` — `nemo-speech` restart loop on `/models/magpie-tts/extracted`.

## Changes

- `scripts/download-nemo-speech-models.sh`: `chmod -R a+rX "${DEST}"` after ASR/TTS/codec download and extract

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: download-script permission bit only; no runtime Python/client behavior change
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: new downloads are fixed by the script; no user-facing API change

## Documentation Writer Review

- [x] Documentation writer reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: one `chmod` at the end of the download script; documented deploy steps already run this script as the user
- Agent: Cursor
<!-- docs-review-head-sha: ca884ba -->
<!-- docs-review-agents-blob-sha: -->

## Verification

- [x] Applicable lint, test, and build checks passed
- [ ] Documentation validation passed for changed documentation
- [x] No secrets, API keys, or credentials are committed

## Test plan

- [ ] On Thor (host UID ≠ 1000): run `bash scripts/download-nemo-speech-models.sh`, then `docker compose --profile generic-assistant/single-gpu up -d`, confirm `nemo-speech` stays healthy (no `Permission denied` on `/models/magpie-tts/extracted`)
- [ ] Existing Thor tree without re-download: `chmod -R a+rX models/nemo-speech` and restart `nemo-speech`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloaded speech models now have the required read and directory access permissions after installation.
  * Improved access reliability for tools and processes using the downloaded models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->