### PR TITLE
Updating max Model Length for Lightening

### DIFF
--- a/docker/docker-compose.nemotron35-lightning.yaml
+++ b/docker/docker-compose.nemotron35-lightning.yaml
@@ -52,7 +52,7 @@ services:
           --host 0.0.0.0
           --port 8000
           --served-model-name nvidia/nemotron-3.5-lightning-30b-a3b
-          --max-model-len 4096
+          --max-model-len 32768
           --trust-remote-code
           --enable-auto-tool-choice
           --tool-call-parser qwen3_coder


### PR DESCRIPTION
## Summary

  Align the single-GPU Lightning vLLM context window with the NIM server profile.

  Before: frontend/backend agent requests could exceed the 4,096-token vLLM context limit and fail with HTTP 400 before generating a response.

  After: the single-GPU Lightning profile uses a 32,768-token context window, allowing the talker and thinker request budgets to fit.

  ## Changes

  - Set `--max-model-len` from `4096` to `32768` in `docker/docker-compose.nemotron35-lightning.yaml`.

  ## Type of Change

  - [x] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates
  - [ ] Doc only (prose changes, no code sample modifications)
  - [ ] Doc only (includes code sample changes)

  ## Quality Gates

  - [ ] Tests added or updated for changed behavior
  - [ ] Existing tests cover changed behavior — justification:
  - [x] Tests not applicable — justification: This is a single Docker Compose serving-configuration change; GPU-backed single-GPU deployment validation is required separately.
  - [ ] Docs updated for user-facing behavior changes
  - [x] Docs not applicable — justification: The documented deployment behavior does not change.

  ## Documentation Writer Review

  - [ ] Documentation writer reviewed the completed changes
  - Result: `blocked`
  - Evidence: No documentation changes are required; documentation writer review has not been run.
  - Agent: Codex CLI
  <!-- docs-review-head-sha: replace with `git rev-parse --short HEAD` after cherry-picking -->
  <!-- docs-review-agents-blob-sha: replace with `git rev-parse --short HEAD:AGENTS.md` after cherry-picking -->

  ## Verification

  - [x] Applicable lint, test, and build checks passed
  - [ ] Documentation validation passed for changed documentation
  - [x] No secrets, API keys, or credentials are committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum supported input and output context length to 32,768 tokens, enabling longer prompts and responses when serving the model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->