### PR TITLE
feat(client): show launched example in session panel and rename omni subagents prompt

### DIFF
--- a/client/src/components/PipelineExampleSelector.tsx
+++ b/client/src/components/PipelineExampleSelector.tsx
@@ -8,9 +8,9 @@ import { PanelSection } from "./PanelSection";
 export function PipelineExampleSelector() {
   const { isLocked } = useConnectionState();
   const { selectedExample, selectExample, deploymentOptions, deploymentSelectable } = useApp();
-  const disabled = isLocked || !deploymentSelectable;
+  const canSwitch = deploymentSelectable && deploymentOptions.length > 1;
 
-  if (!selectedExample || deploymentOptions.length <= 1) return null;
+  if (!selectedExample || !canSwitch) return null;
 
   return (
     <PanelSection label="EXAMPLE">
@@ -18,7 +18,7 @@ export function PipelineExampleSelector() {
         className="select-dark select-full"
         value={selectedExample.key}
         onChange={(e) => selectExample(e.target.value)}
-        disabled={disabled}
+        disabled={isLocked}
         aria-label="Example"
       >
         {deploymentOptions.map((option) => (

--- a/client/src/components/status-panel/SessionSection.tsx
+++ b/client/src/components/status-panel/SessionSection.tsx
@@ -9,7 +9,7 @@ import { PanelSection } from "../PanelSection";
 import { StatusRow } from "./StatusRow";
 
 export function SessionSection() {
-  const { availableTransports, selectedTransport } = useApp();
+  const { availableTransports, selectedTransport, selectedExample } = useApp();
   const selectedTransportLabel =
     availableTransports.find((transport) => transport.id === selectedTransport)?.label ?? selectedTransport;
 
@@ -31,6 +31,14 @@ export function SessionSection() {
 
   return (
     <PanelSection label="SESSION">
+      {selectedExample && (
+        <StatusRow
+          label="Example"
+          value={selectedExample.label}
+          title={selectedExample.key}
+          valueClassName="status-value--wrap"
+        />
+      )}
       <StatusRow label="Transport" value={selectedTransportLabel} />
       <StatusRow label="RTVI protocol" value={protocolVersion || "---"} />
     </PanelSection>

--- a/client/src/components/status-panel/StatusRow.tsx
+++ b/client/src/components/status-panel/StatusRow.tsx
@@ -5,14 +5,15 @@ interface StatusRowProps {
   label: string;
   value: string;
   title?: string;
+  valueClassName?: string;
   children?: React.ReactNode;
 }
 
-export function StatusRow({ label, value, title, children }: Readonly<StatusRowProps>) {
+export function StatusRow({ label, value, title, valueClassName, children }: Readonly<StatusRowProps>) {
   return (
     <div className="status-row">
       <span>{label}</span>
-      <span className="status-value" title={title}>
+      <span className={valueClassName ? `status-value ${valueClassName}` : "status-value"} title={title}>
         {value}
         {children}
       </span>

--- a/client/src/styles/nvidia-theme.scss
+++ b/client/src/styles/nvidia-theme.scss
@@ -1581,6 +1581,13 @@ body {
   font-size: var(--text-sm);
 }
 
+.status-value--wrap {
+  min-width: 0;
+  text-align: right;
+  white-space: normal;
+  word-break: break-word;
+}
+
 // Spinner animation
 .spinner {
   width: 14px;

--- a/examples_registry.yaml
+++ b/examples_registry.yaml
@@ -63,7 +63,7 @@ examples:
     slots: [llm, tts]
     capabilities: [attachments, webcam]
     defaults:
-      prompt: [generic_omni_assistant]
+      prompt: [omni_subagents_assistant]
       llm: [nemotron-omni-nvfp4]
       tts: [magpie-multilingual-tts]
     bot: examples.omni_assistant_subagents.pipeline:bot

--- a/src/examples/omni_assistant_subagents/prompts.yaml
+++ b/src/examples/omni_assistant_subagents/prompts.yaml
@@ -44,7 +44,7 @@ shared:
     If nothing meaningful changed, set observation exactly to "No notable change." and do not repeat your previous
     sentence; still return the complete JSON object with visual_control.
 
-generic_omni_assistant:
+omni_subagents_assistant:
   description: "Nemotron Omni voice assistant using one model for ASR and LLM."
   content: |
     Identity and voice:

--- a/tests/unit/test_speaker_action_contract.py
+++ b/tests/unit/test_speaker_action_contract.py
@@ -170,14 +170,14 @@ class PromptAndStreamingContractTests(unittest.TestCase):
         for action in ("respond", "think", "analyze_attachment", "capture_highres", "clarify"):
             self.assertIn(action, self.full)
             self.assertIn(action, lean)
-        system = _expand_fragments(self.catalog["generic_omni_assistant"]["content"], self.catalog)
+        system = _expand_fragments(self.catalog["omni_subagents_assistant"]["content"], self.catalog)
         self.assertIn("ten-sentence story", system)
         self.assertIn("one, two, three, four, five", system)
         self.assertIn("What would you like help with?", system)
         self.assertIn("the camera is ON", system)
 
     def test_catalog_prompts_have_no_unresolved_fragments(self) -> None:
-        contents = [self.catalog["generic_omni_assistant"]["content"]]
+        contents = [self.catalog["omni_subagents_assistant"]["content"]]
         for prompts in self.catalog["agent_prompts"].values():
             contents.extend(prompt["content"] for prompt in prompts.values())
         for content in contents:
@@ -221,7 +221,7 @@ class PromptFragmentTests(unittest.TestCase):
         self.assertIn("visual_sources", shared)
 
     def test_all_placeholders_resolve_with_no_leftovers(self) -> None:
-        generic = _expand_fragments(self.catalog["generic_omni_assistant"]["content"], self.catalog)
+        generic = _expand_fragments(self.catalog["omni_subagents_assistant"]["content"], self.catalog)
         thinker = _agent_prompt_content(self.catalog, "ThinkerAgent", "thinking_system_prompt")
         media = _agent_prompt_content(self.catalog, "MediaAnalyzerAgent", "analysis_system_prompt")
         for expanded in (generic, thinker, media):


### PR DESCRIPTION
## Summary

Two small UX enhancements from the release review:

- **Surface the launched example on the first page.** Adds an `Example` row to the right-hand **SESSION** panel (next to `Transport` / `RTVI protocol`), so single-example compose recipes — where the left selector is hidden — still tell the user which pipeline is running. Long names wrap cleanly; the registry key shows on hover.
- **Left EXAMPLE selector is switcher-only.** It now renders only when more than one example is available, instead of showing a greyed-out control for pinned recipes.
- **Disambiguate the omni prompts.** Renames the `omni-assistant-subagents` prompt key `generic_omni_assistant` → `omni_subagents_assistant` so it no longer looks identical to the plain `omni-assistant` example in the PROMPT dropdown. Updated in `examples_registry.yaml`, the example `prompts.yaml`, and the unit tests.

## Changes

- `client/src/components/status-panel/SessionSection.tsx`, `StatusRow.tsx`, `client/src/styles/nvidia-theme.scss` — SESSION `Example` row + wrap style
- `client/src/components/PipelineExampleSelector.tsx` — switcher-only rendering
- `examples_registry.yaml`, `src/examples/omni_assistant_subagents/prompts.yaml`, `tests/unit/test_speaker_action_contract.py` — prompt key rename
- `CHANGELOG.md` — note under Unreleased/Added

## Test plan

- [x] `client` production build passes (`npm run build`)
- [x] Prompt-catalog contract unit tests pass (`pytest tests/unit/test_speaker_action_contract.py`)
- [ ] Manual: launch a single-example recipe (e.g. `omni-assistant-subagents/single-gpu`) and confirm the SESSION panel shows the example name on the idle screen
- [ ] Manual: with `EXAMPLE_SELECTION=all`, confirm the left EXAMPLE dropdown still switches examples
- [ ] Manual: confirm the PROMPT dropdown shows `omni_subagents_assistant` for the subagents example and `generic_omni_assistant` for the plain omni example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Client SESSION panel now shows the launched example’s name and key for single-example Compose recipes.
  * Deployment selection is shown only when multiple options are available.
* **Bug Fixes**
  * Deployment selection remains available when appropriate and is disabled only while the connection is locked.
  * Long example labels now wrap cleanly within the status panel.
* **Maintenance**
  * Updated the Omni Assistant subagents example configuration and related validation to use its current assistant prompt name.
  * Added a changelog entry documenting the session panel update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->