### PR TITLE
fix(client): fix transcript ordering, mic toggle, and RTVI version display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,15 @@ This minor release adds Nemotron 3.5 Lightning and Nemotron 3 Nano Omni support,
 - Updated Magpie TTS Multilingual NIM to version 1.10.0 and `nvidia-riva-client` to version 2.27.0.
 - Renamed the Magpie Multilingual Compose services to `magpie-multilingual-tts-service` and `magpie-multilingual-tts-service-perf`.
 - Updated Chatterbox TTS Multilingual NIM to version 1.1.0 and documented its available model profiles.
+- Updated the React UI client to `@pipecat-ai/client-react` 1.8.2 and rendered the conversation transcript directly from Pipecat's `usePipecatConversation()` hook, removing the custom client-side turn reconstruction and timestamp re-anchoring.
 
 ### Fixed
 
 - Cap Omni NIM KV cache (`NIM_KVCACHE_PERCENT` default `0.6`, `NIM_MAX_MODEL_LEN` `32768`) so Magpie TTS can share GPU 0.
-- Emit `user-turn-finalized` from Omni Assistant Subagents and keep the earlier user-turn timestamp in the client so transcripts stay in speaking order.
+- Emit `user-turn-finalized` from Omni Assistant Subagents so the server signals user-turn boundaries.
+- Keep chat transcripts in speaking order by rendering the Pipecat SDK message stream directly instead of merging server- and client-derived timestamps, which could reorder turns under clock skew.
+- Render each bot turn as a single transcript bubble instead of splitting multi-sentence responses into separate messages.
+- Show the negotiated RTVI protocol version in the Session panel instead of the client library version.
 - Resolve shared TTS voice ids (`John`) against the catalog default language so the disabled language dropdown shows `en-US` instead of the alphabetically first locale.
 
 ### Removed

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@pipecat-ai/client-js": "1.13.0",
-        "@pipecat-ai/client-react": "1.8.1",
+        "@pipecat-ai/client-react": "1.8.2",
         "@pipecat-ai/small-webrtc-transport": "1.10.6",
         "@pipecat-ai/websocket-transport": "1.7.1",
         "@tanstack/react-query": "^5.100.11",
@@ -1388,9 +1388,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-react": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-react/-/client-react-1.8.1.tgz",
-      "integrity": "sha512-558BVmslUuhjOr2e8mrpmOrWJJ47fcacw/EeZ0CyvHj8j2Doh4GDvsFSjnPT123BCaFB4JBP63z7SiQRwujRFg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-react/-/client-react-1.8.2.tgz",
+      "integrity": "sha512-F6Uf5lkjiYfv2UlwMnJkDleAZpX7ljWTPkp6Z1z5fIjy9+/DbyKdX0Otli6HuotgkVAPhbLjxGT+XKmOVvECxQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jotai": "^2.9.0"

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@pipecat-ai/client-js": "1.13.0",
-    "@pipecat-ai/client-react": "1.8.1",
+    "@pipecat-ai/client-react": "1.8.2",
     "@pipecat-ai/small-webrtc-transport": "1.10.6",
     "@pipecat-ai/websocket-transport": "1.7.1",
     "@tanstack/react-query": "^5.100.11",

--- a/client/src/components/content/ConversationPanel.tsx
+++ b/client/src/components/content/ConversationPanel.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024–2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { Fragment, useCallback, useEffect, useMemo, useReducer, useRef, useState, type ChangeEvent } from "react";
-import { RTVIEvent, type BotLLMTextData } from "@pipecat-ai/client-js";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { RTVIEvent } from "@pipecat-ai/client-js";
 import {
   usePipecatConversation,
   useRTVIClientEvent,
@@ -42,52 +42,14 @@ type AgentTask = {
   createdAt: string;
   updatedAt: string;
   attachmentName: string;
+  anchorCreatedAt: string;
 };
 
 type AssistantTurn = {
   id: string;
   text: string;
   createdAt: string;
-};
-
-type LlmTurn = {
-  id: string;
-  text: string;
-  createdAt: string;
-};
-
-type LlmTurnState = {
-  active: LlmTurn | null;
-  completed: LlmTurn[];
-};
-
-type LlmTurnAction =
-  | { type: "start"; turn: LlmTurn }
-  | { type: "append"; text: string; fallbackTurn: LlmTurn }
-  | { type: "finish" }
-  | { type: "reset" };
-
-const finishActiveLlmTurn = (state: LlmTurnState): LlmTurnState => {
-  const active = state.active;
-  if (!active) return state;
-  const text = active.text.trim();
-  return {
-    active: null,
-    completed: text
-      ? [...state.completed, { ...active, text }].slice(-40)
-      : state.completed,
-  };
-};
-
-const llmTurnReducer = (state: LlmTurnState, action: LlmTurnAction): LlmTurnState => {
-  if (action.type === "reset") return { active: null, completed: [] };
-  if (action.type === "finish") return finishActiveLlmTurn(state);
-  if (action.type === "start") {
-    const finished = finishActiveLlmTurn(state);
-    return { ...finished, active: action.turn };
-  }
-  const active = state.active ?? action.fallbackTurn;
-  return { ...state, active: { ...active, text: `${active.text}${action.text}` } };
+  anchorCreatedAt: string;
 };
 
 const renderPartText = (part: ConversationMessagePart): string => {
@@ -113,53 +75,7 @@ const renderMessageText = (message: ConversationMessage): string =>
 const isUserOrAssistant = (m: ConversationMessage) =>
   m.role === "user" || m.role === "assistant";
 
-const findLatestUserMessage = (messages: ConversationMessage[]) => {
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (messages[i].role === "user") return messages[i];
-  }
-  return undefined;
-};
-
-const findLatestUnanchoredUser = (
-  messages: ConversationMessage[],
-  anchors: { has: (key: string) => boolean }
-) => {
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (messages[i].role !== "user") continue;
-    return anchors.has(messages[i].createdAt) ? undefined : messages[i];
-  }
-  return undefined;
-};
-
 const normalizeTranscript = (text?: string | null) => (text ?? "").trim().replace(/\s+/g, " ");
-
-const validTimestampOrNow = (timestamp: string) =>
-  Number.isNaN(Date.parse(timestamp)) ? new Date().toISOString() : timestamp;
-
-const earlierISO = (left: string | null, right: string) => {
-  if (!left) return right;
-  const leftMs = Date.parse(left);
-  const rightMs = Date.parse(right);
-  if (Number.isNaN(leftMs)) return right;
-  if (Number.isNaN(rightMs)) return left;
-  return leftMs <= rightMs ? left : right;
-};
-
-const findUserMessageByTranscript = (
-  messages: ConversationMessage[],
-  transcript: string | null | undefined,
-  finalizedCreatedAts: { has: (key: string) => boolean }
-) => {
-  const normalizedTranscript = normalizeTranscript(transcript);
-  if (!normalizedTranscript) return undefined;
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const message = messages[i];
-    if (message.role !== "user") continue;
-    if (message.final || finalizedCreatedAts.has(message.createdAt)) continue;
-    if (normalizeTranscript(renderMessageText(message)) === normalizedTranscript) return message;
-  }
-  return undefined;
-};
 
 function mediaKindFromFile(file: File): MediaKind | null {
   if (file.type.startsWith("image/")) return "image";
@@ -239,6 +155,13 @@ function AttachMediaButton({ onClick }: Readonly<{ onClick: () => void }>) {
   );
 }
 
+const START_ANCHOR = "__start__";
+
+type ExtraItem =
+  | { kind: "task"; id: string; anchor: string; createdAt: string; sortKey: number; task: AgentTask }
+  | { kind: "assistant-turn"; id: string; anchor: string; createdAt: string; sortKey: number; turn: AssistantTurn }
+  | { kind: "attachment"; id: string; anchor: string; createdAt: string; sortKey: number; attachment: LocalAttachment };
+
 export function ConversationPanel() {
   const { currentSessionId, selectedExample, setCurrentSessionId } = useApp();
   const { messages } = usePipecatConversation();
@@ -246,57 +169,25 @@ export function ConversationPanel() {
   const [attachments, setAttachments] = useState<LocalAttachment[]>([]);
   const attachmentsRef = useRef<LocalAttachment[]>([]);
   const [agentTasks, setAgentTasks] = useState<AgentTask[]>([]);
+  const agentTasksRef = useRef<AgentTask[]>([]);
   const [assistantTurns, setAssistantTurns] = useState<AssistantTurn[]>([]);
-  const [llmTurnState, dispatchLlmTurn] = useReducer(llmTurnReducer, {
-    active: null,
-    completed: [],
-  });
-  const llmTurnSequenceRef = useRef(0);
-  const createLlmTurn = useCallback((): LlmTurn => {
-    llmTurnSequenceRef.current += 1;
-    return {
-      id: `llm-turn-${llmTurnSequenceRef.current}`,
-      text: "",
-      createdAt: new Date().toISOString(),
-    };
-  }, []);
   const canUploadAttachments = selectedExample?.capabilities?.includes("attachments") ?? false;
-  const [currentUserTurnActive, setCurrentUserTurnActive] = useState(false);
-  const [userTurnAnchors, setUserTurnAnchors] =
-    useState<Map<string, string>>(new Map());
-  const userTurnAnchorsRef = useRef(userTurnAnchors);
-  useEffect(() => {
-    userTurnAnchorsRef.current = userTurnAnchors;
-  }, [userTurnAnchors]);
-  // Holds a finalize signal that arrived before its turn's user bubble exists
-  // (the Omni model emits the user transcript late). Applied to the bubble once
-  // it appears.
-  const pendingUserAnchorRef = useRef<string | null>(null);
-  const anchorUserTurn = useCallback((createdAt: string, anchorISO: string) => {
-    setUserTurnAnchors((prev) => {
-      if (prev.has(createdAt)) return prev;
-      const next = new Map(prev);
-      next.set(createdAt, anchorISO);
-      return next;
-    });
-  }, []);
 
   useEffect(() => {
     attachmentsRef.current = attachments;
   }, [attachments]);
 
+  useEffect(() => {
+    agentTasksRef.current = agentTasks;
+  }, [agentTasks]);
+
   const resetConversationExtras = useCallback(() => {
-    setCurrentUserTurnActive(false);
-    setUserTurnAnchors(new Map());
-    pendingUserAnchorRef.current = null;
     setAttachments((prev) => {
       prev.forEach((attachment) => URL.revokeObjectURL(attachment.previewUrl));
       return [];
     });
     setAgentTasks([]);
     setAssistantTurns([]);
-    dispatchLlmTurn({ type: "reset" });
-    llmTurnSequenceRef.current = 0;
   }, []);
 
   const visibleMessages = useMemo(
@@ -310,39 +201,6 @@ export function ConversationPanel() {
   }, [visibleMessages]);
 
   useRTVIClientEvent(
-    RTVIEvent.BotLlmStarted,
-    useCallback(() => {
-      dispatchLlmTurn({ type: "start", turn: createLlmTurn() });
-    }, [createLlmTurn])
-  );
-
-  useRTVIClientEvent(
-    RTVIEvent.BotLlmText,
-    useCallback((data: BotLLMTextData) => {
-      if (!data.text) return;
-      dispatchLlmTurn({
-        type: "append",
-        text: data.text,
-        fallbackTurn: createLlmTurn(),
-      });
-    }, [createLlmTurn])
-  );
-
-  useRTVIClientEvent(
-    RTVIEvent.BotLlmStopped,
-    useCallback(() => {
-      dispatchLlmTurn({ type: "finish" });
-    }, [])
-  );
-
-  useRTVIClientEvent(
-    RTVIEvent.UserStartedSpeaking,
-    useCallback(() => {
-      setCurrentUserTurnActive(true);
-    }, [])
-  );
-
-  useRTVIClientEvent(
     RTVIEvent.ServerMessage,
     useCallback((message: unknown) => {
       if (!isRecord(message)) return;
@@ -353,6 +211,9 @@ export function ConversationPanel() {
         if (!taskId) return;
         const now = new Date().toISOString();
         const spokenResponse = stringField(message, "spoken_response");
+        const existing = agentTasksRef.current.find((task) => task.id === taskId);
+        const anchorCreatedAt =
+          existing?.anchorCreatedAt ?? (visibleMessagesRef.current.at(-1)?.createdAt ?? "");
         setAgentTasks((prev) => {
           const previous = prev.find((task) => task.id === taskId);
           const next: AgentTask = {
@@ -371,31 +232,18 @@ export function ConversationPanel() {
             attachmentName: attachmentNameFromMessage(message) || previous?.attachmentName || "",
             createdAt: previous?.createdAt || now,
             updatedAt: now,
+            anchorCreatedAt: previous?.anchorCreatedAt || anchorCreatedAt,
           };
           return [...prev.filter((task) => task.id !== taskId), next].slice(-20);
         });
         if (stringField(message, "status") === "done" && spokenResponse) {
           setAssistantTurns((prev) => [
             ...prev.filter((turn) => turn.id !== taskId),
-            { id: taskId, text: spokenResponse, createdAt: now },
+            { id: taskId, text: spokenResponse, createdAt: now, anchorCreatedAt },
           ].slice(-20));
         }
-        return;
       }
-
-      if (type !== "user-turn-finalized") return;
-      setCurrentUserTurnActive(false);
-      const anchorISO = earlierISO(
-        pendingUserAnchorRef.current,
-        validTimestampOrNow(stringField(message, "timestamp"))
-      );
-      const anchors = userTurnAnchorsRef.current;
-      const target =
-        findUserMessageByTranscript(visibleMessagesRef.current, stringField(message, "transcript"), anchors) ??
-        findLatestUnanchoredUser(visibleMessagesRef.current, anchors);
-      if (target) anchorUserTurn(target.createdAt, anchorISO);
-      else pendingUserAnchorRef.current = anchorISO;
-    }, [anchorUserTurn])
+    }, [])
   );
 
   useRTVIClientEvent(
@@ -409,28 +257,6 @@ export function ConversationPanel() {
   useEffect(() => () => {
     attachmentsRef.current.forEach((attachment) => URL.revokeObjectURL(attachment.previewUrl));
   }, []);
-
-  useEffect(() => {
-    if (!pendingUserAnchorRef.current) return;
-    const target = findLatestUnanchoredUser(visibleMessages, userTurnAnchors);
-    if (!target) return;
-    const anchorISO = pendingUserAnchorRef.current;
-    pendingUserAnchorRef.current = null;
-    anchorUserTurn(target.createdAt, anchorISO);
-  }, [visibleMessages, userTurnAnchors, anchorUserTurn]);
-
-  const latestUserCreatedAt = useMemo(
-    () => findLatestUserMessage(visibleMessages)?.createdAt,
-    [visibleMessages]
-  );
-
-  const computeStreaming = (message: ConversationMessage): boolean => {
-    if (message.role !== "user") return !message.final;
-    if (message.final) return false;
-    if (userTurnAnchors.has(message.createdAt)) return false;
-    const isLatestUser = message.createdAt === latestUserCreatedAt;
-    return isLatestUser && currentUserTurnActive;
-  };
 
   const handleAttachmentSelected = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -475,117 +301,90 @@ export function ConversationPanel() {
     }
   };
 
-  const conversationItems = useMemo(() => {
-    const messageItems = visibleMessages.flatMap((message, idx) => {
-      // Assistant bubbles come from RTVI LLM events, not TTS transcript frames.
-      if (message.role === "assistant") return [];
-      const text = renderMessageText(message);
-      if (!text) return [];
-      return [{
-        type: "message" as const,
-        id: `${message.createdAt}-${idx}`,
-        createdAt: message.createdAt,
-        message,
-        text,
-        index: idx,
-      }];
-    });
-    const allLlmTurns = llmTurnState.active
-      ? [...llmTurnState.completed, llmTurnState.active]
-      : llmTurnState.completed;
-    const llmItems = allLlmTurns.flatMap((turn) => {
-      const text = turn.text.trim();
-      if (!text) return [];
-      return [{
-        type: "llm-turn" as const,
-        id: turn.id,
-        createdAt: turn.createdAt,
-        turn,
-        text,
-        streaming: turn.id === llmTurnState.active?.id,
-        index: 100,
-      }];
-    });
-    const llmTurnTexts = new Set(
-      allLlmTurns.map((turn) => normalizeTranscript(turn.text)).filter(Boolean)
+  const assistantMessageTexts = useMemo(
+    () =>
+      new Set(
+        visibleMessages
+          .filter((m) => m.role === "assistant")
+          .map((m) => normalizeTranscript(renderMessageText(m)))
+          .filter(Boolean)
+      ),
+    [visibleMessages]
+  );
+
+  const extras = useMemo<ExtraItem[]>(() => {
+    const list: ExtraItem[] = [];
+    agentTasks.forEach((task) =>
+      list.push({ kind: "task", id: task.id, anchor: task.anchorCreatedAt, createdAt: task.createdAt, sortKey: 1, task })
     );
-    const taskItems = agentTasks.map((task) => ({
-      type: "task" as const,
-      id: task.id,
-      createdAt: task.createdAt,
-      task,
-      index: 101,
-    }));
-    // Analyzer follow-ups can bypass normal LLM lifecycle events. Keep their
-    // explicit spoken response, unless the same complete LLM turn is present.
-    const assistantTurnItems = assistantTurns
-      .filter((turn) => !llmTurnTexts.has(normalizeTranscript(turn.text)))
-      .map((turn) => ({
-        type: "assistant-turn" as const,
-        id: turn.id,
-        createdAt: turn.createdAt,
-        turn,
-        index: 102,
-      }));
-    const attachmentItems = attachments.map((attachment) => ({
-      type: "attachment" as const,
-      id: attachment.id,
-      createdAt: attachment.createdAt,
-      attachment,
-      index: 103,
-    }));
-    const orderTimeMs = (createdAt: string) => {
-      const created = new Date(createdAt).getTime();
-      const anchor = userTurnAnchors.get(createdAt);
-      return anchor ? Math.min(created, new Date(anchor).getTime()) : created;
+    assistantTurns
+      .filter((turn) => !assistantMessageTexts.has(normalizeTranscript(turn.text)))
+      .forEach((turn) =>
+        list.push({ kind: "assistant-turn", id: turn.id, anchor: turn.anchorCreatedAt, createdAt: turn.createdAt, sortKey: 2, turn })
+      );
+    attachments.forEach((attachment) =>
+      list.push({ kind: "attachment", id: attachment.id, anchor: attachment.anchorCreatedAt, createdAt: attachment.createdAt, sortKey: 3, attachment })
+    );
+    return list;
+  }, [agentTasks, assistantTurns, assistantMessageTexts, attachments]);
+
+  const { startExtras, extrasByAnchor } = useMemo(() => {
+    const messageIds = new Set(visibleMessages.map((m) => m.createdAt));
+    const lastCreatedAt = visibleMessages.at(-1)?.createdAt ?? "";
+    const resolve = (anchor: string) => {
+      if (!anchor) return START_ANCHOR;
+      if (messageIds.has(anchor)) return anchor;
+      return lastCreatedAt || START_ANCHOR;
     };
-    return [...messageItems, ...llmItems, ...taskItems, ...assistantTurnItems, ...attachmentItems].sort((a, b) => {
-      const timeDelta = orderTimeMs(a.createdAt) - orderTimeMs(b.createdAt);
-      return timeDelta || a.index - b.index;
-    });
-  }, [agentTasks, assistantTurns, attachments, llmTurnState, visibleMessages, userTurnAnchors]);
+    const byAnchor = new Map<string, ExtraItem[]>();
+    for (const extra of extras) {
+      const key = resolve(extra.anchor);
+      const bucket = byAnchor.get(key) ?? [];
+      bucket.push(extra);
+      byAnchor.set(key, bucket);
+    }
+    for (const bucket of byAnchor.values()) {
+      bucket.sort((a, b) => a.sortKey - b.sortKey || a.createdAt.localeCompare(b.createdAt));
+    }
+    return { startExtras: byAnchor.get(START_ANCHOR) ?? [], extrasByAnchor: byAnchor };
+  }, [extras, visibleMessages]);
+
+  const renderExtra = (extra: ExtraItem) => {
+    if (extra.kind === "task") return <AgentTaskCard key={extra.id} task={extra.task} />;
+    if (extra.kind === "attachment") return <AttachmentPreview key={extra.id} attachment={extra.attachment} />;
+    return (
+      <TranscriptMessage
+        key={`assistant-turn-${extra.id}`}
+        role="bot"
+        text={extra.turn.text}
+        timestamp={extra.turn.createdAt}
+        streaming={false}
+      />
+    );
+  };
 
   const showAttachmentControl = Boolean(currentSessionId) && canUploadAttachments && visibleMessages.length > 0;
-  const bottomAnchorRef = useStickToBottom(conversationItems);
+  const stickSignal = useMemo(() => ({ messages: visibleMessages, extras }), [visibleMessages, extras]);
+  const bottomAnchorRef = useStickToBottom(stickSignal);
 
   return (
     <div className="p-4">
       <ul className="d-flex flex-col gap-2" style={{ listStyle: "none", padding: 0, margin: 0 }}>
-        {conversationItems.map((item) => {
-          if (item.type === "task") return <AgentTaskCard key={item.id} task={item.task} />;
-          if (item.type === "attachment") return <AttachmentPreview key={item.id} attachment={item.attachment} />;
-          if (item.type === "llm-turn") {
-            return (
-              <TranscriptMessage
-                key={item.id}
-                role="bot"
-                text={item.text}
-                timestamp={item.createdAt}
-                streaming={item.streaming}
-              />
-            );
-          }
-          if (item.type === "assistant-turn") {
-            return (
-              <TranscriptMessage
-                key={`assistant-turn-${item.id}`}
-                role="bot"
-                text={item.turn.text}
-                timestamp={item.turn.createdAt}
-                streaming={false}
-              />
-            );
-          }
-
-          const msg = item.message;
+        {startExtras.map(renderExtra)}
+        {visibleMessages.map((message, idx) => {
+          const text = renderMessageText(message);
+          const bucket = extrasByAnchor.get(message.createdAt);
           return (
-            <Fragment key={item.id}>
-              <TranscriptMessage
-                role={msg.role === "assistant" ? "bot" : "user"}
-                text={item.text}
-                timestamp={userTurnAnchors.get(msg.createdAt) ?? msg.createdAt}
-                streaming={computeStreaming(msg)}
-              />
+            <Fragment key={`${message.createdAt}-${idx}`}>
+              {text && (
+                <TranscriptMessage
+                  role={message.role === "assistant" ? "bot" : "user"}
+                  text={text}
+                  timestamp={message.createdAt}
+                  streaming={!message.final}
+                />
+              )}
+              {bucket?.map(renderExtra)}
             </Fragment>
           );
         })}

--- a/client/src/components/status-panel/DevicesSection.tsx
+++ b/client/src/components/status-panel/DevicesSection.tsx
@@ -11,6 +11,7 @@ import {
 export function DevicesSection() {
   const { enableMic, isMicEnabled } = usePipecatClientMicControl();
   const { availableMics, selectedMic, updateMic } = usePipecatClientMediaDevices();
+  const [micOn, setMicOn] = useState(isMicEnabled);
   const [showDeviceMenu, setShowDeviceMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -26,7 +27,9 @@ export function DevicesSection() {
   }, [showDeviceMenu]);
 
   const handleMicToggle = () => {
-    enableMic(!isMicEnabled);
+    const next = !micOn;
+    setMicOn(next);
+    enableMic(next);
   };
 
   const handleMicSelect = (deviceId: string) => {
@@ -38,16 +41,16 @@ export function DevicesSection() {
     <div className="header-devices" ref={menuRef}>
       <div className="device-row">
         <button
-          className={`device-item device-button ${!isMicEnabled ? 'device-disabled' : ''}`}
+          className={`device-item device-button ${!micOn ? 'device-disabled' : ''}`}
           onClick={handleMicToggle}
-          title={isMicEnabled ? "Click to mute" : "Click to unmute"}
+          title={micOn ? "Click to mute" : "Click to unmute"}
         >
           <span className="device-icon">🎤</span>
           <div className="device-visualizer">
             <VoiceVisualizer
               participantType="local"
               backgroundColor="transparent"
-              barColor={isMicEnabled ? "#76b900" : "#666666"}
+              barColor={micOn ? "#76b900" : "#666666"}
               barCount={16}
               barGap={3}
               barWidth={4}

--- a/client/src/components/status-panel/SessionSection.tsx
+++ b/client/src/components/status-panel/SessionSection.tsx
@@ -1,21 +1,38 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024–2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { usePipecatClient } from "@pipecat-ai/client-react";
+import { useCallback, useState } from "react";
+import { RTVIEvent, type BotReadyData } from "@pipecat-ai/client-js";
+import { useRTVIClientEvent } from "@pipecat-ai/client-react";
 import { useApp } from "../../context/useApp";
 import { PanelSection } from "../PanelSection";
 import { StatusRow } from "./StatusRow";
 
 export function SessionSection() {
-  const client = usePipecatClient();
   const { availableTransports, selectedTransport } = useApp();
   const selectedTransportLabel =
     availableTransports.find((transport) => transport.id === selectedTransport)?.label ?? selectedTransport;
 
+  const [protocolVersion, setProtocolVersion] = useState<string>("");
+
+  useRTVIClientEvent(
+    RTVIEvent.BotReady,
+    useCallback((data: BotReadyData) => {
+      setProtocolVersion(data.version ?? "");
+    }, [])
+  );
+
+  useRTVIClientEvent(
+    RTVIEvent.Disconnected,
+    useCallback(() => {
+      setProtocolVersion("");
+    }, [])
+  );
+
   return (
     <PanelSection label="SESSION">
       <StatusRow label="Transport" value={selectedTransportLabel} />
-      <StatusRow label="RTVI" value={client?.version ?? "---"} />
+      <StatusRow label="RTVI protocol" value={protocolVersion || "---"} />
     </PanelSection>
   );
 }


### PR DESCRIPTION
## Summary

- Render the conversation transcript directly from Pipecat's `usePipecatConversation()` hook and bump `@pipecat-ai/client-react` to `1.8.2`, removing the custom client-side turn reconstruction and timestamp re-anchoring that could reorder turns under client/server clock skew.
- Keep turns in speaking order by trusting the SDK's already-ordered message stream instead of merging server- and client-derived timestamps.
- Render each bot turn as a single transcript bubble instead of splitting multi-sentence responses (root-caused to a v2-protocol bot-output finalization bug fixed upstream in `client-react` 1.8.2).
- Show the negotiated RTVI protocol version (from the `BotReady` event) in the Session panel instead of the client library version, which was misleading.
- Fix the mic toggle: drive the button from an optimistic local state so a single tap reliably toggles it, instead of the stale `isMicEnabled` read from the small-webrtc transport that lagged the icon by one tap and made every other tap a no-op.

## Why

The previous `ConversationPanel` merged five separate item streams and re-timed user/bot turns using a mix of server (`user-turn-finalized`) and client wall-clock timestamps. Under clock skew this reordered turns (e.g. a later question rendering before the previous answer). Relying on the SDK's ordered stream is the Pipecat-recommended pattern and removes the whole class of ordering bugs.

The mic indicator read the transport's live `isMicEnabled` (`daily.localAudio()`), which is not updated synchronously and gets re-read on track events, so the icon lagged the actual mic state by one tap.

## Changes

- `client/package.json`, `client/package-lock.json`: `@pipecat-ai/client-react` 1.8.1 -> 1.8.2.
- `client/src/components/content/ConversationPanel.tsx`: render from `usePipecatConversation()`; drop custom reconstruction/re-anchoring/sorting.
- `client/src/components/status-panel/SessionSection.tsx`: display negotiated RTVI protocol version from `BotReady`.
- `client/src/components/status-panel/DevicesSection.tsx`: optimistic local mic state for the toggle/indicator.
- `CHANGELOG.md`: document the transcript/RTVI changes under 2.2.0.

## Test plan

- [ ] Build the client (`npm run build`) — type-check and lint pass.
- [ ] Deploy an example (e.g. `omni-assistant-subagents/single-gpu`) and run 4+ back-and-forth turns; confirm user/bot turns stay in speaking order (previously broke from the 3rd turn onward).
- [ ] Confirm a multi-sentence bot turn renders as a single bubble.
- [ ] Confirm the Session panel shows the RTVI protocol version (e.g. `2.1.0`) and resets on disconnect.
- [ ] Confirm one tap toggles the mic cleanly (green <-> red) in step with the visualizer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added display of the negotiated RTVI protocol version in the session status panel.
  - Improved conversation display by grouping tasks, assistant responses, and attachments with their related transcript messages.
- **Bug Fixes**
  - Corrected transcript ordering, grouping, and duplicate assistant text.
  - Improved handling of user-turn events and streaming states.
  - Fixed microphone toggle feedback so controls and visual indicators stay synchronized with the selected state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->