### PR TITLE
fix(deploy): enable Magpie TTS text normalization on single-gpu

### DIFF
--- a/docker/docker-compose.nemo-speech-cpp.yaml
+++ b/docker/docker-compose.nemo-speech-cpp.yaml
@@ -3,6 +3,8 @@ x-nemo-speech: &nemo-speech
   ipc: host
   volumes:
     - ${NEMO_SPEECH_MODEL_LOC:-../models/nemo-speech}:/models:ro
+  tmpfs:
+    - /tmp
   ports:
     - "50051:50051"
   deploy:
@@ -28,6 +30,7 @@ services:
       - --tts.magpie-model=/models/magpie-tts/magpie_tts_multilingual_357m.v2602.f16.gguf
       - --tts.codec-model=/models/nano-codec/nemo_nano_codec_22khz_1.89kbps_21.5fps.decoder.f16.gguf
       - --tts.tokenizer-model-dir=/models/magpie-tts/extracted
+      - --tts.tn-model-dir=/models/tn_configs
       - --tts.language-code=en-US
       - --tts.voice-name=John
       - --tts.threads=${NEMO_SPEECH_TTS_THREADS:-8}
@@ -44,6 +47,7 @@ services:
       - --tts.magpie-model=/models/magpie-tts/magpie_tts_multilingual_357m.v2602.f16.gguf
       - --tts.codec-model=/models/nano-codec/nemo_nano_codec_22khz_1.89kbps_21.5fps.decoder.f16.gguf
       - --tts.tokenizer-model-dir=/models/magpie-tts/extracted
+      - --tts.tn-model-dir=/models/tn_configs
       - --tts.language-code=en-US
       - --tts.voice-name=John
       - --tts.threads=${NEMO_SPEECH_TTS_THREADS:-8}
@@ -58,6 +62,7 @@ services:
       - --tts.magpie-model=/models/magpie-tts/magpie_tts_multilingual_357m.v2602.f16.gguf
       - --tts.codec-model=/models/nano-codec/nemo_nano_codec_22khz_1.89kbps_21.5fps.decoder.f16.gguf
       - --tts.tokenizer-model-dir=/models/magpie-tts/extracted
+      - --tts.tn-model-dir=/models/tn_configs
       - --tts.language-code=en-US
       - --tts.voice-name=John
       - --tts.threads=${NEMO_SPEECH_TTS_THREADS:-8}

--- a/docker/docker-compose.nemo-speech-cpp.yaml
+++ b/docker/docker-compose.nemo-speech-cpp.yaml
@@ -4,7 +4,7 @@ x-nemo-speech: &nemo-speech
   volumes:
     - ${NEMO_SPEECH_MODEL_LOC:-../models/nemo-speech}:/models:ro
   tmpfs:
-    - /tmp
+    - /tmp:mode=1777
   ports:
     - "50051:50051"
   deploy:

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -86,7 +86,7 @@ Each example ships as Docker Compose **profiles**. Pick exactly one per deployme
 
     **4.3 Single GPU** (one supported GPU). Hardware support varies by example as listed above. `omni-assistant-subagents/single-gpu` is not supported on Jetson Thor. Cascaded recipes run NeMo-Speech.cpp next to Nemotron 3.5 Lightning. Omni recipes retain the multimodal Omni model and use NeMo-Speech.cpp for TTS. The Lightning container selects NVFP4, FP8, or BF16 from the supported platform and GPU compute capability. DGX Spark enables DSpark speculative decoding and Blackwell workstations enable DFlash automatically. Follow the [Jetson Thor guide](03-jetson-thor.md) when applicable.
 
-    Download the NeMo-Speech.cpp weights **once, as your user** (do not use `sudo`). The script reads `HF_TOKEN` from `.env` and creates `models/nemo-speech`:
+    Download the NeMo-Speech.cpp weights **once, as your user** (do not use `sudo`). The script reads `HF_TOKEN` from `.env`, pulls the GGUFs from Hugging Face, and fetches Magpie TTS text-normalization grammars from the [NeMo-Speech.cpp GitHub release](https://github.com/NVIDIA/NeMo-Speech.cpp/releases) into `models/nemo-speech`:
 
     ```bash
     bash scripts/download-nemo-speech-models.sh

--- a/docs/03-jetson-thor.md
+++ b/docs/03-jetson-thor.md
@@ -37,7 +37,8 @@ the supported configuration on Thor.
     `omni-assistant-subagents/single-gpu` is **not supported** on Jetson Thor. Use cloud `omni-assistant-subagents` for that example, which runs on NVIDIA cloud endpoints and needs `NVIDIA_API_KEY` (not `HF_TOKEN`). The no-`NVIDIA_API_KEY` rule above applies only to the `*/single-gpu` path.
 
 3. Download the NeMo-Speech.cpp model weights. **One-time per machine.** The script
-   fetches the ASR, Magpie TTS, and NanoCodec GGUFs into `models/nemo-speech`:
+   fetches the ASR, Magpie TTS, and NanoCodec GGUFs plus Magpie TTS
+   text-normalization grammars (`tn_configs`) into `models/nemo-speech`:
 
     ```bash
     bash scripts/download-nemo-speech-models.sh

--- a/docs/06-troubleshooting.md
+++ b/docs/06-troubleshooting.md
@@ -55,6 +55,7 @@ Self-hosted Nemotron-3 models only. Cloud (NVCF) has the parsers enabled server-
 |-----------------|-------------|-----------|
 | Synthesis fails or produces odd audio on code / Markdown / JSON output | Characters reserved by the Magpie preprocessor (`{`, `}`, `<tag>`) reached the engine. Apply the text filter, using `NemotronSpeechMarkdownTextFilter` for Markdown-heavy output. | [Configure TTS → TTS text filter](how-to/configure-tts.md#tts-text-filter) |
 | Mispronounced brand / domain terms | Add them to an IPA dictionary using `TTS_IPA_FILE_PATH`. | [Configure TTS → Pronunciation (IPA)](how-to/configure-tts.md#pronunciation-ipa) |
+| Single-GPU TTS reads digits, dates, or currency as characters (for example "2" instead of "two") | Magpie TTS text normalization is off. Re-run `bash scripts/download-nemo-speech-models.sh` so `models/nemo-speech/tn_configs` is present, then restart the `*/single-gpu` profile. The sidecar must receive `--tts.tn-model-dir=/models/tn_configs`. | [Getting Started](01-getting-started.md#docker-based-deployment) · [Jetson Thor](03-jetson-thor.md) |
 | Long replies are rejected or truncated | The TTS NIM caps a request at **2,000 normalized characters**. The NVIDIA Pipecat TTS service streams replies **sentence-by-sentence with a 200-character hard limit per sentence**, so the cap is not reached in normal use. It mainly affects custom integrations that synthesize large blocks at once. Split long text into sentence or paragraph chunks. | [Configure TTS](how-to/configure-tts.md) · [TTS NIM troubleshooting](https://docs.nvidia.com/nim/speech/latest/troubleshooting/tts.html) |
 
 ## Response quality (hallucination and repetition)
@@ -88,7 +89,7 @@ The hosted **[build.nvidia.com](https://build.nvidia.com/)** endpoints are for *
 |-----------------|-------------|-----------|
 | `RuntimeError: Engine core initialization failed` (vLLM) | Often low available memory from cached pages held by the kernel (the `nvidia-llm-vllm-lightning` logs show the engine-core failure). Reclaim caches with `sudo sync && sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'`, then re-up the `<example>/single-gpu` profile and re-check `free -h`. | [Jetson Thor](03-jetson-thor.md) · [Configure LLM → VRAM](how-to/configure-llm.md#vram--hardware-support) |
 | Choppy / glitchy bot speech (vLLM and the speech sidecar share one GPU) | vLLM is starved of GPU or host memory. For automatically sized recipes, increase `VLLM_VRAM_HEADROOM_MIB` in `.env` or set a lower `VLLM_GPU_MEMORY_UTILIZATION` override. Lightning on DGX Spark and Jetson Thor already uses a fixed value of `0.35`, so inspect host memory and reduce workload or concurrency first. Restart the profile and re-measure with the speech sidecar loaded. | [Jetson Thor](03-jetson-thor.md) |
-| Speech models not found | The GGUF weights are missing. Run `bash scripts/download-nemo-speech-models.sh` as your user (not sudo), or point `NEMO_SPEECH_MODEL_LOC` in `.env` at the absolute path holding them. | [Jetson Thor](03-jetson-thor.md) |
+| Speech models not found | The GGUF weights are missing. Run `bash scripts/download-nemo-speech-models.sh` as your user (not sudo), or point `NEMO_SPEECH_MODEL_LOC` in `.env` at the absolute path holding them. The same script also downloads TTS TN grammars into `tn_configs`. | [Jetson Thor](03-jetson-thor.md) |
 
 ## Browser access
 

--- a/docs/how-to/configure-tts.md
+++ b/docs/how-to/configure-tts.md
@@ -56,7 +56,7 @@ TTS runs one of these ways, and the repo wires the right one per profile:
   Then select the matching catalog key in the Services tab (or `defaults.tts`). Omitting the opt-in profile leaves that sidecar running and holding the ports—stop it before Magpie Multilingual can bind again (`docker compose --profile <profile> stop <service>`, then recipe `up -d`).
 
   Magpie Zeroshot NGC access is restricted — apply at the [Magpie TTS Zeroshot NGC page](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/magpie-tts-zeroshot). For audio-prompt cloning, see [Voice cloning / zero-shot](#voice-cloning--zero-shot).
-- **NeMo-Speech.cpp (single GPU, including Jetson Thor)**: on `*/single-gpu`, an on-device sidecar serves Magpie TTS from local GGUF weights: `nemo-speech` / `nemo-speech-multilingual` (ASR + TTS together) or `nemo-speech-tts` (TTS only, for Omni). See [Jetson Thor](../03-jetson-thor.md).
+- **NeMo-Speech.cpp (single GPU, including Jetson Thor)**: on `*/single-gpu`, an on-device sidecar serves Magpie TTS from local GGUF weights: `nemo-speech` / `nemo-speech-multilingual` (ASR + TTS together) or `nemo-speech-tts` (TTS only, for Omni). `scripts/download-nemo-speech-models.sh` also fetches Sparrowhawk TN grammars so digits and dates are spoken as words (`--tts.tn-model-dir=/models/tn_configs`). See [Jetson Thor](../03-jetson-thor.md).
 
 ### VRAM & Hardware Support
 

--- a/scripts/download-nemo-speech-models.sh
+++ b/scripts/download-nemo-speech-models.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Download NeMo-Speech.cpp GGUF weights for */single-gpu recipes.
+# Download NeMo-Speech.cpp GGUF weights and TTS TN grammars for */single-gpu recipes.
 #
 # Run as your user, never sudo. The script:
 #   - reads HF_TOKEN from the repo .env
@@ -82,6 +82,105 @@ reclaim_if_unwritable() {
   fi
 }
 
+# Magpie TTS text-normalization grammars live on the NeMo-Speech.cpp GitHub
+# release, not Hugging Face. Pin matches nvcr.io/nvidia/nemo-speech.cpp:0.1.0.
+NEMO_SPEECH_CPP_RELEASE="${NEMO_SPEECH_CPP_RELEASE:-v0.1.0}"
+TN_ARCHIVE="tn_configs.tar.bz2"
+TN_SHA256="${NEMO_SPEECH_TN_SHA256:-2ca242c6d29f551eba3663d7e508c0d9dad10440e287628234154c6d1a72c7bc}"
+TN_URL="https://github.com/NVIDIA/NeMo-Speech.cpp/releases/download/${NEMO_SPEECH_CPP_RELEASE}/${TN_ARCHIVE}"
+
+download_url() {
+  local url="$1"
+  local dest="$2"
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fL --retry 3 --connect-timeout 30 --max-time 180 -o "${dest}" "${url}"; then
+      return 0
+    fi
+    echo "curl failed for ${url}; trying another downloader..." >&2
+    rm -f "${dest}"
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    if wget -O "${dest}" "${url}"; then
+      return 0
+    fi
+    echo "wget failed for ${url}; trying another downloader..." >&2
+    rm -f "${dest}"
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    if gh release download "${NEMO_SPEECH_CPP_RELEASE}" \
+      --repo NVIDIA/NeMo-Speech.cpp \
+      --pattern "${TN_ARCHIVE}" \
+      --dir "$(dirname "${dest}")"; then
+      return 0
+    fi
+    echo "gh release download failed for ${TN_ARCHIVE}." >&2
+  fi
+  echo "Need a working curl, wget, or gh to download ${url}" >&2
+  return 1
+}
+
+verify_sha256() {
+  local file="$1"
+  local expected="$2"
+  local actual
+  actual="$(sha256sum "${file}" | awk '{print $1}')"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "Checksum mismatch for ${file}" >&2
+    echo "  expected ${expected}" >&2
+    echo "  got      ${actual}" >&2
+    return 1
+  fi
+}
+
+# Best-effort install of the Magpie TTS text-normalization grammars. Returns
+# non-zero (without exiting) if the release asset is unavailable, corrupt, or
+# incomplete, so the GGUF setup still counts as a success.
+install_tn_grammars() {
+  local tar="${DEST}/${TN_ARCHIVE}"
+
+  if [[ -f "${tar}" ]]; then
+    local have
+    have="$(sha256sum "${tar}" | awk '{print $1}')"
+    if [[ "${have}" != "${TN_SHA256}" ]]; then
+      echo "Existing ${tar} has an unexpected checksum; re-downloading..."
+      rm -f "${tar}"
+    fi
+  fi
+
+  if [[ ! -f "${tar}" ]]; then
+    echo "Downloading TTS text-normalization grammars (${TN_ARCHIVE})..."
+    download_url "${TN_URL}" "${tar}" || return 1
+  fi
+
+  verify_sha256 "${tar}" "${TN_SHA256}" || return 1
+
+  rm -rf "${DEST}/tn_configs"
+  tar -xjf "${tar}" -C "${DEST}" || return 1
+
+  [[ -f "${DEST}/tn_configs/en/tokenize_and_classify.far" && \
+     -f "${DEST}/tn_configs/en/verbalize.far" ]] || return 1
+}
+
+warn_tn_unavailable() {
+  rm -rf "${DEST}/tn_configs"
+  cat >&2 <<EOF
+
+============================================================================
+WARNING: TTS text-normalization (TN) grammars could not be installed.
+
+  Source: ${TN_URL}
+
+  Without them, single-GPU Magpie TTS reads digits, dates, and currency
+  literally (for example "2" instead of "two").
+
+  The rest of the speech models downloaded successfully. Re-run this script
+  to retry the TN download. If the GitHub release asset moved, pin the new
+  checksum with NEMO_SPEECH_TN_SHA256.
+============================================================================
+
+EOF
+}
+
 reclaim_if_unwritable "${DEST}"
 reclaim_if_unwritable "${HF_CACHE}"
 mkdir -p "${DEST}/magpie-tts/extracted" "${DEST}/nano-codec" "${HF_CACHE}"
@@ -109,6 +208,16 @@ tar -xf "${DEST}/magpie-tts/magpie_tts_multilingual_357m.nemo" \
   nemo_nano_codec_22khz_1.89kbps_21.5fps.decoder.f16.gguf \
   --local-dir "${DEST}/nano-codec"
 
+tn_ok=true
+if ! install_tn_grammars; then
+  warn_tn_unavailable
+  tn_ok=false
+fi
+
 chmod -R a+rX "${DEST}"
 
-echo "Models ready at ${DEST}"
+if [[ "${tn_ok}" == true ]]; then
+  echo "Models ready at ${DEST} (TTS text normalization enabled)."
+else
+  echo "Models ready at ${DEST} (TTS text normalization NOT installed; see warning above)."
+fi

--- a/scripts/download-nemo-speech-models.sh
+++ b/scripts/download-nemo-speech-models.sh
@@ -84,9 +84,11 @@ reclaim_if_unwritable() {
 
 # Magpie TTS text-normalization grammars live on the NeMo-Speech.cpp GitHub
 # release, not Hugging Face. Pin matches nvcr.io/nvidia/nemo-speech.cpp:0.1.0.
-NEMO_SPEECH_CPP_RELEASE="${NEMO_SPEECH_CPP_RELEASE:-v0.1.0}"
+TN_PINNED_RELEASE="v0.1.0"
+TN_PINNED_SHA256="2ca242c6d29f551eba3663d7e508c0d9dad10440e287628234154c6d1a72c7bc"
+NEMO_SPEECH_CPP_RELEASE="${NEMO_SPEECH_CPP_RELEASE:-${TN_PINNED_RELEASE}}"
 TN_ARCHIVE="tn_configs.tar.bz2"
-TN_SHA256="${NEMO_SPEECH_TN_SHA256:-2ca242c6d29f551eba3663d7e508c0d9dad10440e287628234154c6d1a72c7bc}"
+TN_SHA256="${NEMO_SPEECH_TN_SHA256:-${TN_PINNED_SHA256}}"
 TN_URL="https://github.com/NVIDIA/NeMo-Speech.cpp/releases/download/${NEMO_SPEECH_CPP_RELEASE}/${TN_ARCHIVE}"
 
 download_url() {
@@ -138,6 +140,11 @@ verify_sha256() {
 install_tn_grammars() {
   local tar="${DEST}/${TN_ARCHIVE}"
 
+  if [[ "${NEMO_SPEECH_CPP_RELEASE}" != "${TN_PINNED_RELEASE}" && "${TN_SHA256}" == "${TN_PINNED_SHA256}" ]]; then
+    echo "NEMO_SPEECH_CPP_RELEASE=${NEMO_SPEECH_CPP_RELEASE} but the checksum is still the ${TN_PINNED_RELEASE} pin;" >&2
+    echo "set NEMO_SPEECH_TN_SHA256 for ${NEMO_SPEECH_CPP_RELEASE} or the download will fail verification." >&2
+  fi
+
   if [[ -f "${tar}" ]]; then
     local have
     have="$(sha256sum "${tar}" | awk '{print $1}')"
@@ -152,17 +159,22 @@ install_tn_grammars() {
     download_url "${TN_URL}" "${tar}" || return 1
   fi
 
-  verify_sha256 "${tar}" "${TN_SHA256}" || return 1
+  verify_sha256 "${tar}" "${TN_SHA256}" || { rm -f "${tar}"; return 1; }
 
   rm -rf "${DEST}/tn_configs"
-  tar -xjf "${tar}" -C "${DEST}" || return 1
+  if ! tar -xjf "${tar}" -C "${DEST}"; then
+    rm -rf "${DEST}/tn_configs"
+    return 1
+  fi
 
-  [[ -f "${DEST}/tn_configs/en/tokenize_and_classify.far" && \
-     -f "${DEST}/tn_configs/en/verbalize.far" ]] || return 1
+  if [[ ! -f "${DEST}/tn_configs/en/tokenize_and_classify.far" || \
+        ! -f "${DEST}/tn_configs/en/verbalize.far" ]]; then
+    rm -rf "${DEST}/tn_configs"
+    return 1
+  fi
 }
 
 warn_tn_unavailable() {
-  rm -rf "${DEST}/tn_configs"
   cat >&2 <<EOF
 
 ============================================================================

--- a/scripts/download-nemo-speech-models.sh
+++ b/scripts/download-nemo-speech-models.sh
@@ -161,17 +161,21 @@ install_tn_grammars() {
 
   verify_sha256 "${tar}" "${TN_SHA256}" || { rm -f "${tar}"; return 1; }
 
+  local stage="${DEST}/.tn_configs.staging"
+  rm -rf "${stage}"
+  mkdir -p "${stage}"
+  if ! tar -xjf "${tar}" -C "${stage}"; then
+    rm -rf "${stage}"
+    return 1
+  fi
+  if [[ ! -f "${stage}/tn_configs/en/tokenize_and_classify.far" || \
+        ! -f "${stage}/tn_configs/en/verbalize.far" ]]; then
+    rm -rf "${stage}"
+    return 1
+  fi
   rm -rf "${DEST}/tn_configs"
-  if ! tar -xjf "${tar}" -C "${DEST}"; then
-    rm -rf "${DEST}/tn_configs"
-    return 1
-  fi
-
-  if [[ ! -f "${DEST}/tn_configs/en/tokenize_and_classify.far" || \
-        ! -f "${DEST}/tn_configs/en/verbalize.far" ]]; then
-    rm -rf "${DEST}/tn_configs"
-    return 1
-  fi
+  mv "${stage}/tn_configs" "${DEST}/tn_configs"
+  rm -rf "${stage}"
 }
 
 warn_tn_unavailable() {

--- a/skills/deploy/references/single-gpu.md
+++ b/skills/deploy/references/single-gpu.md
@@ -14,7 +14,7 @@ Once, from the repo root, as your user (not sudo):
 bash scripts/download-nemo-speech-models.sh
 ```
 
-The script reads `HF_TOKEN` from `.env`. If `docker compose` already created `models/nemo-speech` as root, the script reclaims ownership automatically.
+The script reads `HF_TOKEN` from `.env` and also downloads Magpie TTS text-normalization grammars from the matching NeMo-Speech.cpp GitHub release. If `docker compose` already created `models/nemo-speech` as root, the script reclaims ownership automatically.
 
 ## Memory Fit
 


### PR DESCRIPTION
## Summary

Single-GPU Magpie TTS spoke digits, dates, and currency literally (for example "2" instead of "two") because the Sparrowhawk text-normalization (TN) grammars were never provisioned. This wires TN up end to end for the `*/single-gpu` recipes.

- **`scripts/download-nemo-speech-models.sh`**: fetches `tn_configs.tar.bz2` from the matching [NeMo-Speech.cpp GitHub release](https://github.com/NVIDIA/NeMo-Speech.cpp/releases) (curl → wget → gh fallback), verifies its SHA256, and extracts into `models/nemo-speech`. Best-effort: if the release asset is unavailable, corrupt, or incomplete, it prints a warning and continues so the GGUF setup still succeeds.
- **`docker/docker-compose.nemo-speech-cpp.yaml`**: passes `--tts.tn-model-dir=/models/tn_configs` to all three single-gpu speech services, and mounts a `tmpfs` at `/tmp` so Sparrowhawk can stage its `.far` grammars (the minimal image has no `/tmp`, and `/models` is mounted read-only).
- **docs**: document the TN grammar download in getting-started, Jetson Thor, configure-tts, and the deploy skill reference, plus a troubleshooting entry for literal digit/date pronunciation.

## Notes

- The TN grammars share the existing `models/nemo-speech` (`/models`) mount as the GGUFs, so no new bind mount is needed. Only the source differs (GitHub release vs Hugging Face).
- `chmod -R a+rX` already covers the extracted `tn_configs` so the sidecar (different UID, read-only mount) can read them.

## Test plan

- [ ] `bash scripts/download-nemo-speech-models.sh` populates `models/nemo-speech/tn_configs/en/{tokenize_and_classify,verbalize}.far`.
- [ ] Bring up a `*/single-gpu` profile; the `nemo-speech` sidecar starts without the `temp_directory_path: No such file or directory [/tmp]` crash.
- [ ] TTS speaks digits/dates/currency as words (e.g. "12/25" → spoken date, "2" → "two").
- [ ] Simulate a missing TN asset: the download script warns and still completes the GGUF setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically downloads and installs Magpie TTS text-normalization grammars with speech models.
  * Enables spoken normalization for digits, dates, and currency in TTS deployments.
  * Improves container support with temporary filesystem mounting and configured normalization resources.

* **Bug Fixes**
  * Adds checksum verification, required-file validation, and fallback download options for more reliable setup.

* **Documentation**
  * Updates deployment and troubleshooting guides with text-normalization setup and recovery instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->