### PR TITLE
feat(skill): refine voice agent deployment routing

### DIFF
--- a/skills/create-voice-agent/SKILL.md
+++ b/skills/create-voice-agent/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: create-voice-agent
-description: Create or refine an NVIDIA voice agent with Pipecat or LiveKit. Covers cascaded and omni pipelines, domain speech customization, NVIDIA cloud, GPU workstations, DGX Spark, and Jetson Thor. Use when asked to build, scaffold, start, or modify a voice agent, voice bot, speech assistant, real-time audio pipeline, ASR word boosting, or TTS pronunciation.
+description: Create or refine NVIDIA voice agents with Pipecat or LiveKit. Use for Cascaded or Omni pipelines, speech customization, and cloud or local deployment.
 version: "2.2.0"
 metadata:
   author: NVIDIA Voice Agent Team <nemotron-voice-agent@nvidia.com>
-  tags: [voice-agent, nvidia, nemotron, magpie, pipecat, livekit, nim, omni]
+  tags: [voice-agent, nvidia, nemotron, magpie, pipecat, livekit, nim, vllm, nemo-speech, omni]
 ---
 
 # Create Voice Agent
@@ -27,17 +27,23 @@ For an empty project, follow these phases in order:
 | Phase | Read |
 | --- | --- |
 | 1. Intake | `references/intake.md` resolves pipeline and framework first, then routes preflight, models, language, and domain files |
-| 2. Build | `references/platforms/readiness.md` if self-hosted → exact profile in the routed model file → `references/output-contract.md` → routed platform + `references/platforms/deployment.md` → `references/operations/observability.md` → selected framework files |
+| 2. Build | `references/platforms/readiness.md` if self-hosted → exact profile or quantization variant in the routed model file → `references/output-contract.md` → routed deployment path → `references/operations/observability.md` → selected framework files |
 | 3. Hand over | `references/operations/run.md` gates the client on the generated `scripts/smoke.sh`, then `references/operations/troubleshoot.md` if the spoken exchange fails |
 | 4. Iterate | `references/operations/iterate.md` for changes to a working agent |
 
 Wait for approval before writing files.
 
-During build, keep the approved language and behavior locks from intake. Read every routed
-file before generating code. Cloud deployment skips readiness, `list-model-profiles`,
-Compose, and the shared-GPU gate; wire endpoints per `references/platforms/deployment.md`
-§Cloud. Use `references/networking/remote-webrtc.md` when Pipecat WebRTC crosses hosts or
+`references/preflight.md` §4 probes the host and selects the deployment path. The routed
+platform file owns that path from there.
+
+Also read `references/networking/remote-webrtc.md` when Pipecat WebRTC crosses hosts or
 networks.
 
-During handover, require a successful spoken exchange. A running process alone is not a
-working voice agent.
+## Rules
+
+- Resolve every model id, image tag, profile, and serve flag from current NVIDIA
+  documentation at build time. Never from memory.
+- Read every routed file before generating code, and keep the language and behavior locks
+  approved in intake.
+- Handover requires a successful spoken exchange. A running process is not a working voice
+  agent.

--- a/skills/create-voice-agent/evals/EVAL.md
+++ b/skills/create-voice-agent/evals/EVAL.md
@@ -1,0 +1,49 @@
+# Create Voice Agent Evaluation Guidance
+
+## Questions
+
+- Explicit requests that name `create-voice-agent`.
+- Implicit and contextual requests for Cascaded and Omni voice agents.
+- DGX Spark, Jetson Thor, low-concurrency workstation, high-concurrency workstation,
+  hybrid, and cloud routing.
+- Pipecat selection, LiveKit selection, and the LiveKit plus Omni conflict.
+- Partial `nvidia-smi` failures and occupied GPU memory.
+- Reasoning on and off, multilingual routing, and domain speech customization.
+- Approved Cascaded, Omni, and LiveKit builds from generation through non-GPU smoke tests.
+- Existing-project iteration and failure recovery through regression verification.
+- Negative text-only, batch-transcription, and unrelated NVIDIA development requests.
+
+## Behaviors
+
+- Read `SKILL.md` first, then only the references routed by the selected workflow.
+- Resolve framework and pipeline before deployment details.
+- Generate framework APIs only from the current Pipecat or LiveKit documentation MCP.
+- Separate LLM NIM, VLM NIM, Speech NIM, and raw-vLLM documentation families.
+- Route DGX Spark, Jetson Thor, and low-concurrency workstations to vLLM plus
+  NeMo-Speech.cpp. Route high-concurrency workstations to NIM.
+- Treat probe failures as unknown hardware state rather than proof of no GPU.
+- Identify reclaimable GPU memory and obtain approval before stopping a named container.
+- Resolve models, profiles, quantization, identifiers, flags, and reasoning settings from
+  current authoritative sources.
+- Keep reasoning off by default. When enabled, use the locked model's contract and keep
+  reasoning away from TTS.
+- Wait for approval before writing files and require smoke plus a spoken exchange before
+  declaring success.
+- For approved builds, generate the complete output contract and run every check supported
+  by the evaluation environment.
+- Distinguish deterministic mock verification from the final hardware-backed spoken
+  exchange. Never report a physical test that did not run.
+
+## Notes
+
+Keep the CI dataset small enough for the one-hour NVSkills CI limit. Planning cases verify
+selection and safety. End-to-end cases verify project generation, static checks, unit tests,
+deterministic mock endpoints, generated smoke paths, and accurate handover without requiring
+NVIDIA GPUs, model downloads, external credentials, or long-running services.
+
+Run physical microphone, speaker, GPU, DGX Spark, Jetson Thor, and workstation deployments
+separately. Report those hardware-backed spoken exchanges as extended evidence in
+`BENCHMARK.md`.
+
+Negative cases are required. They should ensure the skill does not activate for text-only
+chatbots, standalone batch transcription, generic Docker support, or unrelated CUDA work.

--- a/skills/create-voice-agent/evals/evals.json
+++ b/skills/create-voice-agent/evals/evals.json
@@ -1,0 +1,238 @@
+{
+  "skill_name": "create-voice-agent",
+  "evals": [
+    {
+      "id": "create-voice-agent-explicit-dgx-spark",
+      "prompt": "Use the create-voice-agent skill to plan a Pipecat cascaded English voice assistant on my DGX Spark for one user. Do not write files yet.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A concise proposal that routes DGX Spark to vLLM plus NeMo-Speech.cpp, uses current NVIDIA sources to resolve Nemotron 3.5 Lightning and speech models, requires HF_TOKEN rather than a NIM credential, and waits for approval before generating files.",
+      "assertions": [
+        "Loaded create-voice-agent/SKILL.md and the references routed for intake, preflight, Pipecat, models, and DGX Spark.",
+        "Selected the cascaded pipeline and Pipecat without asking the user to repeat choices already present.",
+        "Routed local deployment to vLLM plus NeMo-Speech.cpp rather than NIM.",
+        "Planned from available unified memory and included the measured speech reserve gate.",
+        "Presented one filled proposal table and did not write project files before approval."
+      ]
+    },
+    {
+      "id": "create-voice-agent-implicit-low-concurrency-workstation",
+      "prompt": "I have a Linux workstation with one RTX PRO 6000 Blackwell GPU. Build a private voice assistant for me and two colleagues using Pipecat, streaming speech, and low turn latency.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "The agent recognizes a low-concurrency NVIDIA voice-agent request, probes the host, proposes a cascaded Pipecat pipeline, and routes local services to vLLM plus NeMo-Speech.cpp with model-specific quantization and measured memory controls.",
+      "assertions": [
+        "Activated the skill without the user naming it.",
+        "Inferred low concurrency from the stated user count and recorded that assumption in the Deployment row.",
+        "Selected vLLM plus NeMo-Speech.cpp instead of workstation NIM.",
+        "Resolved quantization from the locked model page for the exact GPU rather than from memory.",
+        "Kept reasoning off by default for low voice latency."
+      ]
+    },
+    {
+      "id": "create-voice-agent-contextual-high-concurrency-workstation",
+      "prompt": "We are adding a spoken support agent to an existing service. It will run on an x86_64 NVIDIA GPU workstation and must serve hundreds of simultaneous customer sessions. Recommend the NVIDIA deployment and framework, then show the decisions for approval.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A proposal that infers high concurrency, recommends the workstation NIM path, resolves the framework and pipeline, verifies each NIM service against its current documentation family, budgets all co-located services, and waits for approval.",
+      "assertions": [
+        "Inferred high concurrency without asking a separate concurrency question.",
+        "Recommended NIM for the high-concurrency workstation.",
+        "Kept LLM, Speech, and VLM NIM documentation families distinct.",
+        "Marked co-location provisional until the measured shared-GPU gate passes.",
+        "Did not silently move a slot to cloud or select a smaller model."
+      ]
+    },
+    {
+      "id": "create-voice-agent-jetson-thor-omni",
+      "prompt": "Create a single-agent Nemotron 3 Omni voice assistant on Jetson Thor. I want Pipecat and one local user.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A Pipecat Omni proposal for Jetson Thor using raw vLLM plus NeMo-Speech.cpp TTS, with no ASR service, no speculative draft model, HF_TOKEN model access, arm64 checks, and current Omni model instructions.",
+      "assertions": [
+        "Confirmed Jetson Thor rather than treating every Jetson as supported.",
+        "Selected Pipecat because LiveKit does not support the Omni pipeline.",
+        "Used the single-GPU vLLM path and did not apply NIM profiles or Speech NIM tags.",
+        "Omitted ASR and configured the speech service for TTS only.",
+        "Rejected the concurrent-subagent Omni shape and did not add a draft model on Thor."
+      ]
+    },
+    {
+      "id": "create-voice-agent-workstation-omni-nim",
+      "prompt": "Plan a Nemotron 3 Omni contact-center voice agent on a multi-GPU workstation for high concurrency.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A high-concurrency Pipecat Omni proposal using Omni VLM NIM plus TTS, with no ASR service. Hardware fit, precision, image, profiles, environment and runtime controls come from current VLM NIM documentation rather than LLM NIM documentation.",
+      "assertions": [
+        "Selected Pipecat and the Omni pipeline.",
+        "Selected the workstation NIM path because the use case is high concurrency.",
+        "Used the Omni VLM NIM support matrix, quickstart, profiles, utilities, and environment documentation.",
+        "Did not validate Omni with the LLM NIM support matrix or a cascaded LLM profile.",
+        "Budgeted Omni plus TTS and omitted ASR."
+      ]
+    },
+    {
+      "id": "create-voice-agent-gpu-probe-partial-failure",
+      "prompt": "Set up a local NVIDIA voice agent. nvidia-smi -L shows an H100, but querying index,name,memory.total,memory.free,compute_cap together exits with code 2 saying compute_cap is not a valid field.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "The agent treats this as partial field support rather than no GPU, reruns stable memory fields separately, resolves compute capability through the documented fallback, and does not force cloud because one field failed.",
+      "assertions": [
+        "Accepted nvidia-smi -L as evidence that a GPU exists.",
+        "Separated compute_cap from the stable memory query.",
+        "Reported that compute capability was derived when the driver could not return it.",
+        "Required confirmation against the selected model's authoritative compatibility source.",
+        "Did not classify the host as no_gpu or silently route it to cloud."
+      ]
+    },
+    {
+      "id": "create-voice-agent-vram-reclamation",
+      "prompt": "Deploy the voice agent locally. The GPU has 20 GiB free out of 96 GiB and docker ps shows an old unhealthy model container from this project holding about 50 GiB.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "The agent identifies the named stale container as reclaimable memory, explains the resulting local fit, asks for explicit approval before stopping it, and remeasures memory afterward instead of immediately downgrading or using cloud.",
+      "assertions": [
+        "Reported total and free memory with the process or container holding the remainder.",
+        "Named the specific container and estimated memory it would return.",
+        "Waited for user approval before stopping anything.",
+        "Did not run broad kill, prune, or stop commands.",
+        "Did not reduce model, precision, context, or placement around reclaimable memory."
+      ]
+    },
+    {
+      "id": "create-voice-agent-livekit-omni-conflict",
+      "prompt": "Build the agent with LiveKit and the Nemotron 3 Omni pipeline.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A single focused conflict question asking whether to keep LiveKit with a Cascaded pipeline or keep Omni with Pipecat. No files or deployment proposal are generated until the user resolves the conflict.",
+      "assertions": [
+        "Recognized that LiveKit is Cascaded-only in this skill.",
+        "Did not generate a LiveKit Omni implementation.",
+        "Asked exactly one conflict-resolution question.",
+        "Offered the two valid combinations without silently changing either choice.",
+        "Did not write files before resolution and approval."
+      ]
+    },
+    {
+      "id": "create-voice-agent-reasoning-mode",
+      "prompt": "Create a voice agent for complex multi-step engineering diagnosis. I want reasoning enabled, but the spoken answer must never include internal reasoning.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "The proposal records reasoning as enabled, resolves budget, token limits, nesting and sampling from the exact locked model API reference, retains the required server parser, and ensures only final response content reaches TTS.",
+      "assertions": [
+        "Did not apply one universal reasoning budget across Lightning and Omni.",
+        "Resolved reasoning fields and sampling from the locked model's current API reference.",
+        "Kept the required reasoning parser enabled independently of request mode.",
+        "Passed provider fields through the framework's documented request mechanism.",
+        "Required a streaming verification that reasoning content never reaches TTS."
+      ]
+    },
+    {
+      "id": "create-voice-agent-negative-text-rag",
+      "prompt": "Build a text-only RAG chatbot over my PDF collection. It has no microphone, speech input, or audio output.",
+      "expected_skill": null,
+      "expected_output": "The create-voice-agent skill does not activate because the request is explicitly text-only and contains no voice-agent workflow.",
+      "assertions": [
+        "Did not load or apply create-voice-agent.",
+        "Did not introduce ASR, TTS, Pipecat voice transports, or NVIDIA speech services."
+      ]
+    },
+    {
+      "id": "create-voice-agent-e2e-cascaded-generation",
+      "prompt": "Use create-voice-agent for this approved build. Generate a Pipecat Cascaded English voice assistant for one local user on an RTX PRO 6000 Blackwell workstation. Use vLLM plus NeMo-Speech.cpp. Reasoning is off. The local model services are already running on documented OpenAI-compatible and Riva-compatible endpoints, so do not download models or start GPU containers. Create the complete project, validate it, run its non-GPU tests, exercise the generated smoke path against deterministic local mock endpoints, and report whether it is ready for the final live spoken exchange.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A complete generated Cascaded project with pinned configuration, Pipecat pipeline, transport, service adapters, environment template, Compose or service configuration, smoke test, observability, runbook, and README. Static checks and deterministic mock smoke tests pass. The agent distinguishes this from the final hardware-backed spoken exchange and does not claim production readiness without that exchange.",
+      "assertions": [
+        "Treated the supplied deployment and behavior decisions as approved and did not reopen intake.",
+        "Read current Pipecat documentation through its documentation source before generating framework APIs.",
+        "Generated the complete output contract without putting model ids, voice ids, or non-secret settings in the secrets file.",
+        "Connected transport audio through ASR, the Cascaded LLM, and TTS in the correct order.",
+        "Ran available formatting, static, unit, and deterministic mock smoke checks and reported their actual results.",
+        "Did not claim the final spoken exchange passed when only mock endpoints were exercised."
+      ]
+    },
+    {
+      "id": "create-voice-agent-e2e-omni-generation",
+      "prompt": "Proceed with an approved end-to-end build of a Pipecat Nemotron 3 Omni assistant for one user on DGX Spark. Use raw vLLM plus NeMo-Speech.cpp TTS, reasoning off, and no ASR. The model and TTS endpoints are already available locally. Generate the full project, validate all generated artifacts, test turn handling and reasoning filtering with deterministic local mocks, run the smoke script, and stop only at the real microphone and speaker acceptance test.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A complete DGX Spark Omni project that uses the current NVIDIA Omni service and Smart Turn implementations, routes audio directly to Omni and text content to TTS, contains no ASR, validates generated configuration, and passes deterministic local tests without falsely claiming that the physical spoken exchange ran.",
+      "assertions": [
+        "Used the current upstream NvidiaOmniLLMService and NvidiaOmniSettings implementation rather than reimplementing it.",
+        "Copied the current audio-only Smart Turn strategy and used the required turn mute behavior.",
+        "Generated no ASR service or transcription-dependent turn logic.",
+        "Installed or documented the vLLM audio extras and required modality limits for the locked Omni runtime.",
+        "Verified that reasoning content cannot reach TTS and that final content can.",
+        "Ran generated checks and clearly left the physical spoken exchange as the remaining acceptance gate."
+      ]
+    },
+    {
+      "id": "create-voice-agent-e2e-livekit-cascaded",
+      "prompt": "The proposal is approved. Build a LiveKit Cascaded voice agent for English and Spanish callers. Model services are reachable through deterministic local test endpoints. Generate the project end to end, including participant handling, streaming ASR, the LLM, TTS, configuration, tests, observability, smoke checks, and handover instructions. Run every check that does not require a real LiveKit room or GPU.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A complete LiveKit Cascaded project generated from current LiveKit documentation with explicit bilingual model and voice routing, participant lifecycle handling, tests and smoke checks. The report separates checks that ran from the real-room spoken exchange that remains.",
+      "assertions": [
+        "Used the LiveKit documentation source before generating framework APIs.",
+        "Generated a Cascaded pipeline and did not introduce Omni.",
+        "Handled participant connection, audio input, interruption, cleanup, and reconnect behavior.",
+        "Locked English and Spanish support across ASR, LLM, and TTS before selecting exact runtime identifiers.",
+        "Ran all non-room checks and did not state that a real-room spoken exchange passed."
+      ]
+    },
+    {
+      "id": "create-voice-agent-hybrid-remote-webrtc",
+      "prompt": "Plan a Pipecat Cascaded agent where ASR and TTS run on my workstation, the LLM uses NVIDIA cloud, and browser clients connect over WebRTC from another network. Expect 20 concurrent users. Include credentials, placement, TURN, security, and verification gates.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A hybrid deployment proposal with explicit per-slot placement, correct separation of NVIDIA cloud and NGC credentials, a measured local speech budget, remote WebRTC signaling and TURN requirements, security boundaries, and staged verification.",
+      "assertions": [
+        "Recorded placement for ASR, LLM, and TTS separately rather than treating hybrid as one service.",
+        "Required NVIDIA_API_KEY for the cloud LLM and NGC_API_KEY for self-hosted container pulls without conflating them.",
+        "Budgeted the local speech services and framework against measured free GPU memory.",
+        "Included coturn, advertised addresses, firewall ports, TLS, and credential handling for cross-network WebRTC.",
+        "Required local smoke, remote connectivity, and final spoken-exchange verification."
+      ]
+    },
+    {
+      "id": "create-voice-agent-unsupported-jetson-orin",
+      "prompt": "Deploy Nemotron 3.5 Lightning, ASR, and TTS locally on my Jetson AGX Orin 64GB using the Jetson Thor instructions.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "The agent identifies that Orin is not Jetson Thor and does not reuse the Thor local deployment. It offers supported cloud or remote-GPU placement and waits for the user to choose.",
+      "assertions": [
+        "Verified the Jetson model and identified it as Orin-class hardware.",
+        "Did not generate Thor containers, arm64 commands, quantization, or memory assumptions for Orin.",
+        "Explained the unsupported local route concisely.",
+        "Offered cloud or a supported remote NVIDIA GPU host rather than fabricating local compatibility."
+      ]
+    },
+    {
+      "id": "create-voice-agent-multilingual-domain-speech",
+      "prompt": "Create a Hindi and English healthcare appointment voice agent. It must recognize the drug names apixaban and empagliflozin and pronounce them consistently. Use Pipecat and a Cascaded pipeline. Show the proposal before writing files.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A proposal that locks Hindi and English support across every slot, selects exact compatible ASR and TTS entries from current sources, separates ASR word boosting from TTS pronunciation controls, preserves the supplied terms exactly, and waits for approval.",
+      "assertions": [
+        "Validated both languages across ASR, LLM, and TTS before selecting models.",
+        "Did not infer language support from the LLM alone.",
+        "Placed apixaban and empagliflozin in ASR customization with documented boost controls.",
+        "Created a separate TTS pronunciation plan using only controls documented for the selected TTS service.",
+        "Did not write files before proposal approval."
+      ]
+    },
+    {
+      "id": "create-voice-agent-existing-project-iteration",
+      "prompt": "My existing Pipecat Cascaded voice agent already passes its spoken smoke test. Change it from one English user to 80 concurrent English users on the same workstation, while preserving the approved language, voice, interruption behavior, and observability.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "An iteration plan that reads the existing project, preserves behavior locks, reopens deployment fit because concurrency changed, migrates the local stack from vLLM plus NeMo-Speech.cpp to the appropriate NIM services when supported, minimizes unrelated changes, and revalidates the complete spoken path.",
+      "assertions": [
+        "Used the iteration workflow rather than rebuilding blindly.",
+        "Reopened deployment routing because workstation concurrency changed materially.",
+        "Revalidated Cascaded LLM NIM, ASR NIM, and TTS NIM through their correct current sources.",
+        "Preserved language, voice, interruption, networking, and observability unless a required incompatibility was found.",
+        "Required regression checks and a new spoken exchange before declaring the modified agent healthy."
+      ]
+    },
+    {
+      "id": "create-voice-agent-e2e-failure-recovery",
+      "prompt": "Repair this previously working local Cascaded voice agent end to end. The GPU service starts, then TTS fails with an OOM. nvidia-smi shows an unrelated healthy training container using 42 GiB. Preserve that container. Diagnose the cause, make the smallest safe correction, rerun validation and smoke checks, and report the remaining live acceptance step.",
+      "expected_skill": "create-voice-agent",
+      "expected_output": "A troubleshooting workflow that preserves the unrelated container, reconstructs the measured memory budget, identifies over-allocation or placement as the cause, proposes a scoped documented memory correction, verifies services in dependency order, and reruns smoke checks without destructive cleanup.",
+      "assertions": [
+        "Used the troubleshooting workflow and collected runtime evidence before changing configuration.",
+        "Did not stop, kill, or prune the unrelated healthy training container.",
+        "Recomputed model, KV cache, ASR, TTS, framework, and startup reserves from current free memory.",
+        "Changed only documented runtime memory, context, profile, batch, or placement controls required by the measured budget.",
+        "Restarted and verified one affected service at a time, then reran smoke checks.",
+        "Did not claim recovery was complete before the final spoken exchange."
+      ]
+    }
+  ]
+}

--- a/skills/create-voice-agent/references/domain/speech-customization.md
+++ b/skills/create-voice-agent/references/domain/speech-customization.md
@@ -42,28 +42,41 @@ supported streaming alternative. Never swap models silently.
 
 ### Platform Source
 
-| Platform | Customization source |
+| Routed stack | Customization source |
 | --- | --- |
-| Cloud / workstation / DGX Spark | Speech NIM docs and matrices above |
-| Jetson Thor | current Riva Quick Start plus the Riva ASR / TTS docs below |
+| Cloud, or NIM on a workstation | Speech NIM docs and matrices above |
+| vLLM plus NeMo-Speech.cpp | [NeMo-Speech.cpp ASR configuration](https://github.com/NVIDIA/NeMo-Speech.cpp/blob/main/docs/asr/configuration.md) and [TTS configuration](https://github.com/NVIDIA/NeMo-Speech.cpp/blob/main/docs/tts/configuration.md) |
 
-Jetson Thor runs Riva L4T, not Speech NIM. For the Riva model selected in
-`platforms/jetson-thor.md`, verify against:
+The single-GPU stack does not run Speech NIM, so Speech NIM tags and customization
+procedures do not apply to it. Read the two configuration documents above before drafting
+a glossary for DGX Spark, Jetson Thor, or a low-concurrency workstation.
 
-- [Riva ASR customization and word boosting](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/asr/asr-customizing.html#word-boosting)
-- [Riva TTS custom models and pronunciations](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/public/tts/tts-custom.html)
+Its two speech directions are not symmetric, and that asymmetry has to reach the user
+before a glossary is approved.
 
-Prefer request-time Riva customization:
+**ASR boosting is supported and depends on the decoder.** Approved phrases and a score
+travel per request in the recognition configuration's speech contexts. The cache-aware
+streaming Nemotron models this stack uses accept boosting with no extra artifacts.
+Flashlight beam decoding on a CTC model needs a language model and a lexicon first, and a
+greedy CTC model with no language model ignores boosting entirely, as does an offline-only
+model. Score ranges are not comparable across decoders, so read the range for the decoder
+actually loaded and never carry a score over from a NIM deployment. Boosting also depends
+on the tokenizer embedded in the model file, so an older GGUF may need reconversion before
+it takes effect.
 
-- ASR: add the approved phrases and score to the streaming recognition request through
-  `SpeechContext` or the current Riva client helper.
-- TTS: send approved custom pronunciations or SSML through the synthesis request when the
-  selected Riva model supports them.
+**TTS pronunciation customization is not available on this stack.** The synthesis service
+takes plain text and exposes no request-time phoneme, IPA, or pronunciation-dictionary
+path. Say that plainly rather than drafting IPA that cannot be wired. Two supported
+options remain, and both belong in the proposal instead:
 
-Do not apply Speech NIM tags or assume every ARM64 Quick Start model supports the same
-decoder or phoneme set. Global ASR lexicon changes and server-side TTS dictionaries require
-the current Riva model-build flow and may regenerate the model repository. Treat that as a
-deployment change, preserve the current repository, and get approval before rebuilding.
+- text-normalization grammars, which decide how written numbers, dates, and currency are
+  spoken (`platforms/single-gpu.md` §One-time speech model setup)
+- the spelling of the term in the LLM instruction, so the model emits a form the voice
+  already pronounces correctly (`domain/agent-behavior.md`)
+
+If correct pronunciation of a specific term is a hard requirement, say that the NIM path
+or cloud is where that control exists, and let the user decide before build rather than
+discovering it at verification.
 
 ## Glossary Approval
 
@@ -75,6 +88,10 @@ Draft one table and show every term before writing files:
 
 Use the current docs for score ranges and IPA support. Start with the lowest recommended
 boost that solves the ambiguity. Higher scores increase false positives.
+
+On the single-GPU stack the TTS column stays empty, because that path has no pronunciation
+control. Show the table with that column marked unsupported rather than filling it, and
+name the alternative you are proposing for each affected term.
 
 Wait for explicit approval of the displayed terms, scores, and pronunciations. “Use your
 suggestions” counts only after the complete table has been shown. Do not create a glossary
@@ -94,16 +111,22 @@ RNNT, TDT, or Nemotron ASR without checking the current docs.
 
 ## TTS
 
-Use the current TTS docs to choose request-time SSML phonemes or a custom pronunciation
-dictionary. Use only phonemes supported by the locked model and language.
+On cloud and the NIM path, use the current TTS docs to choose request-time SSML phonemes
+or a custom pronunciation dictionary. Use only phonemes supported by the locked model and
+language.
 
 Wire the approved dictionary through the selected framework's current NVIDIA TTS API.
 After startup, synthesize every customized term and let the user confirm pronunciation.
 
+The single-GPU stack has no pronunciation control, so there is nothing to wire there. Use
+the alternatives in §Platform source and still synthesize every term at verification, so
+the user hears what the agent will actually say.
+
 ## Omni
 
 Omni has no ASR slot, so ASR word boosting does not apply. Do not add ASR just for domain
-terms. TTS pronunciation customization still applies.
+terms. TTS pronunciation customization still applies wherever the routed stack supports
+it.
 
 Domain terms may also be added to the Omni system instruction for response consistency,
 but that is not ASR boosting.
@@ -136,7 +159,8 @@ When customization is approved:
 ```
 
 - Omit `asr` for Omni or when boosting is not approved. Omit `tts` when pronunciation
-  customization is not approved. Do not write placeholder or `null` entries.
+  customization is not approved or the routed stack does not support it. Do not write
+  placeholder or `null` entries.
 - Keep model ids, scores, and pronunciation data out of `.env`.
 - Load the glossary from agent code and map it to the framework APIs documented today.
 - Include a short README note explaining how to edit and revalidate the glossary.
@@ -146,7 +170,8 @@ When customization is approved:
 Test each term in a natural sentence:
 
 1. ASR returns the intended spelling without causing nearby false positives.
-2. TTS pronounces the term correctly.
+2. TTS pronounces the term acceptably, and where pronunciation is not controllable, the
+   user hears it and accepts the result.
 3. A normal sentence without glossary terms still works.
 4. The full spoken exchange in `operations/run.md` still passes.
 
@@ -155,7 +180,10 @@ Tune one term or score at a time. Use `operations/iterate.md` for later glossary
 ## Anti-Patterns
 
 - Writing or wiring a glossary before showing it and receiving approval.
-- Assuming every ASR model supports word boosting.
+- Assuming every ASR model supports word boosting, or that the loaded decoder does.
+- Carrying a boost score across decoders or across deployment stacks.
 - Applying ASR boosting to Omni.
 - Inventing IPA unsupported by the selected TTS model or language.
+- Drafting pronunciation rules for a stack that has no pronunciation control, instead of
+  saying so before approval.
 - Raising boost scores without checking false positives.

--- a/skills/create-voice-agent/references/frameworks/livekit.md
+++ b/skills/create-voice-agent/references/frameworks/livekit.md
@@ -59,8 +59,9 @@ writing constants. Streaming ASR first (`models/asr.md`).
 
 - STT / TTS: NVIDIA plugin from the MCP (`livekit.plugins.nvidia` or current package name).
   Cloud uses NVIDIA endpoints and `NVIDIA_API_KEY`. Self-hosted points `server` (or the
-  current equivalent) at the local NIM started from that model’s build.nvidia.com `/deploy`
-  page (`platforms/deployment.md`).
+  current equivalent) at the local speech endpoint, which is a Speech NIM started from that
+  model’s build.nvidia.com `/deploy` page (`platforms/deployment.md`) or the single
+  NeMo-Speech.cpp gRPC endpoint (`platforms/single-gpu.md`).
 - LLM: use the MCP’s documented way to call the locked Nemotron model id (NVIDIA cloud or
   self-hosted OpenAI-compatible base URL). Do not invent a plugin class from memory.
 
@@ -73,16 +74,17 @@ model string is the served id from `GET /v1/models`, not the catalog slug.
 
 Function ids for cloud speech come from build.nvidia.com, not from `/v1/models`.
 
-On Jetson Thor, follow `platforms/jetson-thor.md`: point both NVIDIA speech plugins at the
-shared Riva gRPC endpoint, leave function ids empty, and point the OpenAI-compatible LLM
-client at vLLM. Resolve the current `server`, SSL, language, and voice arguments from the
-LiveKit docs MCP.
+On the single-GPU stack, follow `platforms/single-gpu.md`. Point both NVIDIA speech plugins
+at the one shared gRPC endpoint, leave function ids empty, and point the OpenAI-compatible
+LLM client at vLLM. Resolve the current `server`, SSL, language, and voice arguments from
+the LiveKit docs MCP, and note that this endpoint is plaintext gRPC, so the plugins must
+not be configured for TLS unless a proxy terminates it.
 
 ## Run Shape
 
-The LiveKit CLI (`lk`) runs the worker. Before handover, confirm it is installed; if not,
-give the current install steps from the LiveKit docs MCP and wait. The worker start command
-depends on it.
+The LiveKit CLI (`lk`) runs the worker. Before handover, confirm it is installed. When it
+is missing, give the current install steps from the LiveKit docs MCP and wait, because the
+worker start command depends on it.
 
 Credentials set → LiveKit CLI available → start self-hosted model services if the deployment
 row needs them → run the worker the way the MCP documents (typically `lk agent dev` on
@@ -108,8 +110,8 @@ are in `operations/run.md`.
 
 ## After It Runs
 
-Re-query the MCP before changing any LiveKit API. For workstation / DGX NIM LLM profile
-changes, return to **Select a NIM Model Profile** in `models/llm.md`. Jetson Thor returns
+Re-query the MCP before changing any LiveKit API. For NIM LLM profile changes, return to
+**Select a NIM Model Profile** in `models/llm.md`. The single-GPU stack returns
 to its model card and platform guide.
 
 ## Anti-Patterns

--- a/skills/create-voice-agent/references/frameworks/omni.md
+++ b/skills/create-voice-agent/references/frameworks/omni.md
@@ -15,8 +15,9 @@ Do not add an ASR service, ASR NIM, or transcription-dependent turn strategy.
 
 Pipecat does not provide the required Omni service. Use NVIDIA's
 [`nvidia_omni_multimodal_service.py`](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/blob/main/src/examples/omni_assistant/nvidia_omni_multimodal_service.py)
-directly and build the pipeline around `NvidiaOmniMultimodalService`. Copy the current
-upstream file into the generated project. Do not reimplement or simplify it.
+directly. Copy the current upstream file into the generated project and use the service and
+settings classes imported by the current upstream pipeline. They are currently
+`NvidiaOmniLLMService` and `NvidiaOmniSettings`. Do not reimplement or simplify them.
 
 Also copy NVIDIA's current
 [`audio_only_smart_turn_strategy.py`](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent/blob/main/src/examples/omni_assistant/audio_only_smart_turn_strategy.py).
@@ -33,14 +34,66 @@ card for endpoint settings.
 
 Resolve the exact model through `models/llm.md`. Keep reasoning off for voice.
 
-| Host | Source |
-| --- | --- |
-| Cloud | model id from `/v1/models`, API shape from its build.nvidia.com reference |
-| Workstation / DGX Spark | current self-host instructions from the locked model page or card |
-| Jetson Thor | Omni Hugging Face card and vLLM path in `platforms/jetson-thor.md` |
+One page carries the model, both self-hosted paths, and the request format:
 
-Budget Omni + TTS only. `NIM_MODEL_PROFILE` applies only when the chosen self-hosted page
-actually deploys a NIM. It never applies to raw vLLM.
+[Nemotron 3 Omni](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning)
+
+Read it at build time. It publishes the precision variants, the pinned vLLM container, the
+serve command, a DGX Spark section, the thinking and instruct mode parameters, and the
+audio request shape. Fetching it returns that content, so there is no reason to work from
+memory here. Its API reference in `models/llm.md` §Pages to open carries the request
+contract, and both pages answer a fetch.
+
+| Routed stack | Source |
+| --- | --- |
+| Cloud | model id from `/v1/models`, API shape from the page above |
+| Workstation NIM | §Workstation NIM below. Use VLM NIM documentation, not LLM NIM documentation |
+| Single-GPU vLLM plus NeMo-Speech.cpp | the vLLM section of the page above, plus `platforms/single-gpu.md` |
+
+Omni self-hosts on both local stacks. It has its own NIM for the workstation NIM path and
+its own published checkpoints for the single-GPU stack, so the source follows the routed
+stack rather than the pipeline shape. `preflight.md` §4 selects that stack.
+
+The model is named **Nemotron 3 Omni**, while its slug, repository ids, and NIM image still
+carry `nano-omni`. Use the product name in the proposal and the README, and the published
+ids verbatim everywhere they are strings
+(`models/llm.md` §The Omni name and its ids differ).
+
+Budget Omni plus TTS only. `NIM_MODEL_PROFILE` applies only on the NIM path. It never
+applies to raw vLLM.
+
+Omni is more memory-hungry than the cascaded LLM on the single-GPU stack, and its coverage
+is not identical across platforms. Check the coverage row in `platforms/dgx-spark.md` or
+`platforms/jetson-thor.md` before proposing it locally.
+
+### Workstation NIM
+
+Omni is a VLM NIM. Open these current sources before proposing or generating it:
+
+- [Omni VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/2.0.4-variant/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning) for verified GPU, memory, precision, and GPU count
+- [VLM NIM quickstart](https://docs.nvidia.com/nim/vision-language-models/2.0.4-variant/get-started/quickstart.html) for the current image and launch shape
+- [VLM NIM profiles](https://docs.nvidia.com/nim/vision-language-models/2.0.4-variant/profiles.html) and [utilities](https://docs.nvidia.com/nim/vision-language-models/2.0.4-variant/utilities.html) for profile selection and `list-model-profiles`
+- [VLM NIM environment variables](https://docs.nvidia.com/nim/vision-language-models/2.0.4-variant/environment-variables.html) for model, context, cache, and runtime controls
+
+Resolve the release version from the current Omni build page before following versioned
+VLM documentation. Select a candidate precision and GPU count from the Omni row in the VLM
+matrix. After readiness passes, run that image's `list-model-profiles` on the exact GPU set
+and either accept automatic selection or pin a Compatible profile returned there. Verify
+the selected profile in startup logs and the served id through `/v1/models`.
+
+Do not use the LLM NIM support matrix, LLM profile naming assumptions, or LLM NIM memory
+variables for Omni. Continue through `platforms/deployment.md` for co-location with TTS.
+
+## Audio Is Not in the Image
+
+On the single-GPU stack, the published vLLM image ships without the audio extras, so Omni
+will serve text and refuse audio until `vllm[audio]` is installed in the container, pinned
+to that image's vLLM version. It also needs explicit per-prompt modality limits and a media
+path allowance before it will accept an audio request.
+
+That combination is why an Omni agent can pass a health check, answer a text prompt, and
+still fail on the first spoken turn. Prove the audio path in smoke rather than at the
+microphone (`platforms/single-gpu.md` §Omni needs audio extras).
 
 A self-hosted Omni endpoint hits the same client traps as the cascaded LLM in
 `frameworks/pipecat.md` §Local LLM wiring: an API-key argument may be required even
@@ -48,12 +101,13 @@ locally, reasoning-off has to arrive nested inside `extra_body`, and the model s
 the served id from the endpoint rather than the catalog slug.
 
 For domain vocabulary, follow `domain/speech-customization.md`. Only TTS pronunciation
-customization applies because Omni has no ASR slot.
+customization applies because Omni has no ASR slot, and the single-GPU stack does not
+support even that.
 
 ## Turn Handling
 
-Wire transport audio and context into `NvidiaOmniMultimodalService`, then route its text
-output to TTS.
+Wire transport audio and context into the copied `NvidiaOmniLLMService`, then route its
+text output to TTS.
 
 - Start turns from VAD and stop them with `AudioOnlySmartTurnStopStrategy`.
 - Use Pipecat's current `MuteUntilFirstBotCompleteUserMuteStrategy` so microphone input
@@ -67,6 +121,7 @@ output to TTS.
 ## Verify
 
 - `scripts/smoke.sh` passes, using the Omni audio request rather than a chat completion.
+  A passing text request proves nothing about the audio path.
 - No ASR service or ASR sidecar exists.
 - The upstream Omni service and audio-only Smart Turn strategy were copied unchanged.
 - The model endpoint serves the locked Omni model, and the agent uses its exact served id.
@@ -80,6 +135,9 @@ output to TTS.
 
 - LiveKit Omni.
 - Stock text-only LLM service or separate ASR used in place of Omni.
-- Rewriting `NvidiaOmniMultimodalService`.
+- Rewriting `NvidiaOmniLLMService`.
 - Stock Smart Turn stop strategy waiting for a transcription.
 - Reasoning left at the model default.
+- Serving Omni without the audio extras, or declaring the deployment working from a text
+  request alone.
+- Dropping `nano` from a slug, repository id, or image tag to match the product name.

--- a/skills/create-voice-agent/references/frameworks/pipecat.md
+++ b/skills/create-voice-agent/references/frameworks/pipecat.md
@@ -36,8 +36,8 @@ generated Compose services.
 
 ## Local LLM Wiring
 
-Cascaded only, and it covers any local endpoint, whether that is a NIM or raw vLLM on
-Jetson Thor. Omni follows `frameworks/omni.md`. Two failures here cost a full connect
+Cascaded only, and it covers any local endpoint, whether that is a NIM or raw vLLM on the
+single-GPU stack. Omni follows `frameworks/omni.md`. Two failures here cost a full connect
 cycle each because both look like a model problem, so resolve the exact shapes from the
 MCP before generating. Query it for the NVIDIA LLM service class and import, the local
 base-URL argument, the API-key argument's behaviour, and the settings wrapper that carries
@@ -95,9 +95,9 @@ Full startup and connection steps are in `operations/run.md`.
 
 ## After It Runs
 
-Re-query the MCP before changing any Pipecat API. Workstation / DGX NIM profile changes
-return to **Select a NIM Model Profile** in `models/llm.md`.
-Jetson Thor returns to its model card and platform guide.
+Re-query the MCP before changing any Pipecat API. NIM profile changes return to **Select a
+NIM Model Profile** in `models/llm.md`. The single-GPU stack returns to its model card and
+`platforms/single-gpu.md`.
 
 ## Anti-Patterns
 

--- a/skills/create-voice-agent/references/intake.md
+++ b/skills/create-voice-agent/references/intake.md
@@ -56,9 +56,14 @@ As soon as the framework is resolved, read its framework file and verify that it
 is available. If it is unavailable, give the setup steps from that file and wait. Complete
 this check before proposing models or offering speech customization.
 
-Infer language, vertical, reasoning hardness, and latency-vs-quality from the use case.
-Derive the system instruction through `domain/agent-behavior.md`. Do not run a separate
-persona wizard. One follow-up for missing use-case context is allowed. Never two.
+Infer language, vertical, reasoning hardness, latency-vs-quality, and expected concurrency
+from the use case. Derive the system instruction through `domain/agent-behavior.md`. Do not
+run a separate persona wizard. One follow-up for missing use-case context is allowed. Never
+two.
+
+Concurrency is inferred, never asked. It selects the local stack on a workstation through
+`preflight.md` §4, so state the assumption in the Deployment row and let the user amend
+that row.
 
 ## 2. Propose
 
@@ -67,10 +72,10 @@ IDs from `models/llm.md`, `models/asr.md`, and `models/tts.md` using `models/cat
 family names. These are catalog ids that record the choice, and two values stay open until
 the services answer: the LLM's served model id and the exact TTS voice (`models/llm.md`
 §Resolve three names). Lock the TTS locale now and present neither of those as final here.
-For shared self-hosting, show the candidate LLM profile and runtime cap, speech profile
-reserves, startup reserve, and usable VRAM from `preflight.md` §Deployment fit. Mark
-provisional co-location until post-approval profile discovery succeeds and
-`platforms/deployment.md` §Shared-GPU memory gate passes.
+For shared self-hosting, show the candidate LLM profile or quantization variant, the
+runtime memory control, the speech reserve, the startup reserve, and usable memory from
+`preflight.md` §Deployment fit. Mark provisional co-location until the routed stack's
+measured gate passes (`preflight.md` §Shared rules).
 No code, compose, or layout in this turn.
 
 The example below assumes W4A16 is the lightest candidate supported for this H100 in the
@@ -79,7 +84,7 @@ matrix (Lightning NVFP4 needs Blackwell). Post-approval profile discovery must c
 ```
 Framework    Pipecat                 supports both pipeline shapes
 Pipeline     cascaded                spoken Q&A
-Deployment   self-hosted             H100 80GB, provisional co-location
+Deployment   self-hosted, NIM        H100 80GB workstation, many users assumed, provisional co-location
 Transport    both                    WebRTC + WebSocket
 Language     English (en-US)         fixed, lowest latency
 LLM          Nemotron 3.5 Lightning  nvidia/nemotron-3.5-lightning-30b-a3b, candidate vllm-w4a16-tp1-pp1
@@ -91,16 +96,21 @@ Memory       runtime budget planned  context, LLM cap, speech reserves, startup 
 Reply "go" to build, or name a row to change.
 ```
 
+The Deployment row names the local stack and the concurrency behind it, because that pair
+is what the user needs to be able to correct. A single-user version of the same row reads
+`self-hosted, vLLM + NeMo-Speech.cpp` with `one user assumed`.
+
 ### Shape Changes
 
 - Omni: drop ASR, add the Omni model, and recalculate deployment fit
   (`frameworks/omni.md`).
 - LiveKit: drop transport. LiveKit cannot run Omni. If both are requested, ask which to
   keep.
-- DGX Spark: follow `platforms/dgx-spark.md`. Budget available unified memory and disclose
-  any hybrid slot.
-- Jetson Thor: use the vLLM + Riva rows from `platforms/jetson-thor.md`. Disclose the
-  platform substitutions.
+- DGX Spark or Jetson Thor: use the vLLM plus NeMo-Speech.cpp rows from
+  `platforms/dgx-spark.md` or `platforms/jetson-thor.md`. Budget available unified memory,
+  disclose the substitutions away from NIM, and name any hybrid slot.
+- Workstation with high concurrency: NIM rows with matrix-verified quantization. With one
+  user or a few sessions, the single-GPU rows instead (`platforms/single-gpu.md`).
 - Remote Pipecat WebRTC: route `networking/remote-webrtc.md`.
 - Several languages: route fixed vs automatic detection through
   `models/language-routing.md`.
@@ -111,7 +121,7 @@ Reply "go" to build, or name a row to change.
 | --- | --- | --- |
 | Framework | explicit intake choice, otherwise Pipecat recommendation | user chooses LiveKit |
 | Pipeline | explicit intake choice, otherwise Cascaded recommendation | user chooses Omni or audio-native |
-| Deployment | self-hosted when routed platform fit passes. Provisional when slots share one GPU | otherwise hybrid/cloud, name each cloud slot |
+| Deployment | self-hosted when routed platform fit passes, on the stack `preflight.md` §4 selected. Provisional when slots share one GPU | otherwise hybrid/cloud, name each cloud slot |
 | Transport | both | user named one, or LiveKit (omit this row) |
 | Language | fixed locale from `models/language-routing.md` | user requested several languages |
 | LLM | Nemotron 3.5 Lightning | user named Super, Ultra, or another id |
@@ -134,9 +144,11 @@ Amend a row in place. Re-show the table only when the change cascades. LiveKit d
 and transport. Omni replaces ASR and changes fit. Full cloud removes the Memory row.
 Hybrid recalculates Memory for local slots. Otherwise just build.
 
-After self-hosting approval, run `platforms/readiness.md`, then discover and pin the exact
-Compatible LLM profile. If profile, memory fit, or placement changes, re-show the affected
-rows and wait for confirmation before writing files. During deployment, follow
+After self-hosting approval, run `platforms/readiness.md`. On the NIM path, then discover
+and pin the exact Compatible LLM profile. On the single-GPU stack, then confirm the
+quantization variant on the locked model card and complete the one-time speech model
+download. If profile, variant, memory fit, or placement changes, re-show the affected rows
+and wait for confirmation before writing files. During deployment, follow
 `platforms/deployment.md` §Per-slot reuse before starting services.
 
 ## Stop Only For

--- a/skills/create-voice-agent/references/models/asr.md
+++ b/skills/create-voice-agent/references/models/asr.md
@@ -4,8 +4,13 @@ Nemotron ASR, Parakeet CTC / RNNT / TDT, and other models on the live Speech mat
 Docs first. Never invent the roster from memory.
 
 Do not use the LLM support matrix, `list-model-profiles`, or `NIM_MODEL_PROFILE` here.
-Jetson Thor uses Riva L4T models selected from its ARM64 quickstart, not Speech NIM
-deployment. See `platforms/jetson-thor.md`.
+
+This file covers cloud ASR and Speech NIM ASR. The single-GPU stack does not run Speech
+NIM, so when `preflight.md` §4 routes there, select the ASR model from
+`platforms/single-gpu.md` §One-time speech model setup instead. That path serves a GGUF
+build of a streaming Nemotron ASR model from local files, so there is no `CONTAINER_ID`,
+no `NIM_TAGS_SELECTOR`, and no batch-size tag to choose. §Streaming first and the language
+rules below still apply.
 
 ## Streaming First
 
@@ -86,6 +91,10 @@ Planning estimates only. Authoritative GPU memory is the chosen row on the
 | Nemotron ASR Streaming, `batch_size=64` | about 15 GB |
 | Self-hosted floor | compute capability 8.0+, ≥16 GB VRAM for the speech NIM |
 | Selection | `NIM_TAGS_SELECTOR` (not `NIM_MODEL_PROFILE`) |
+
+A quantized GGUF model on the single-GPU stack is far smaller than these figures, and it
+shares one service with TTS. Do not plan that stack from this table. Measure the combined
+speech reserve through `platforms/single-gpu.md` §Memory.
 
 Batch size moves ASR memory by more than a factor of two, so on a shared GPU take the
 smallest documented streaming batch that satisfies the use case and write that tag

--- a/skills/create-voice-agent/references/models/catalog.md
+++ b/skills/create-voice-agent/references/models/catalog.md
@@ -6,12 +6,17 @@ slot you are resolving.
 | Slot | Read | Discover first | Confirm on |
 | --- | --- | --- | --- |
 | Language / locale | `models/language-routing.md` | ASR + TTS language tables | selected framework docs MCP |
-| Cascaded LLM | `models/llm.md` | LLM support matrix + `/v1/models` | `build.nvidia.com/nvidia/<model>` |
-| Omni | `models/llm.md` | same, exclude from cascaded LLM | same |
+| Cascaded LLM | `models/llm.md` | LLM NIM support matrix for NIM, or the locked model page for raw vLLM, plus `/v1/models` | [Lightning](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b?nim=self-hosted) |
+| Omni | `models/llm.md` and `frameworks/omni.md` | VLM NIM matrix for NIM, or the locked model page for raw vLLM, plus `/v1/models` | [Nemotron 3 Omni](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) |
 | ASR | `models/asr.md` | [Speech docs](https://docs.nvidia.com/nim/speech/latest/) → [ASR matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html) | `<slug>` and `<slug>/deploy` |
 | TTS | `models/tts.md` | [TTS matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/tts.html) | same pattern |
 
 Family browse: [NVIDIA Nemotron](https://developer.nvidia.com/topics/ai/nemotron#section-nvidia-nemotron-models).
+
+Nemotron 3 Omni is the product name for the Omni slot, and its slug, repository ids, and NIM
+image carry `nano-omni`. The proposal table shows the product name. Generated code and
+Compose carry the published ids verbatim
+(`models/llm.md` §The Omni name and its ids differ).
 
 ## Shared Rules
 
@@ -19,15 +24,22 @@ Family browse: [NVIDIA Nemotron](https://developer.nvidia.com/topics/ai/nemotron
   the choice, and agent code uses the runtime ids resolved after startup.
 - Lock language routing before selecting ASR and TTS.
 - Model ids, voice ids, and function ids go in generated code or config. `.env` is secrets only.
-- LLM tools (`list-model-profiles`, `NIM_MODEL_PROFILE`, LLM support matrix) never apply to ASR or TTS.
+- Model-service tools (`list-model-profiles` and `NIM_MODEL_PROFILE`) never apply to ASR
+  or TTS. Select the LLM or VLM NIM support matrix from the pipeline.
+- The LLM NIM support matrix and its profile assumptions apply to Cascaded LLM only. Omni
+  NIM uses the VLM NIM matrix, profiles, utilities, and environment documentation in
+  `frameworks/omni.md`.
 - Speech profile tags (`NIM_TAGS_SELECTOR`, Speech matrices, `/deploy`) do not apply to
   generated LLM deployments. Pin an LLM with `NIM_MODEL_PROFILE`.
 - For self-hosted Speech, the matrix owns profile fit and tags. The `/deploy` page owns
   image URI and launch shape. Stop if they still conflict.
-- Shared-GPU placement uses the runtime budget in `preflight.md`, LLM controls in
-  `models/llm.md`, and the explicit TTS batch profile in `models/tts.md`. It remains
-  provisional until `platforms/deployment.md` §Shared-GPU memory gate passes.
-- Jetson Thor bypasses Speech NIM selection and follows `platforms/jetson-thor.md`.
+- Shared-GPU placement uses the runtime budget in `preflight.md` and the LLM controls in
+  `models/llm.md`, plus the explicit TTS batch profile in `models/tts.md` on the NIM path.
+  It stays provisional until the routed stack's measured gate passes
+  (`preflight.md` §Shared rules).
+- The single-GPU stack bypasses Speech NIM selection entirely and resolves ASR and TTS
+  through `platforms/single-gpu.md`. That covers DGX Spark, Jetson Thor, and a
+  low-concurrency workstation.
 - If the user names a model outside these families, say so and wait. Do not substitute.
 
 ## Where They Live
@@ -36,10 +48,12 @@ Family browse: [NVIDIA Nemotron](https://developer.nvidia.com/topics/ai/nemotron
 | --- | --- | --- |
 | Catalog slug | Proposal table | `build.nvidia.com/nvidia/<slug>`. Intent only, never agent code |
 | Container image | Self-hosted LLM | the self-hosted build page or NGC command that actually pulls |
-| `NIM_MODEL_PROFILE` | Self-hosted LLM | `list-model-profiles` on the assigned GPU |
+| `NIM_MODEL_PROFILE` | Self-hosted Cascaded LLM or Omni NIM | `list-model-profiles` from that service's NIM image on the assigned GPU set |
+| Quantization variant | Self-hosted LLM on vLLM | the locked Hugging Face card's variant for the probed compute capability |
 | Runtime model id | LLM (and listing checks) | `GET /v1/models` · cloud `https://integrate.api.nvidia.com/v1/models` |
 | Function id | Cloud ASR / TTS | build.nvidia.com model page. gRPC `grpc.nvcf.nvidia.com:443`. Empty when self-hosted |
-| `CONTAINER_ID` + `NIM_TAGS_SELECTOR` | Self-hosted ASR / TTS | Speech matrix, then `/deploy` |
+| `CONTAINER_ID` + `NIM_TAGS_SELECTOR` | Self-hosted ASR / TTS on Speech NIM | Speech matrix, then `/deploy` |
+| GGUF file name | Self-hosted ASR / TTS on the single-GPU stack | that model's Hugging Face page, read at fetch time |
 | Voice id | TTS | running service's documented voice-discovery API |
 
 Slug, image, and runtime model id are three separate strings (`models/llm.md` §Resolve

--- a/skills/create-voice-agent/references/models/language-routing.md
+++ b/skills/create-voice-agent/references/models/language-routing.md
@@ -16,10 +16,10 @@ Record:
 
 Resolve locale codes from the selected platform's current source:
 
-| Platform | Language source |
+| Routed stack | Language source |
 | --- | --- |
-| Cloud / workstation / DGX Spark | Speech NIM ASR and TTS matrices + model pages |
-| Jetson Thor | current Riva ARM64 Quick Start `config.sh` and model documentation |
+| Cloud, or NIM on a workstation | Speech NIM ASR and TTS matrices plus the model pages |
+| vLLM plus NeMo-Speech.cpp | each speech model's Hugging Face page for coverage, then `GetRivaSynthesisConfig` on the running service for what the container actually serves |
 
 For Omni input, use the locked Omni model card and service documentation instead of the
 ASR matrix.
@@ -53,7 +53,11 @@ separately and reflect the response language in `domain/agent-behavior.md`.
 
 Follow `models/asr.md` and require a streaming row that supports the locked locale or
 language set. The model card, matrix language table, and profile tags must agree.
-Jetson Thor instead uses the streaming Riva model enabled by `platforms/jetson-thor.md`.
+
+On the single-GPU stack, the choice is between the English streaming model and the
+multilingual streaming model in `platforms/single-gpu.md` §One-time speech model setup.
+Take coverage from the selected model's Hugging Face page, and treat a multilingual model
+as auto-detecting unless its page says otherwise.
 
 Omni bypasses ASR. Verify its supported audio languages and detection behavior from the
 locked Omni source. Do not apply an ASR locale or assume multilingual detection.
@@ -83,7 +87,12 @@ Follow `models/tts.md` and require a TTS model that supports the response locale
 the service starts, query its documented voice-discovery API and choose only a returned
 voice compatible with that locale.
 
-On Jetson Thor, use only voices exposed by the selected Riva L4T service.
+On the single-GPU stack, the model's language list is an upper bound rather than the served
+set. Some languages are build-time options on that container and are off by default, so a
+locale the model supports can still be unavailable in the image being run. Take the served
+languages and the acceptable voice names from `GetRivaSynthesisConfig` on the running
+service, and say so in the proposal when the requested locale is one of the optional ones.
+See `platforms/single-gpu.md` §Languages and voices.
 
 If no returned voice matches, reopen the TTS row and ask for approval before changing the
 model, locale, or response language.

--- a/skills/create-voice-agent/references/models/llm.md
+++ b/skills/create-voice-agent/references/models/llm.md
@@ -1,10 +1,18 @@
 # LLM
 
 Cascaded Nemotron 3.5 Lightning (default), with Nemotron 3 Super / Ultra when named, plus
-Nemotron 3 Nano Omni for the Omni pipeline. Resolve before the proposal
-table. Self-hosted fit is mandatory. Cloud skips platform fit. Jetson Thor uses raw vLLM
-and follows `platforms/jetson-thor.md`. NIM profile selection below applies to workstation
-and DGX Spark.
+Nemotron 3 Omni for the Omni pipeline. Resolve before the proposal table. Self-hosted fit is
+mandatory. Cloud skips platform fit.
+
+Self-hosted quantization is verified by the documentation family for the routed service:
+
+| Routed stack | Quantization check | Owned by |
+| --- | --- | --- |
+| Cascaded LLM NIM, on a workstation serving many users | LLM NIM support matrix, then `list-model-profiles` on the assigned GPU | §Cascaded LLM NIM fit below |
+| Omni NIM, on a workstation serving many users | VLM NIM support matrix, then VLM `list-model-profiles` on the assigned GPU | `frameworks/omni.md` §Workstation NIM |
+| vLLM plus NeMo-Speech.cpp, on DGX Spark, Jetson Thor, or a low-concurrency workstation | the variant the locked page publishes for the probed compute capability | `platforms/single-gpu.md` §Precision |
+
+Never apply an LLM NIM matrix or profile rule to Omni. Raw vLLM has no NIM profile.
 
 ## Discover
 
@@ -12,16 +20,52 @@ and DGX Spark.
 | --- | --- |
 | Family browse | [NVIDIA Nemotron](https://developer.nvidia.com/topics/ai/nemotron#section-nvidia-nemotron-models) |
 | Confirm id / run | `build.nvidia.com/nvidia/<model>` · self-hosted: `?nim=self-hosted` |
-| Card / API | `…/<slug>/modelcard` · `docs.api.nvidia.com/nim/reference/nvidia-<slug>` |
+| Card / API | `…/<slug>/modelcard` · `docs.api.nvidia.com/nim/reference/nvidia-<slug>`, with dots in the slug written as dashes |
 
-Examples: [Lightning cloud](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b) ·
-[self-hosted](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b?nim=self-hosted) ·
-[Super card](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard) ·
-[Super API](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-super-120b-a12b).
+### Pages to Open
 
-**Omni** is the separate **Nemotron 3 Nano Omni** multimodal model (audio-native), not the
-cascaded text LLM and not a Lightning build. It is the only slot that keeps a Nano id.
-Exclude it from the cascaded LLM slot. Never interchange.
+Every slot has a build page that carries deployment and an API reference that carries the
+request contract. Open both for the slot being built.
+
+| Slot | Build page | API reference |
+| --- | --- | --- |
+| Cascaded LLM | [Nemotron 3.5 Lightning, self-hosted](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b?nim=self-hosted). Drop the parameter for cloud | [Lightning](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-5-lightning-30b-a3b) |
+| Omni | [Nemotron 3 Omni](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) | [Omni](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) |
+| Super, only when named | [Super card](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard) | [Super](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-super-120b-a12b) |
+
+The API reference host replaces every dot in the slug with a dash, so
+`nemotron-3.5-lightning-30b-a3b` becomes `nvidia-nemotron-3-5-lightning-30b-a3b`. Carrying
+the dot across returns 404, so use these links rather than assembling one from §Discover.
+
+These models are the roster. Resolve every proposal from these pages, never from recall of
+what the family used to contain, and confirm the slot's model is still current when the page
+opens. If a page no longer serves it or marks it superseded, report that and propose the
+current model. When a user names a model off the roster, say so and wait
+(`models/catalog.md` §Shared rules).
+
+### The Omni Name and Its Ids Differ
+
+The product is **Nemotron 3 Omni**, and its slug, repository, and image ids carry
+`nano-omni`. Use the name for people and the ids verbatim in code. Dropping `nano` from a
+slug gives a 404, and from an image id a failed pull.
+
+Omni is the audio-native multimodal model. It is not a cascaded text LLM, so exclude it from
+that slot.
+
+### Reading These Pages in Realtime
+
+| Page | What a fetch returns |
+| --- | --- |
+| Omni build page | full self-host content: precision variants, required vLLM version, serve command, a DGX Spark section, and mode parameters |
+| Lightning build page `?nim=self-hosted` | the model card only. The deploy panel renders in the browser, so the `nvcr.io` image and run command are usually **not** in fetched content |
+| Either API reference | server-rendered and reliable to fetch. Use it for the request contract when a build panel does not come back |
+
+The Lightning card still gives the supported languages, context limit, and quantization
+recipe. It does not give the container.
+
+When the panel is not in what you fetched, do not build an `nvcr.io` tag from the slug and a
+guessed version. Read the tag from that NIM's NGC catalog page, or ask the user to paste the
+panel. State which you used, because an image tag with no source is not verified.
 
 Every card lists the languages the model supports, and that list is usually shorter than the
 speech coverage around it. Check the approved response language against it through
@@ -59,15 +103,13 @@ and can leak into TTS (`<think>`, silence, `redacted_thinking`).
 | off (propose this) | normal voice agent |
 | on, budget 8192 | user asked hard multi-step / specialized. Warn if budget > 16384 |
 
-Verify on the locked model's API reference, for example:
-[Lightning](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-5-lightning-30b-a3b) ·
+Verify on the locked slot's API reference in §Pages to open, alongside
 [NIM reasoning](https://docs.nvidia.com/nim/large-language-models/latest/reasoning-model.html).
 
-The model's own build.nvidia.com page is the fastest check. Its prototype panel shows a
-runnable request for that exact model, including where the reasoning fields sit. For example, use
-[Lightning](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b). Read that example and the
-API reference before generating the request, because field names and nesting move between
-model generations.
+The build page is the faster of the two checks, because its prototype panel shows a runnable
+request for that exact model with the reasoning fields already in position. Read that
+example and the API reference before generating the request, because field names and nesting
+move between model generations.
 
 With an OpenAI-compatible SDK these provider fields travel in `extra_body`, which
 merges them into the top level of the request body. A raw HTTP call sets them at the
@@ -101,28 +143,22 @@ constants + restart, not mid-session, unless the framework docs say otherwise.
 
 ### Reasoning Parser
 
-A model card's serve command can enable the reasoning parser independently of each request's
-thinking mode. Keep the parser enabled for both modes. It separates thinking from `content`
-when reasoning is on and applies the model's reasoning-off contract when
+A model card's serve command enables the reasoning parser independently of each request's
+thinking mode. **Keep the parser enabled in both modes.** It separates thinking from
+`content` when reasoning is on and applies the model's reasoning-off contract when
 `enable_thinking:false`. TTS must read only `content`.
 
-| Reasoning Mode | Serve Flags | Request Setting |
-| --- | --- | --- |
-| Off (voice default) | Enable the parser required by the locked model card | Set `extra_body.chat_template_kwargs.enable_thinking` to `false` |
-| On | Enable the parser required by the locked model card | Set `extra_body.chat_template_kwargs.enable_thinking` to `true`, and keep `reasoning_content` away from TTS |
+The serve command therefore does not change with the reasoning row. Only the request does,
+through `extra_body.chat_template_kwargs.enable_thinking`. With reasoning on, also keep
+`reasoning_content` away from TTS.
 
-Parser names and plugin requirements are not shared across this family. Read the row for the
-exact model and server you run:
-
-| Locked Model and Server | Current Parser Flag |
-| --- | --- |
-| Cascaded Lightning on vLLM | `--reasoning-parser nemotron_v3` (built-in, no plugin file) |
-| Omni NVFP4 on vLLM | `--reasoning-parser nemotron_v3` |
-
-Both add `--enable-auto-tool-choice --tool-call-parser qwen3_coder`. When a card names a
-separate parser-plugin file, it must be downloaded and present before the server starts.
-Confirm the parser and any plugin from the model card for the server you run, and never
-adapt a vLLM row for a different server such as SGLang.
+Parser names and plugin requirements are not shared across this family, so read them from
+the locked card for the server you actually run. Both current vLLM paths use
+`--reasoning-parser nemotron_v3` alongside
+`--enable-auto-tool-choice --tool-call-parser qwen3_coder`, which is a value to confirm
+rather than one to copy. When a card names a separate parser-plugin file, download it and
+have it present before the server starts. Never adapt a vLLM row for a different server
+such as SGLang.
 
 Prove the result on the streaming endpoint in both modes. `scripts/smoke.sh` asserts
 non-empty `delta.content` and empty or absent `delta.reasoning_content` when reasoning is
@@ -131,7 +167,7 @@ off (`output-contract.md` §Smoke Before Client). One non-streaming answer does 
 ## Serve Flags
 
 Every serve-time flag must trace to one of three sources: the locked model card, the memory
-controls in §Tight fit, or a fatal log line that names the flag. Nothing else belongs on the
+controls in §Runtime memory controls, or a fatal log line that names the flag. Nothing else belongs on the
 command line.
 
 Performance and scheduling flags are the usual trap. Reaching for eager mode, a scheduling
@@ -142,10 +178,14 @@ speculative flag then has to be reverted, and a revert is indistinguishable from
 When a flag looks necessary, name the log line that requires it, change that one thing, and
 rerun `scripts/smoke.sh` before touching anything else.
 
-## Platform Fit (Self-Hosted)
+## Cascaded LLM NIM Fit
 
 Hardware first from `preflight.md`. Never propose model / precision / TP until verified
 for the probed GPU.
+
+This section covers a cascaded LLM on LLM NIM only. Omni NIM uses the VLM NIM sources in
+`frameworks/omni.md` §Workstation NIM. The single-GPU stack uses
+`platforms/single-gpu.md` §Precision.
 
 ### 1. Support Matrix HTML
 
@@ -172,8 +212,8 @@ Before proposal, use the support matrix to select a candidate profile and mark s
 fit provisional. After the user approves self-hosting and container readiness passes, run
 `list-model-profiles` on that NIM for the probed GPU. Standard `*/server` deployments use
 the result to verify manifest auto-selection. Explicitly pinned self-hosted deployments use
-the exact result in generated Compose. Profile verification is mandatory on every
-workstation / DGX Spark NIM LLM deployment. Buckets:
+the exact result in generated Compose. Profile verification is mandatory on every NIM LLM
+deployment. Buckets:
 
 ```bash
 docker run --rm --gpus '"device=0"' <nim_llm_image> list-model-profiles
@@ -190,9 +230,10 @@ Do not infer the image or tag.
 | Low memory | apply the suggested `--max-model-len` / `NIM_MAX_MODEL_LEN` if the user accepts |
 | Incompatible | use lower precision on the same image, or a smaller LLM |
 
-Prefer the smallest Compatible precision that fits (nvfp4 > mxfp4 > w4a16 > fp8 > bf16)
-unless the user asked for a heavier one. On a local GPU under ~90 GB, prefer Compatible
-nvfp4 when listed. Do not default to a heavier precision if a lighter one is Compatible.
+Prefer the lightest Compatible precision that fits, in this order: `nvfp4`, `mxfp4`,
+`w4a16`, `fp8`, `bf16`. On a local GPU under about 90 GB, prefer Compatible `nvfp4` when
+listed. Do not default to a heavier precision when a lighter one is Compatible, unless the
+user asked for it.
 
 For an explicitly pinned self-hosted LLM deployment, set `NIM_MODEL_PROFILE` in the launch
 environment to one of:
@@ -241,85 +282,53 @@ rather than assuming a precision exists.
 | Lightning NVFP4 | ~19 GB |
 | Lightning W4A16 | ~19 GB |
 | Lightning BF16 | ~63 GB |
-| Omni 30B NVFP4 | ~15 GB (ASR in-process) |
 
 The support matrix lists exact min VRAM per GPU per precision and TP; use it over these
 estimates. Super / Ultra: on one workstation GPU, say they will not fit. Offer Lightning
 local or that model in the cloud. Do not silently substitute.
 
-### 4. Tight Fit
+## Runtime Memory Controls
 
-Apply this section to every shared single-GPU layout, not only after an OOM.
+This section covers both NIM families and raw vLLM. These controls are required in the
+generated `compose.yaml` on any shared GPU, not applied after an OOM. Choose the control
+from the actual server path, never from the pipeline name.
 
-| Deployment path | Knobs | Source |
-| --- | --- | --- |
-| Workstation / DGX NIM | `NIM_MAX_MODEL_LEN`, documented runtime memory limit | current NIM environment and memory troubleshooting docs |
-| Raw vLLM, including Jetson Thor | `--gpu-memory-utilization`, `--max-model-len` | locked Hugging Face model card for the required flags, [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) for their meaning and current defaults |
+| Path | Controls | Flag source | Budget owner |
+| --- | --- | --- | --- |
+| Cascaded LLM NIM | `NIM_MAX_MODEL_LEN`, plus exactly one documented runtime memory limit, either `--gpu-memory-utilization` through `NIM_PASSTHROUGH_ARGS` or `NIM_KVCACHE_PERCENT` when the image documents it | [LLM NIM environment variables](https://docs.nvidia.com/nim/large-language-models/latest/reference/environment-variables.html) · [LLM NIM memory troubleshooting](https://docs.nvidia.com/nim/large-language-models/latest/troubleshooting/memory.html) | `preflight.md` §NIM budget |
+| Omni NIM | `NIM_MAX_MODEL_LEN`, plus only the runtime memory limit its current VLM NIM instructions document | [VLM NIM environment variables](https://docs.nvidia.com/nim/vision-language-models/2.0.4-variant/environment-variables.html) · `frameworks/omni.md` §Workstation NIM | `preflight.md` §NIM budget |
+| Raw vLLM on the single-GPU stack | `--max-model-len`, `--gpu-memory-utilization` | locked model card, then [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) for meaning and current defaults | `platforms/single-gpu.md` §Memory |
 
-Both server paths fill their runtime budget with KV cache after weights and overhead. The
-documented default fraction is 0.9 or higher on each path, which can starve co-located
-speech even when quantized weights are small, so read the exact current default from the
-source in the table.
+Both servers fill their runtime budget with KV cache after weights and overhead, and the
+documented default fraction is 0.9 or higher on each. That default starves co-located
+speech even when quantized weights are small, so read the current default from the flag
+source and set the value from the budget owner instead of accepting it.
 
-On raw vLLM that fraction is per-instance and measured against total device memory. The
-reference states it does not account for memory another process already holds, so a
-co-located speech container does not lower it. Derive the fraction from the budget below
-rather than expecting vLLM to leave room.
+Four rules hold on both paths:
 
-Before first start:
-
-1. re-read free VRAM immediately before launch, including other GPU processes
-2. calculate `LLM budget = current free VRAM - startup reserve` minus the reserve of every
-   speech slot placed on this GPU, which is TTS plus ASR for Cascaded and TTS alone for
-   Omni. Slots in the cloud or on another GPU take nothing from this budget
-3. reject co-location when that budget cannot hold the selected build's weights, runtime
-   overhead, and a usable KV cache. Move a slot instead, or take a lighter build, which
-   is a smaller Compatible profile on NIM and a lighter quantization from the locked card
-   on raw vLLM
-4. set the context to the smallest value that satisfies the approved use case, through
-   `NIM_MAX_MODEL_LEN` on NIM or `--max-model-len` on raw vLLM
-5. cap runtime memory so the server cannot exceed `LLM budget`, which as a fraction is no
-   higher than `LLM budget / total GPU memory`:
-   - NIM: leave profile selection unset for standard `*/server`. For an explicitly pinned
-     deployment, pin the exact `NIM_MODEL_PROFILE`. Then take exactly one control from the
-     selected image's current docs, either `--gpu-memory-utilization` passed through
-     `NIM_PASSTHROUGH_ARGS` or `NIM_KVCACHE_PERCENT` when that image documents it
-   - raw vLLM: pass `--gpu-memory-utilization` directly, or an absolute KV cache size
-     when the current reference documents one
-
-Never set both runtime memory controls. Do not copy either value from another image or
-model version.
-If the calculated cap leaves no usable KV cache, the layout does not fit. Do not keep
-lowering the cap to force co-location.
-
-On a shared single GPU the chosen control is **required in the generated `compose.yaml`**,
-not a troubleshooting step applied after an OOM. Derive its value from the budget above
-rather than reusing a number. Leaving the container default in place is what lets the LLM
-take the whole device and starve TTS and ASR.
-
-At deployment, verify the measured budget before each service starts. NIM uses
-`platforms/deployment.md` §Shared-GPU memory gate. Raw vLLM on Jetson Thor uses the
-unified-memory check in `platforms/jetson-thor.md` §Start and verify. Do not let TTS
-discover an invalid LLM budget through repeated OOM restarts.
-
-Sources:
-[environment variables](https://docs.nvidia.com/nim/large-language-models/latest/reference/environment-variables.html) ·
-[GPU memory troubleshooting](https://docs.nvidia.com/nim/large-language-models/latest/troubleshooting/memory.html) ·
-[vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/).
-
-Do not choose a knob from the pipeline name. Choose it from the actual server path.
+1. **Never set both memory controls**, and never copy either value from another image or
+   model version.
+2. **Set context to the smallest length the approved use case needs.**
+3. **A cap that leaves no usable KV cache means the layout does not fit.** Take a lighter
+   build, which is a smaller Compatible profile on NIM and a lighter quantization on raw
+   vLLM, or move a slot. Do not keep lowering the cap to force co-location.
+4. **Verify the measured budget before each service starts**, through
+   `platforms/deployment.md` §Shared-GPU memory gate on NIM and
+   `platforms/single-gpu.md` §Start and verify on the single-GPU stack. Do not let TTS
+   discover an invalid LLM budget through repeated OOM restarts.
 
 ## Anti-Patterns
 
 - Voice agent with reasoning left at model default (on).
-- Reasoning parser or plugin left enabled while the reasoning row is off.
+- Serving without the reasoning parser, or without a plugin file the card requires, in
+  either reasoning mode. Dropping the parser because the reasoning row is off.
 - Adding a serve flag the card does not list and no fatal log demands.
 - `chat_template_kwargs` passed as a plain SDK argument rather than through `extra_body`.
   Reasoning flags in `.env`.
-- Reasoning on locally without the reasoning parser and plugin file the card requires.
 - Cascaded slot → omni model. Model ids in `.env`.
 - Propose from memory / Verified GPUs list alone. Click matrix UI or use `.html.md` for fit.
 - Override a failed matrix / `list-model-profiles` check. Guess a SKU. Use the deprecated
   `NIM_TAGS_SELECTOR` on a generated LLM deployment.
+- Validate Omni with the LLM NIM matrix or copy a cascaded LLM profile onto Omni NIM.
 - Treat quantized weight size as total LLM VRAM or leave vLLM at its default memory budget
   while co-locating speech.

--- a/skills/create-voice-agent/references/models/tts.md
+++ b/skills/create-voice-agent/references/models/tts.md
@@ -4,8 +4,14 @@ Magpie and other TTS models on the live Speech matrix. Docs first. Never invent 
 roster from memory.
 
 Do not use the LLM support matrix, `list-model-profiles`, or `NIM_MODEL_PROFILE` here.
-Jetson Thor uses Riva L4T TTS selected from its ARM64 quickstart, not Magpie Speech NIM.
-See `platforms/jetson-thor.md`.
+
+This file covers cloud TTS and Speech NIM TTS. The single-GPU stack does not run Speech
+NIM, so when `preflight.md` §4 routes there, select TTS from
+`platforms/single-gpu.md` §One-time speech model setup instead. That path serves a GGUF
+Magpie token generator plus a NanoCodec decoder from local files, so there is no
+`CONTAINER_ID`, no `NIM_TAGS_SELECTOR`, and no batch-size tag to choose. The voice-locking
+rule below still applies, and §Languages and voices in that file owns which languages the
+container actually serves.
 
 ## Discover
 
@@ -48,6 +54,11 @@ Planning estimates only. Authoritative GPU memory is the chosen row on the
 Self-hosted floor: compute capability 8.0+, ≥16 GB VRAM for the speech NIM. Selection is
 `NIM_TAGS_SELECTOR` (not `NIM_MODEL_PROFILE`).
 
+A quantized GGUF Magpie build on the single-GPU stack is far smaller than these figures,
+has no batch profile, and shares one service with ASR. Do not plan that stack from this
+table. Measure the combined speech reserve through
+`platforms/single-gpu.md` §Memory.
+
 Batch size is the TTS memory profile, not only a throughput knob. On a shared single-GPU
 layout, select the smallest documented batch profile that satisfies the use case and
 write it explicitly into `NIM_TAGS_SELECTOR`. For Magpie TTS Multilingual that is
@@ -72,12 +83,16 @@ free VRAM through `platforms/deployment.md` §Shared-GPU memory gate.
    look up a speech function id in `/v1/models`.
 6. Voice id: after the TTS service is up, query its voice list and lock a voice from that
    response before handover. Speech NIM currently serves `GET /v1/audio/list_voices`, while
-   raw Riva exposes
+   a gRPC service exposes
    [`GetRivaSynthesisConfig`](https://docs.nvidia.com/nim/speech/latest/reference/api-references/tts/protos.html)
    through its client instead. Confirm the path on the API reference above before calling
    it, because a near miss such as `/v1/audio/voices` returns 404 and reads like a mute
    service. Record the path in the README and smoke script, and never hardcode a voice the
    service did not return.
+
+The single-GPU stack is gRPC only, so it has no voice-list URL. It answers
+`GetRivaSynthesisConfig`, and that response is also the authority for which languages the
+container was built with. See `platforms/single-gpu.md` §Languages and voices.
 
 ## Anti-Patterns
 

--- a/skills/create-voice-agent/references/networking/remote-webrtc.md
+++ b/skills/create-voice-agent/references/networking/remote-webrtc.md
@@ -75,6 +75,11 @@ Generate a coturn Compose service only when this project owns the TURN deploymen
 derive it from current coturn deployment documentation. Otherwise document the external
 TURN endpoint. Do not duplicate infrastructure the user already has.
 
+DGX Spark and Jetson Thor are aarch64, and common coturn images publish `amd64` only.
+Confirm an `arm64` image exists before generating that service on either platform. When
+none does, use an external TURN endpoint and say why, rather than generating a service that
+cannot start.
+
 ## Browser Security
 
 Remote microphone access requires a secure browser context. Serve the client and signaling

--- a/skills/create-voice-agent/references/operations/iterate.md
+++ b/skills/create-voice-agent/references/operations/iterate.md
@@ -24,7 +24,7 @@ Never overwrite `.env` or read secrets into the response.
 | Domain glossary, boosting, or pronunciation | `domain/speech-customization.md` | show and confirm every changed term |
 | Transport or turn handling | selected framework file + docs MCP | confirm user-visible behavior |
 | Logs or latency metrics | `operations/observability.md` + framework docs MCP | no new intake table |
-| Cloud / self-hosted / GPU placement | `preflight.md` + `platforms/deployment.md` | confirm deployment row |
+| Cloud / self-hosted / GPU placement, or expected concurrency | `preflight.md` + the routed platform guide | confirm deployment row |
 | Cascaded / Omni | `intake.md` + selected framework files | confirm all changed rows |
 | Pipecat / LiveKit | `intake.md` + both framework files | full framework confirmation |
 | Hardware platform | `preflight.md` + routed platform guide | rerun probe and deployment fit |
@@ -44,9 +44,13 @@ anything it changes downstream.
 
 ## Cascading Changes
 
-- LLM swap: workstation / DGX NIM reruns the support matrix and
-  `list-model-profiles`. Cloud rechecks model id/API. Jetson Thor reopens the vLLM model
-  card. Then revisit reasoning and stack fit.
+- Model swap: a Cascaded NIM reruns the LLM NIM matrix and `list-model-profiles`. Omni NIM
+  reruns the VLM NIM sources in `frameworks/omni.md`. Cloud rechecks model id and API. The
+  single-GPU stack reopens the vLLM model card and reconfirms the quantization variant for
+  this GPU. Then revisit reasoning and stack fit.
+- Concurrency change on a workstation: reopen `preflight.md` §4, because it can move the
+  agent between the single-GPU stack and NIM. Confirm the Deployment row before touching
+  anything, since that swap replaces every local service.
 - ASR swap: keep streaming first and recheck language, tags, and deployment fit.
 - TTS or language change: restart TTS when required, then query its voice-discovery API
   again.

--- a/skills/create-voice-agent/references/operations/run.md
+++ b/skills/create-voice-agent/references/operations/run.md
@@ -27,14 +27,18 @@ Start or reuse local model services and wait for readiness exactly as
 `platforms/deployment.md` or the selected platform guide defines. Use the generated Compose
 services and commands in the project README. Move on only after every local slot is ready.
 
-A speech service's first start can sit at `starting` for a long time while it downloads
-models and builds an engine. Read its logs rather than restarting it. See
-`platforms/deployment.md` §First boot takes much longer.
+Expect one long first start, and which service it is depends on the routed stack. A speech
+NIM sits at `starting` while it downloads models and builds an engine
+(`platforms/deployment.md` §First boot takes much longer). On the single-GPU stack the
+speech service starts quickly and vLLM is the slow one, because it compiles kernels
+(`platforms/single-gpu.md` §First boot compiles kernels). Read the logs rather than
+restarting, and treat a long wait on the wrong service as a symptom instead of expected
+behavior.
 
 ## Smoke
 
 Run `scripts/smoke.sh` before the agent starts: on self-hosted or hybrid, once every local
-service is healthy; on cloud, as soon as dependencies are installed, since there are no
+service is healthy, and on cloud as soon as dependencies are installed, since there are no
 local services to wait on. It proves the locked model answers on the streaming endpoint, the
 locked voice speaks and is transcribed back, and the agent's own services construct. Cloud
 and hybrid layouts run it against their configured endpoints. A silent connect failure in the browser is far more

--- a/skills/create-voice-agent/references/operations/troubleshoot.md
+++ b/skills/create-voice-agent/references/operations/troubleshoot.md
@@ -33,7 +33,9 @@ looks exactly like a fix.
 | Smoke fails constructing a service | API-key argument, `extra_body` shape, framework file |
 | Agent runs and stays mute with no error | reasoning parser, request mode, and streamed `content` |
 | Browser does not connect | framework client path, microphone permission, transport |
+| Not enough VRAM to start, or an unexpected OOM | what is already resident, before any model change |
 | User speech is not detected | input audio frames, VAD, end-of-turn |
+| Transcripts arrive only when the session ends | ASR endpointing on the single-GPU speech service |
 | No transcript (cascaded) | streaming ASR endpoint and language |
 | Wrong input or reply language | `models/language-routing.md` |
 | No reply | LLM/Omni endpoint, model id, request error |
@@ -49,42 +51,64 @@ looks exactly like a fix.
   `platforms/readiness.md` before changing model configuration.
 - Authentication or image-pull failure: re-check `preflight.md` credentials. Never print
   a secret.
-- Wrong workstation / DGX NIM LLM profile: rerun `list-model-profiles` and follow
-  `models/llm.md`. Cloud checks model id/API. Jetson Thor checks its vLLM model card and
+- Wrong NIM model profile: Cascaded uses the LLM NIM matrix and profile procedure in
+  `models/llm.md`. Omni uses the VLM NIM sources in
+  `frameworks/omni.md` §Workstation NIM. Rerun `list-model-profiles` from the selected
+  image on the assigned GPU set. Cloud checks model id and API. The single-GPU stack checks
+  its vLLM model card, the quantization variant for the probed compute capability, and the
   serve flags.
-- Wrong workstation / DGX Speech tags: reopen the ASR or TTS matrix and locked `/deploy`
-  page. Jetson Thor checks its Riva `config.sh`.
+- Wrong Speech NIM tags: reopen the ASR or TTS matrix and locked `/deploy` page. The
+  single-GPU stack instead checks the GGUF paths passed to the speech service and the
+  models that actually loaded.
 - Speech service still `starting` or `unhealthy` on first boot: read the logs before
   changing anything. Model download and TensorRT engine building routinely take 15 to 30
   minutes or more, and a restart discards that work. See `platforms/deployment.md` §First
   boot takes much longer. Treat it as a failure only on process exit, a fatal log such as
   CUDA OOM, or stalled progress past the documented window.
-- Speech HTTP ready but deaf or mute: query `GetRivaSpeechRecognitionConfig` or
+- Speech ready but deaf or mute: query `GetRivaSpeechRecognitionConfig` or
   `GetRivaSynthesisConfig` and compare the loaded model, language, and voice with the lock.
   On Speech NIM TTS, also call the voice-list path from its current TTS API reference and
   confirm the locked voice is actually returned. A wrong or near-miss path returns 404 or
   an empty list, which looks like a mute service.
-- OOM on workstation / DGX: stop the failing service. Compare actual per-process GPU use
-  with the budget in `preflight.md`. Verify the LLM loaded the pinned quantization profile,
-  then reduce its documented runtime memory cap or `NIM_MAX_MODEL_LEN`. Confirm TTS uses
-  the smallest approved explicit batch profile. Restart one service at a time through the
+- OOM when the budget said it would fit: something is resident that was not there at probe
+  time. Read `nvidia-smi --query-compute-apps=pid,used_memory,name --format=csv` and
+  `docker ps` first, and identify what holds the memory before changing anything. A stale
+  container from an earlier attempt is the common cause, and stopping that named container
+  is the fix rather than shrinking the model. Follow
+  `preflight.md` §Find out what is holding the memory, and never prune or stop containers
+  the user did not approve.
+- OOM on the NIM path: stop the failing service. Compare actual per-process GPU use with
+  the budget in `preflight.md`. Verify the LLM loaded the pinned quantization profile, then
+  reduce its documented runtime memory cap or `NIM_MAX_MODEL_LEN`. Confirm TTS uses the
+  smallest approved explicit batch profile. Restart one service at a time through the
   memory gate in `platforms/deployment.md`, or move one slot to cloud. Do not silently
   change the approved model.
 - LLM fails with no available KV cache blocks: its cap is too low for that profile. Do not
   reduce it again. Use a smaller Compatible profile, raise the cap only when speech
   reserves still fit, or move a slot to another GPU or cloud.
-- OOM on Jetson Thor: lower `--max-model-len` first, then the memory fraction, and restart
-  vLLM. Follow `platforms/jetson-thor.md`.
-- vLLM will not start on Thor while the host looks like it has memory: compare Linux free
-  memory with available memory. The startup check has been observed to read free memory, so
-  page cache left by downloads and engine builds can block it. Reclaim cache rather than
-  shrinking the model configuration. See `platforms/jetson-thor.md` §Host memory at startup.
-- vLLM on Thor sits silent for a long first boot: look for `nvcc` and `cicc` compile
-  output, which is the NVFP4 kernel compile and not a hang. See `platforms/jetson-thor.md`
-  §First boot compiles kernels.
-- Riva on Thor cannot read its models: assert where `riva_init.sh` actually wrote the
-  repository and whether it is root-owned, then check that the Enterprise variables are all
-  set or all unset. See `platforms/jetson-thor.md` §Model path and credentials.
+- OOM on the single-GPU stack: lower `--max-model-len` first, then the memory fraction, and
+  restart vLLM. Confirm the fraction was derived from the measured speech reserve rather
+  than from free memory at launch. Follow `platforms/single-gpu.md` §Memory.
+- vLLM will not start while the host looks like it has memory: compare Linux free memory
+  with available memory. The startup check has been observed to read free memory, so page
+  cache left by downloads and engine builds can block it. Reclaim cache rather than
+  shrinking the model configuration. See `platforms/single-gpu.md` §Host memory at startup.
+- vLLM sits silent for a long first boot: look for `nvcc` and `cicc` compile output, which
+  is the NVFP4 kernel compile and not a hang. See `platforms/single-gpu.md` §First boot
+  compiles kernels.
+- Speech service exits at startup or reports a missing model: assert the mounted model tree
+  is readable by the container user, and that all three TTS paths and the ASR path resolve
+  inside the container. A tree created by Compose before the download is root-owned. See
+  `platforms/readiness.md` §Speech model tree.
+- Speech service rejects a setting at startup: unknown engine keys are errors on this
+  service, so a mistyped or aliased option is a startup failure rather than a default. Use
+  the canonical dotted option names.
+- Numbers, dates, or currency are spoken literally: the text-normalization grammars are
+  missing, or the container was built without normalization support and logged a warning at
+  startup. See `platforms/single-gpu.md` §One-time speech model setup.
+- Requested TTS locale is refused or silently answered in another language: read the
+  languages `GetRivaSynthesisConfig` advertises. Some are build-time options that are off
+  by default, so the model's language list is an upper bound rather than the served set.
 - Reply text never reaches TTS and no log shows an error: confirm that the serve command
   keeps the reasoning parser required by the locked model card and that the request sets
   `enable_thinking:false`. Reassert non-empty streaming `delta.content` through
@@ -111,6 +135,13 @@ If VAD sees speech but no transcript appears:
 3. confirm the locked profile is streaming
 4. confirm its language matches the request
 
+If transcripts appear only after the session closes, the agent is receiving one final
+result per stream instead of one per utterance. On the single-GPU stack that is ASR
+endpointing left at its default. Enable it, set the end-of-utterance silence threshold, and
+reassert a mid-stream final through `scripts/smoke.sh`. See
+`platforms/single-gpu.md` §Set explicitly. Do not change VAD or turn strategy
+first, because the client-side symptom looks identical.
+
 If a transcript appears but no reply follows, inspect the LLM request and response. Check
 the base URL, exact model id, authentication, and reasoning payload from `models/llm.md`.
 
@@ -131,7 +162,8 @@ phrase, approved score, locked model support, and framework wiring before changi
 ## Omni Pipeline
 
 Confirm the project copied the current upstream
-`nvidia_omni_multimodal_service.py` and instantiates `NvidiaOmniMultimodalService`.
+`nvidia_omni_multimodal_service.py` and instantiates the service class imported by the
+current upstream pipeline, which is currently `NvidiaOmniLLMService`.
 Confirm it also copied `audio_only_smart_turn_strategy.py`. Do not replace either with a
 stock text-only service or transcription-dependent Smart Turn strategy.
 

--- a/skills/create-voice-agent/references/output-contract.md
+++ b/skills/create-voice-agent/references/output-contract.md
@@ -34,12 +34,12 @@ Also write:
 The skill ships no static Compose file. Generate `compose.yaml` from current authoritative
 deployment instructions:
 
-| Platform | Source |
+| Service | Source |
 | --- | --- |
-| Workstation / DGX Spark NIM | each locked model's build.nvidia.com self-hosted page |
-| Workstation / DGX Omni | locked model's current build.nvidia.com or Hugging Face run docs |
-| Jetson Thor LLM | locked Hugging Face model card and the current [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) |
-| Jetson Thor Speech | current Riva ARM64 Quick Start |
+| Workstation NIM LLM, ASR, or TTS | each locked model's build.nvidia.com self-hosted page |
+| Workstation NIM Omni | the Omni build page plus the current VLM NIM quickstart, support matrix, profiles, utilities, and environment documentation in `frameworks/omni.md` §Workstation NIM |
+| Single-GPU LLM or Omni | the locked model's build.nvidia.com page and the current [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) |
+| Single-GPU speech | the NeMo-Speech.cpp container's current NGC page for the run command, and its repository documentation for engine keys |
 | Project-owned coturn | current coturn deployment documentation |
 
 Translate each current launch command into one Compose service. Preserve its image,
@@ -47,42 +47,60 @@ command, environment, mounts, shared-memory or IPC settings, ports, and GPU requ
 except for the approved profile/tags, host ports, cache paths, and GPU placement this skill
 explicitly locks. Use current health checks from the same source.
 
-For a shared single-GPU NIM layout, Compose must pin the exact LLM profile, approved
-context length, exactly one documented runtime memory-control path, and explicit TTS batch
-profile. These are required entries, not optional tuning. Do not rely on auto-selected LLM
-precision, default vLLM memory utilization, or the TTS container default. The memory-control
-value comes from the budget in `preflight.md` §Deployment fit, so do not reuse a number from
-another build. The same requirement applies to a shared-GPU raw vLLM layout such as Jetson
-Thor, where `--gpu-memory-utilization` and `--max-model-len` are the equivalent required
-entries. If free VRAM measured at startup differs from the budget, update Compose before
-starting rather than proceeding with a stale value. Document `platforms/deployment.md`
-§Shared-GPU memory gate in the README.
+Memory controls are required Compose entries on any shared GPU, not optional tuning. Which
+controls depends on the routed stack:
 
-Preserve the documented model cache or export mount for every speech service. First boot
-downloads models and can build engines, and that work must survive container replacement.
-
-| Platform / pipeline | Service names |
+| Routed stack | Required in Compose |
 | --- | --- |
-| Workstation / DGX Spark NIM cascaded | `llm`, `tts`, `asr` |
-| Workstation / DGX Omni | `omni`, `tts` |
-| Jetson Thor cascaded | `llm`, `riva` (ASR + TTS enabled) |
-| Jetson Thor Omni | `omni`, `riva` (TTS enabled, ASR disabled) |
+| Workstation NIM Cascaded | the exact pinned LLM NIM profile, the approved context length, exactly one documented LLM NIM runtime memory-control path, and the explicit TTS batch profile |
+| Workstation NIM Omni | the exact Compatible VLM NIM profile, the approved context length, only controls documented for that VLM NIM release, and the explicit TTS batch profile |
+| Single-GPU vLLM plus NeMo-Speech.cpp | `--gpu-memory-utilization`, `--max-model-len`, and every required speech model path |
+| Single-GPU Omni | the above, plus the audio extras installed before `vllm serve` and pinned to the image's vLLM version, plus the modality limits and media path the model requires (`platforms/single-gpu.md` §Omni needs audio extras) |
+
+Do not rely on auto-selected LLM precision, default vLLM memory utilization, or a container
+default. The memory-control value comes from the budget in `preflight.md` §Deployment fit
+and, on the single-GPU stack, from the measured speech reserve in
+`platforms/single-gpu.md` §Memory. Do not reuse a number from another build. If
+memory measured at startup differs from the budget, update Compose before starting rather
+than proceeding with a stale value. Document the gate that applies in the README, which is
+`platforms/deployment.md` §Shared-GPU memory gate on NIM and
+`platforms/single-gpu.md` §Start and verify on the single-GPU stack.
+
+Preserve the documented cache or model mount for every service. A speech NIM downloads
+models and can build engines on first boot. The single-GPU stack instead mounts a
+pre-populated read-only model tree and caches compiled vLLM kernels. Either way that work
+must survive container replacement.
+
+| Routed stack and pipeline | Service names |
+| --- | --- |
+| Workstation NIM cascaded | `llm`, `tts`, `asr` |
+| Workstation NIM Omni | `omni`, `tts` |
+| Single-GPU cascaded | `llm`, `speech` (ASR and TTS in one service) |
+| Single-GPU Omni | `omni`, `speech` (TTS paths only) |
+
+Generate no HTTP health check for the single-GPU `speech` service. It serves gRPC only, so
+readiness is the configuration query in `platforms/single-gpu.md` §Readiness is gRPC only.
 
 For a hybrid deployment, generate only the services assigned locally. Cloud slots remain
 agent configuration and do not get placeholder Compose services.
 
-For a multi-GPU workstation, follow `platforms/deployment.md` §Scaling across GPUs. DGX
-Spark and Jetson Thor use their platform guides. In Compose, use `device_ids` or `count`,
-never both. A multi-GPU LLM service must expose the exact topology required by its
-compatible profile.
+For a multi-GPU workstation running NIM, follow `platforms/deployment.md` §Scaling across
+GPUs. The single-GPU stack serves one device, so it pins every service to the same GPU. In
+Compose, use `device_ids` or `count`, never both. A multi-GPU LLM service must expose the
+exact topology required by its compatible profile.
+
+On DGX Spark and Jetson Thor, confirm an `arm64` image exists for every generated service
+before writing it.
 
 Compose may read secret values such as `NVIDIA_API_KEY` and `HF_TOKEN` from the user
 environment or `.env`. Write only placeholders to `.env.example`; the user supplies real
 values after file generation is approved. Keep model ids, endpoints, profiles, tags, ports, and GPU placement
 in `compose.yaml` or agent code, not `.env`.
 
-For Jetson Thor, mount the external Riva `model_repository` produced by the one-time
-Quick Start initialization. Do not rebuild it during normal `docker compose up`.
+On the single-GPU stack, mount the speech model tree produced by the one-time download as
+read-only, from a path outside the generated project. Do not populate or repair it during
+`docker compose up`, and do not create it by starting Compose first, because Docker then
+creates it as root (`platforms/readiness.md` §Speech model tree).
 
 Validate before handover:
 
@@ -97,20 +115,26 @@ order alone.
 
 Write the locked choices and exact commands for this project:
 
-1. framework, pipeline, platform, transport, language route, per-slot local/cloud
-   placement, container image, pinned profile, runtime model id, and discovered TTS voice
+1. framework, pipeline, host class, routed local stack and the concurrency it assumes,
+   transport, language route, per-slot local/cloud placement, container image, pinned
+   profile or quantization variant, runtime model id, and discovered TTS voice
 2. prerequisites and required credentials
-3. one-time setup, including Riva initialization when applicable
+3. one-time setup, including the speech model download on the single-GPU stack
 4. dependency installation
-5. service startup in the required order
+5. service startup in the required order for the routed stack
 6. health and model-id checks, then `scripts/smoke.sh`
 7. agent start command and client connection path
 8. spoken-exchange acceptance test
 9. log commands, stop commands, and links to troubleshooting
 
-Item 3 must warn that a speech service's first boot downloads models and can build an
-engine, that this commonly takes far longer than later starts, which log line shows
-progress, and which cache path keeps the result.
+Item 3 must name the long first start for the routed stack, which log line shows progress,
+and which path keeps the result. On NIM that is a speech model download and engine build.
+On the single-GPU stack it is the vLLM kernel compile, plus the one-time speech model
+download and its ownership rules.
+
+Item 5 must give the order the routed stack requires, because the two are opposite. NIM
+starts the LLM first. The single-GPU stack starts speech first, so its reserve can be
+measured before the LLM memory fraction is set.
 
 Do not leave placeholders such as “start the services” or “use the deploy page.” Resolve
 those instructions while building and persist the resulting commands in the README.
@@ -133,7 +157,9 @@ user never debugs this from a browser:
    `delta.content` and empty or absent `delta.reasoning_content`. A non-streaming answer
    still passes while a reasoning parser routes every token away from TTS
    (`models/llm.md` §Reasoning parser)
-3. Omni: endpoint readiness and one minimal audio request, and no LLM or ASR checks
+3. Omni: endpoint readiness and one minimal **audio** request, and no LLM or ASR checks. It
+   must be an audio request, because a text request passes on a server that cannot accept
+   audio at all
 4. TTS voice query, then one sentence synthesized in the approved locale using a voice that
    query actually returned
 5. Cascaded: ASR configuration from the running service, asserting the loaded model and
@@ -143,6 +169,11 @@ user never debugs this from a browser:
 7. in-process construction of the same services the agent builds, using the same classes
    and settings, which is what catches a missing API-key argument or a misplaced reasoning
    payload
+
+On the single-GPU stack, checks 4 and 5 use the gRPC configuration queries rather than an
+HTTP voice list, and check 6 must also assert that a mid-stream final result arrives, which
+is what proves ASR endpointing is enabled
+(`platforms/single-gpu.md` §Set explicitly).
 
 Use the agent's own settings, including per-slot cloud endpoints on a hybrid layout. Print
 no secrets. Run it after the services are healthy and before the runner starts. A passing

--- a/skills/create-voice-agent/references/platforms/deployment.md
+++ b/skills/create-voice-agent/references/platforms/deployment.md
@@ -7,32 +7,47 @@ Choose the platform path first:
 
 | Host class | Deployment source |
 | --- | --- |
-| `workstation` | current build.nvidia.com instructions for every self-hosted slot |
-| `dgx_spark` | NIM path in `platforms/dgx-spark.md`, after GB10 support verification |
-| `jetson_thor` | vLLM + Riva L4T path in `platforms/jetson-thor.md` (not NIM) |
-| `unsupported_edge` | cloud. Local NIM/vLLM path is unsupported |
+| `workstation`, many users and higher concurrency | NIM path below, from current build.nvidia.com instructions for every self-hosted slot |
+| `workstation`, one user or a few concurrent sessions | vLLM plus NeMo-Speech.cpp in `platforms/single-gpu.md` |
+| `dgx_spark` | vLLM plus NeMo-Speech.cpp in `platforms/dgx-spark.md` and `platforms/single-gpu.md`, not NIM |
+| `jetson_thor` | vLLM plus NeMo-Speech.cpp in `platforms/jetson-thor.md` and `platforms/single-gpu.md`, not NIM |
+| `unsupported_edge` | cloud. No local path is supported |
 | `no_gpu` | cloud |
 
-For workstation and DGX Spark NIM slots, take the image, launch command, ports, and
-environment from the locked model's self-hosted page, then apply the verified profile or
-tags from `models/llm.md`, `models/asr.md`, or `models/tts.md`. Persist the result as the
+`preflight.md` §4 owns the choice between these paths and states the concurrency it
+assumed.
+
+Everything below this line describes the NIM path. For NIM slots, take the image, launch
+command, ports, and environment from the locked model's self-hosted page, then apply the
+verified selection from `models/llm.md` for a Cascaded LLM, `frameworks/omni.md` for
+Omni, or `models/asr.md` and `models/tts.md` for speech. Persist the result as the
 generated `compose.yaml` defined by `output-contract.md`.
 
 ## Source of Truth per Slot
 
+The table below covers cloud and the NIM path. Any slot on the single-GPU stack resolves
+through `platforms/single-gpu.md` §Source of truth instead.
+
 | Slot | Cloud | Self-hosted deploy copy |
 | --- | --- | --- |
-| Cascaded LLM | model page + `/v1/models` | `build.nvidia.com/nvidia/<slug>?nim=self-hosted` |
-| ASR | model page (function id) | `build.nvidia.com/nvidia/<slug>/deploy` + ASR matrix tags |
-| TTS | model page (function id) | `build.nvidia.com/nvidia/<slug>/deploy` + TTS matrix tags |
-| Omni | omni model page | follow `frameworks/omni.md` and that model’s build / HF run docs |
+| Cascaded LLM | model page + `/v1/models` | [Lightning self-hosted](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b?nim=self-hosted) |
+| ASR | model page (function id) | [ASR deploy](https://build.nvidia.com/nvidia/nemotron-asr-streaming/deploy) + ASR matrix tags |
+| TTS | model page (function id) | [TTS deploy](https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy) + TTS matrix tags |
+| Omni | [Nemotron 3 Omni](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) | the same page plus the [VLM NIM quickstart](https://docs.nvidia.com/nim/vision-language-models/2.0.4-variant/get-started/quickstart.html), [support matrix](https://docs.nvidia.com/nim/vision-language-models/2.0.4-variant/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning), and `frameworks/omni.md` |
 
-Examples: [Lightning self-hosted](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b?nim=self-hosted) ·
-[ASR deploy](https://build.nvidia.com/nvidia/nemotron-asr-streaming/deploy) ·
-[TTS deploy](https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy).
+For another model in the family, the patterns are
+`build.nvidia.com/nvidia/<slug>?nim=self-hosted` for an LLM and
+`build.nvidia.com/nvidia/<slug>/deploy` for a speech model.
 
-Never invent a `docker run` or image tag from memory. Apply the Speech source precedence
-in `models/catalog.md`.
+Omni self-hosts either way. It has its own NIM for the NIM path and its own published
+checkpoints for the single-GPU stack, so the placement follows the routed stack rather than
+the pipeline shape.
+
+Never invent a `docker run` or image tag from memory, and never assemble one from a slug
+plus a guessed version. The `/deploy` pages return their commands to a fetch. An LLM
+`?nim=self-hosted` panel is rendered in the browser and often does not, so resolve that
+image through `models/llm.md` §Reading these pages in realtime and state where it came
+from. Apply the Speech source precedence in `models/catalog.md`.
 
 ## Cloud
 
@@ -60,7 +75,7 @@ the local Compose commands.
 For LiveKit, configure STT, LLM, and TTS independently through the current plugin APIs.
 Do not assume that selecting one cloud slot moves the full pipeline to cloud.
 
-## Workstation and DGX Spark NIM
+## Workstation NIM
 
 1. Confirm the host clears `preflight.md` §Deployment fit (or move overflowing slots to
    cloud).
@@ -71,8 +86,10 @@ Do not assume that selecting one cloud slot moves the full pipeline to cloud.
 5. Translate each command into the matching service in `compose.yaml` through
    `output-contract.md`.
 6. Overlay locked selection from the slot file:
-   - LLM: pinned Compatible `NIM_MODEL_PROFILE`, max length, exactly one documented
+   - Cascaded LLM: pinned Compatible LLM NIM `NIM_MODEL_PROFILE`, max length, exactly one documented
      runtime memory-control path, and reasoning passthrough from `models/llm.md`
+   - Omni: Compatible VLM NIM profile and VLM NIM controls from
+     `frameworks/omni.md` §Workstation NIM
    - ASR / TTS: streaming `NIM_TAGS_SELECTOR` / `CONTAINER_ID` from the matrix and an
      explicit TTS batch profile
 7. Clear §Shared-GPU memory gate, then start **one Compose service at a time**. Wait
@@ -87,15 +104,17 @@ Do not assume that selecting one cloud slot moves the full pipeline to cloud.
 11. Start the agent only after every local slot is ready and smoke passes
     (`operations/run.md`).
 
-Jetson Thor skips the numbered path above and its shared-GPU memory gate, because
-`platforms/jetson-thor.md` defines the equivalent unified-memory check. §Service health
-checks, §First boot takes much longer, and §Per-slot reuse still apply to it.
+The single-GPU stack skips the numbered path above and this shared-GPU memory gate, because
+`platforms/single-gpu.md` §Start and verify defines the equivalent check and reverses the
+start order. §Per-slot reuse still applies to it. §Service health checks applies except for
+the speech service, which is gRPC only and has no readiness URL. §First boot takes much
+longer describes a speech NIM engine build, which that stack does not perform.
 
 ### Shared-GPU Memory Gate
 
-Do not treat LLM readiness as permission to start speech. This gate covers workstation and
-DGX Spark layouts. Jetson Thor uses the unified-memory check in
-`platforms/jetson-thor.md` §Start and verify instead.
+Do not treat LLM readiness as permission to start speech. This gate covers the workstation
+NIM path. The single-GPU stack measures the speech reserve first instead, through
+`platforms/single-gpu.md` §Start and verify.
 
 Before the first service starts, re-measure free VRAM and confirm the arithmetic in
 `preflight.md` §Deployment fit still passes, with the LLM memory control already present in
@@ -159,6 +178,12 @@ current source when needed, then start that service alone.
 Tell the user which slots will be reused or replaced.
 Never tear down healthy slots to fix one mismatch.
 
+This covers the slots this project owns. Memory held by anything else is a separate
+question, and it is answered before the budget is set, in
+`preflight.md` §Find out what is holding the memory. Bring it up again here only when free
+memory at start time is lower than it was at probe time, which means something new became
+resident. Report what appeared rather than lowering the memory control to fit around it.
+
 ### Why This Order
 
 Intake decides language, framework, and pipeline. After that the deploy is the same ordered
@@ -176,8 +201,13 @@ looked like something else:
 
 ## Scaling Across GPUs
 
-This section covers slot placement on a multi-GPU workstation or DGX system. It does not
-apply to single-GPU DGX Spark or Jetson Thor, and it does not define replica autoscaling.
+This section covers slot placement on a multi-GPU workstation or DGX system running NIM.
+It does not apply to DGX Spark, Jetson Thor, or the single-GPU stack, all of which serve
+one device, and it does not define replica autoscaling.
+
+Splitting slots across GPUs is also what makes a high-concurrency layout possible, because
+each service gets its own memory and its own batch profile. Read this section whenever the
+Deployment row assumes more than a few concurrent sessions and more than one GPU exists.
 
 List GPU UUIDs and current free memory with `nvidia-smi`. Prefer UUIDs for stable
 assignments. Plan from each GPU's free memory, not the sum:
@@ -208,15 +238,17 @@ device. Keep agent endpoint constants aligned with the resulting host ports.
 ## Agent Configuration
 
 - Cloud: use the URLs and function ids in §Cloud.
-- Workstation / DGX: use the host ports mapped from each live deploy page.
-- Jetson Thor: use the vLLM / Riva mappings in `platforms/jetson-thor.md`.
+- Workstation NIM: use the host ports mapped from each live deploy page.
+- Single-GPU stack: use the vLLM and speech mappings in `platforms/single-gpu.md`.
 - Self-hosted speech has empty function ids. Omni has no ASR.
 
 ## Anti-Patterns
 
 - Shipping a remembered image tag, `docker run`, or Compose recipe instead of generating it
   from the locked model's current build.nvidia.com instructions.
-- Applying workstation / DGX NIM instructions to Jetson Thor.
+- Applying NIM instructions to DGX Spark or Jetson Thor.
+- Proposing NIM for a single-user agent, where its scale-out design buys nothing and its
+  footprint costs the whole device.
 - Starting all local NIMs together or assuming fixed ports.
 - Applying the deprecated `NIM_TAGS_SELECTOR` to a generated LLM deployment or
   `NIM_MODEL_PROFILE` to ASR / TTS.

--- a/skills/create-voice-agent/references/platforms/dgx-spark.md
+++ b/skills/create-voice-agent/references/platforms/dgx-spark.md
@@ -1,53 +1,56 @@
 # DGX Spark
 
-Read when `preflight.md` classifies the target as `dgx_spark`. DGX Spark uses the
-self-hosted NIM workflow in `platforms/deployment.md`, subject to the support matrix for
-the locked model and profile.
+Read when `preflight.md` classifies the target as `dgx_spark`. DGX Spark runs the vLLM plus
+NeMo-Speech.cpp stack in `platforms/single-gpu.md`, which owns the pre-proposal checklist,
+models, flags, setup, budget, and verification. This file covers only what is specific to
+GB10.
 
-## Before Proposing
+DGX Spark does **not** use the workstation NIM path. Do not carry a NIM image, a NIM
+profile, `NIM_TAGS_SELECTOR`, or a speech function id onto this platform.
 
-1. Confirm the machine is DGX Spark / GB10 from DMI and `nvidia-smi`.
-2. Use unified memory reported as available by the probe, not the advertised 128 GB.
-3. Verify every local slot:
-   - LLM: DGX Spark appears in the matching model × precision row in the LLM support
-     matrix. Use that row as the proposal candidate. Run `list-model-profiles` after
-     approval and container readiness to pin the exact Compatible profile.
-   - ASR / TTS: the chosen model and profile support DGX Spark in the Speech matrices.
-4. Build the runtime budget from available unified memory. Reserve the selected speech
-   profiles, OS, framework, CUDA, startup, and engine overhead before assigning the
-   remainder to LLM weights and KV cache. Use exactly one memory-control path from
-   `models/llm.md` §Tight fit.
-5. Mark provisional co-location until `platforms/deployment.md` §Shared-GPU memory gate
-   passes.
-6. If any slot is unsupported or the full layout does not fit, move that slot to NVIDIA
-   cloud and show the hybrid layout in the proposal. Do not substitute a different model
-   silently.
+## Identify the Platform
 
-## Deploy
+Either signal confirms GB10:
 
-When a slot's locked source is a Hugging Face card rather than a NIM page, check that card for
-a DGX Spark container before using its generic install line. Cards in this family have named a
-separate container for DGX Spark and Jetson Thor. Harvest the rest of that card through
-`platforms/jetson-thor.md` §What to take from the card, which applies to any raw vLLM slot.
+- the GPU name reported by `nvidia-smi` contains `NVIDIA GB10`
+- `/sys/class/dmi/id/product_name` contains `DGX_Spark`, matched with the underscore
+  exactly as the file reports it
 
-Follow `platforms/deployment.md` for each approved local slot, including its shared
-GPU memory gate.
+`preflight.md` §2 owns how this ranks against the generic aarch64 rule.
 
-If startup reports low memory, follow the compatible profile's `--max-model-len` guidance
-or move a speech slot to cloud.
+## Prerequisites
 
-## Verify
+- DGX Spark running its current supported software release, including the CUDA and
+  container-runtime components
+- Docker Engine and Docker Compose
+- `HF_TOKEN` with access to the locked Nemotron repository, its draft repository, and the
+  speech model repositories
+- The Hugging Face CLI for the one-time speech model download
+- Disk capacity for the LLM weights, the draft model, the speech GGUFs, and the compiled
+  kernel cache
 
-- LLM readiness succeeds, `/v1/models` serves the approved model, and its exact served id
-  is what the agent uses.
-- ASR configuration matches the lock and accepts a streaming transcription request.
-- TTS configuration matches the lock and returns audio for the approved voice.
-- `scripts/smoke.sh` passes before the agent starts.
-- A full spoken exchange succeeds before handover (`operations/run.md`).
+Resolve the supported release and component versions from the current platform
+documentation rather than from this file.
+
+## What Differs From Jetson Thor
+
+| Aspect | DGX Spark |
+| --- | --- |
+| Speculative decoding | serve the published DGX Spark draft model alongside the NVFP4 target |
+| Pipeline coverage | cascaded and Omni, including an Omni deployment with concurrent subagent pipelines |
+
+Everything else in `platforms/single-gpu.md` applies unchanged, including the NVFP4
+quantization, the speech container, the memory method, and the start order.
+
+The draft model is specific to this platform. Do not reuse the workstation Blackwell draft
+model here, and do not carry the DGX Spark draft onto Jetson Thor.
+
+DGX Spark is aarch64, so confirm an `arm64` image exists for every container the project
+generates, including any TURN service it owns (`networking/remote-webrtc.md` §Coturn).
 
 ## Anti-Patterns
 
-- Assuming every NIM supports GB10 because another model does.
-- Reusing a workstation image or profile without matrix verification.
-- Budgeting against advertised unified memory instead of current available memory.
-- Starting all model services concurrently on first load.
+- Assuming a NIM supports GB10 because another model does.
+- Reusing a workstation image, profile, or draft model without confirming it on the card.
+- Leaving the draft model out of the memory budget.
+- Generating an `amd64`-only image for an aarch64 host.

--- a/skills/create-voice-agent/references/platforms/jetson-thor.md
+++ b/skills/create-voice-agent/references/platforms/jetson-thor.md
@@ -1,292 +1,70 @@
 # Jetson Thor
 
-Read when `preflight.md` classifies the target as `jetson_thor`.
+Read when `preflight.md` classifies the target as `jetson_thor`. Jetson Thor runs the vLLM
+plus NeMo-Speech.cpp stack in `platforms/single-gpu.md`, which owns the pre-proposal
+checklist, models, flags, setup, budget, and verification. This file covers only what is
+specific to Thor.
 
-Jetson Thor does **not** use the workstation / DGX NIM deployment path. Run the LLM with
-vLLM from Hugging Face weights and serve speech with the Riva Speech Skills L4T stack.
-Orin-class Jetsons are unsupported.
+Jetson Thor does **not** use the workstation NIM path. Do not carry a NIM image, a NIM
+profile, `NIM_TAGS_SELECTOR`, or a speech function id onto this platform, and do not copy
+an x86 image onto it.
 
-## Source of Truth
+Orin-class Jetsons are not supported. They are not a smaller Thor, because the models in
+this skill do not fit them. Route Orin to cloud through `preflight.md` §2.
 
-Before generating or running the Thor speech deployment, read the current
-[NVIDIA Riva Quick Start Guide](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/quick-start-guide.html).
-Use it as the authority for:
+## Identify the Platform
 
-- supported Jetson / JetPack versions
-- NGC access, licensing, disk, power-mode, and container-runtime prerequisites
-- the current ARM64 Quick Start release and setup flow
-- Riva service ports and `config.sh` fields
-- ASR / TTS deployment and readiness instructions
+Thor is a Tegra platform, so it has no discrete PCI GPU entry and no `/dev/nvidia0`. The
+identity comes from the device tree:
 
-Follow the current guide, then apply the voice-agent choices below.
-Pass `platforms/readiness.md`, then generate the Thor services through
-`output-contract.md`. Do not ship a static Thor Compose recipe.
+- `/proc/device-tree/model` contains both `Jetson` and `Thor`
+- `/sys/class/dmi/id/product_name` may carry the same pair when present
 
-## Platform Stack
-
-| Pipeline | LLM | Speech |
-| --- | --- | --- |
-| Cascaded | [NVIDIA Nemotron 3.5 Lightning NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4) with vLLM | Riva streaming ASR + Riva TTS |
-| Omni | [Nemotron 3 Nano Omni Reasoning NVFP4](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4) with vLLM | Riva TTS only (Omni performs ASR) |
-
-This changes the model table. Do not present workstation NIM images, NIM profiles,
-`NIM_TAGS_SELECTOR`, Magpie NIM, or speech function ids as the Thor deployment.
-Resolve the exact Riva ASR / TTS models from the downloaded ARM64 Quick Start `config.sh`
-and disclose the platform-specific substitutions before build. Lock supported locales
-through `models/language-routing.md`.
+Requiring both words avoids matching an Orin device tree, so confirm it is Thor rather than
+Orin before proposing anything local.
 
 ## Prerequisites
 
-- Jetson Thor with the JetPack release supported by the current Riva guide
+- Jetson Thor flashed with the JetPack release the platform documentation currently
+  supports, including the CUDA, TensorRT, and container-runtime components
 - Docker Engine and Docker Compose
-- NGC CLI configured with `NVIDIA_API_KEY`
-- `HF_TOKEN` with access to the locked Nemotron Hugging Face repository
-- Disk capacity required by the current Riva Quick Start plus the selected models and
-  compiled engines
+- `HF_TOKEN` with access to the locked Nemotron repository and the speech model
+  repositories
+- The Hugging Face CLI for the one-time speech model download
+- Disk capacity for the LLM weights, the speech GGUFs, and the compiled kernel cache
 
-Use the versions compatible with the installed JetPack release. Resolve the current Riva
-ARM64 Quick Start release from the guide and NGC resource:
+Resolve the supported JetPack release from the current platform documentation rather than
+from this file, and use the component versions compatible with the release actually
+installed.
 
-`nvidia/riva/riva_quickstart_arm64`
+## What Differs From DGX Spark
 
-Do not copy an x86 Riva or NIM image onto Thor.
-
-## One-Time Riva Model Build
-
-Follow the current Riva Quick Start to download the JetPack-compatible ARM64 bundle. Keep
-its model repository outside the generated project so it survives project rebuilds.
-
-1. Open the downloaded `config.sh`.
-2. Cascaded: enable ASR and TTS. Choose a streaming ASR profile and the required language.
-3. Omni: disable ASR and enable TTS only.
-4. Set the ASR / TTS languages and models available in that `config.sh`.
-5. Clear §Model path and credentials before running anything.
-6. Run `riva_init.sh` once. It downloads the selected models and compiles TensorRT engines
-   into the resolved model repository.
-7. Do not run `riva_start.sh` when the generated deployment will start Riva itself.
-
-Initialization commonly takes 30 to 60 minutes. Preserve the resulting model repository and
-mount it into the Riva service.
-
-### Model Path and Credentials
-
-Three `config.sh` behaviours each cost a full re-initialization when missed. Check all three
-before running `riva_init.sh`.
-
-**The tegra path can override `riva_model_loc`.** On the tegra branch the script has been
-observed to resolve the model repository under the current working directory instead of the
-value set in `config.sh`, without warning. Read the path handling in the release you actually
-downloaded, then assert where the models landed after initialization rather than trusting the
-configured value. Mount the resolved path, not the intended one.
-
-**Reusing an existing Quick Start carries root ownership.** `riva_init.sh` runs as root, so an
-existing `model_repository` is root-owned. Copying that tree into a new Quick Start directory
-carries the ownership across and the container user may not be able to read it. Re-initialize
-into a fresh path, or mount the original repository where it already lives.
-
-**Enterprise credentials are all three or none.** Setting `RIVA_API_KEY` and `RIVA_EULA`
-switches the Quick Start onto its Enterprise path, which then requires `RIVA_API_NGC_ORG`.
-Two of the three fails during initialization in a way that reads like a bad key. Set all three
-when the current guide documents Enterprise use for this release, otherwise leave all three
-unset and use the standard NGC flow.
-
-## LLM Model Source
-
-Thor reads two sources, and neither one replaces the other:
-
-| Source | Authority over |
+| Aspect | Jetson Thor |
 | --- | --- |
-| Locked Hugging Face model card | vLLM container/version, installation, parser files, request format, and which flags this model requires |
-| [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) | what each serve flag means, its exact spelling, and its current default |
+| Speculative decoding | none. Serve the NVFP4 target model alone, with no draft model |
+| Pipeline coverage | cascaded and single-agent Omni. An Omni deployment that runs concurrent subagent pipelines is not supported here |
 
-| Pipeline | Hugging Face repository id |
-| --- | --- |
-| Cascaded | `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4` |
-| Omni | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4` |
+Everything else in `platforms/single-gpu.md` applies unchanged, including the NVFP4
+quantization, the speech container, the memory method, and the start order.
 
-Read the relevant card immediately before generating the deployment. Do not reuse the
-cascaded launch command for Omni. Omni has model-specific vLLM and audio requirements.
+Do not add a draft model to Thor to match DGX Spark. When the use case needs the
+concurrent-subagent Omni shape, propose it on NVIDIA cloud and say plainly that the local
+platform does not support it.
 
-### What to Take from the Card
+Thor is aarch64, so confirm an `arm64` image exists for every container the project
+generates. The speech container publishes both architectures from one tag. A TURN service
+is the common gap, so check it before generating one
+(`networking/remote-webrtc.md` §Coturn).
 
-Work through the card's vLLM section and record every item below. Skimming it for the launch
-command is how the platform-specific pieces get missed.
-
-| Item | Why it matters |
-| --- | --- |
-| Platform-specific container | The card links a separate vLLM container for Jetson Thor and DGX Spark. Use that, not the generic install line written for a workstation |
-| Minimum vLLM version | The card pins a floor. An older build can accept every flag and still fail on this quantization |
-| Linked cookbook | Fuller deployment guidance than the card's own summary |
-| Parser plugin file | A separate download that must exist before the server starts, and only when reasoning is on |
-| Required environment variables | The NVFP4 kernel path is enabled by environment variables rather than flags |
-| Default context length | The repository configuration carries its own default, so omitting the context flag inherits it |
-| Sampling settings | The card gives different values for reasoning on, reasoning off, and tool calling |
-| Supported response languages | Compare against the approved response language (`models/language-routing.md` §LLM) |
-
-The card's hardware-compatibility summary field is not the deployment authority here. Its
-vLLM section is, because that is where the platform container is named.
-
-A card launch command is an example, not a memory budget for this device. The cascaded
-card's example passes no GPU memory fraction and serves a very long context, so copying it
-verbatim leaves the vLLM default in place and sizes the KV cache for a device that is not
-also running Riva. Treat memory and context as values you calculate, in §Memory and
-context flags.
-
-Authenticate with `HF_TOKEN`. vLLM can download the repository directly from the Hub, so
-a separate model download is not required unless the model card instructs it. Verify
-access with `hf auth whoami`. Use `hf auth login` when authentication is missing.
-
-## LLM with vLLM
-
-Use the current vLLM image/version required by the locked model card and serve the exact
-Hugging Face repository id above. Generate the launch command from that card's current
-deployment guidance, then translate it into the generated `llm` or `omni` Compose service.
-Thor uses raw vLLM, so:
-
-- `HF_TOKEN` supplies model access.
-- `NIM_MODEL_PROFILE` and `list-model-profiles` do not apply.
-- The Omni repository name does not enable reasoning by itself.
-- Reasoning off has two parts. In agent requests, set
-  `extra_body.chat_template_kwargs.enable_thinking` to `false`. In the serve command, keep the
-  reasoning parser required by the locked model card. The parser applies the model's
-  reasoning-off contract and keeps thinking out of TTS content
-  (`models/llm.md` §Reasoning Parser).
-- Take the flags this model requires from the current card, and each flag's meaning and
-  current default from the vLLM `serve` CLI reference. Add nothing the card does not list
-  unless a fatal log names it (`models/llm.md` §Serve flags).
-- Confirm `/v1/models` serves the locked model before starting the agent, and put its
-  exact served id in the agent rather than the Hugging Face repository name.
-- The framework client traps are the same as any local endpoint. Follow
-  `frameworks/pipecat.md` §Local LLM wiring or `frameworks/livekit.md` §NVIDIA models.
-
-### Memory and Context Flags
-
-`--gpu-memory-utilization` and `--max-model-len` are **required in the generated Compose
-service** on Thor, because vLLM and Riva share one device. They are not tuning applied
-after an OOM.
-
-The memory fraction is per-instance and measured against total device memory. The reference
-states it does not account for memory another process already holds, so a running Riva does
-not lower it and vLLM will not leave room on its own. Calculate the fraction with the
-arithmetic in `models/llm.md` §Tight fit, treating the Riva configuration you selected plus
-startup headroom as memory the LLM cannot have.
-
-Set the context to the smallest length that satisfies the approved use case rather than the
-card's example length. KV cache grows with context, and a voice turn is short. The
-repository configuration also carries its own default context, so omitting the flag inherits
-that default instead of something small. When the
-current reference documents an absolute KV cache size such as `--kv-cache-memory-bytes`,
-prefer it over a fraction here, since an absolute budget is easier to reconcile with Riva
-than a fraction of a device both services share.
-
-Raise either value only after the complete vLLM + Riva stack is stable.
-
-### First Boot Compiles Kernels
-
-The NVFP4 path uses FlashInfer kernels that the card enables through environment variables.
-On first boot those kernels can be compiled on the device, which has been observed to run
-around 45 minutes before the server answers. Rising `nvcc` and `cicc` compile output is the
-progress signal, so read the logs instead of treating the wait as a hang.
-
-Mount a persistent cache for the compiled kernels alongside the Hugging Face cache, so later
-starts skip the compile. Resolve the current cache location from the vLLM and FlashInfer
-documentation for the version the card pins. Without that mount every container replacement
-pays the compile again. No serve flag shortens a kernel compile.
-
-### Host Memory at Startup
-
-vLLM's startup check has been observed to read Linux **free** memory rather than **available**
-memory on this platform. Page cache counts against it, so a host with plenty of reclaimable
-memory can still fail to start once model downloads and engine builds have filled the cache.
-
-Read both numbers before starting vLLM. When free memory is the blocker, reclaim page cache
-or restart the host rather than lowering the model configuration. This failure and a real
-device OOM look alike and their fixes are opposite, so confirm which one the log describes
-before changing the memory budget.
-
-## Riva Services
-
-Use the L4T Riva Speech image compatible with the Quick Start and mount the generated model
-repository. Riva serves ASR and TTS through one gRPC endpoint. Read
-`riva_speech_api_port` from the current Quick Start `config.sh` and map that port in the
-generated `riva` Compose service.
-
-| Service | Project endpoint |
-| --- | --- |
-| LLM OpenAI-compatible API | mapped port from the generated vLLM service |
-| Riva ASR + TTS gRPC | port from the current `riva_speech_api_port` |
-
-Function ids are empty. For cascaded mode, never hand over while the shared Riva gRPC
-endpoint is unavailable. For TTS, discover and use a voice exposed by the running Riva
-service rather than a Magpie voice id.
-
-For approved domain terms, follow the Jetson Thor branch in
-`domain/speech-customization.md`. Use Riva request-time word boosting and pronunciation
-only when the selected ARM64 Quick Start model supports them.
-
-### Language on the Quick Start ASR
-
-The streaming ASR model a Quick Start release offers may be a multilingual auto-detecting
-model. On that kind of model a requested locale is advisory and does not restrict
-recognition, so Hindi audio returns Devanagari and English audio returns English on the same
-stream.
-
-Say this in the proposal instead of presenting a fixed locale as a guarantee, and say plainly
-when the release contains no single-language model for the requested locale. Resolve what the
-selected release actually offers through `models/language-routing.md`.
-
-## Resource Sharing
-
-Thor shares unified memory and one GPU between vLLM and Riva. Do not prescribe CPU
-pinning or fixed compute splits. Start from the compute and scheduling defaults supported by
-the current vLLM, Riva, and JetPack releases. Memory is the exception, because §Memory and
-context flags sets those values explicitly. If measured contention causes audio glitches,
-consult the current platform guidance before applying CUDA MPS tuning.
-
-If the stack still OOMs with the calculated budget in place, lower `--max-model-len` first,
-then the memory fraction, before changing the approved model.
-
-## Start and Verify
-
-Assert each result. Do not read a step as done because the previous one produced output.
-
-1. Start the generated vLLM Compose service. Wait for `/v1/models` and confirm it returns
-   the locked served id.
-2. Prove the locked model's input path. For a cascaded pipeline, send one streaming chat
-   completion with reasoning off and assert non-empty `delta.content` plus empty or absent
-   `delta.reasoning_content`. For an Omni pipeline, send one minimal audio request and
-   assert a non-empty text response.
-3. Measure available unified memory. Start Riva only when the remaining budget covers the
-   selected Quick Start configuration plus startup headroom. Otherwise stop vLLM and lower
-   `--max-model-len` or the memory fraction.
-4. Start the generated `riva` service. Query `GetRivaSynthesisConfig` and assert the loaded
-   TTS model plus a voice the service actually returned.
-5. Cascaded only: query `GetRivaSpeechRecognitionConfig` and assert the loaded ASR model and
-   language.
-6. Cascaded only: synthesize one sentence in the approved locale and feed that audio back
-   through streaming ASR. This is the only check that proves both speech directions on the
-   shared Riva endpoint before a microphone is involved.
-7. Run `scripts/smoke.sh`.
-8. Start the framework agent.
-9. Complete a spoken exchange (`operations/run.md`).
-
-Riva's first start after initialization can still spend a long time loading and building
-before it reports ready. Treat it like the first-boot window in `platforms/deployment.md`
-and read the logs rather than restarting.
+Thor is also the platform where `platforms/single-gpu.md` §Host memory at startup and
+§First boot compiles kernels are most likely to appear. Read both before treating a slow
+start as a failure.
 
 ## Anti-Patterns
 
 - Following build.nvidia.com NIM launch instructions on Thor.
-- Using `NIM_MODEL_PROFILE` or Speech `NIM_TAGS_SELECTOR` on the Thor stack.
-- Running `riva_start.sh` after the generated deployment already owns Riva startup.
-- Selecting offline ASR for a live voice agent.
-- Starting from a Magpie NIM voice id instead of querying Riva voices.
-- Copying a card launch command verbatim, which leaves the vLLM memory default in place and
-  sizes the context for a device that is not also running Riva.
-- Keeping the reasoning parser while the reasoning row is off.
-- Adding eager mode, scheduling toggles, or CUDA MPS variables to chase a slow first boot.
-- Mounting the `riva_model_loc` you configured without asserting where the models landed.
-- Copying a root-owned `model_repository` into a new Quick Start directory.
-- Setting some of `RIVA_API_KEY`, `RIVA_EULA`, and `RIVA_API_NGC_ORG` but not all three.
-- Presenting a fixed locale as single-language recognition on an auto-detecting model.
-- Treating unified 128 GB memory as entirely available to vLLM.
+- Copying an x86 image onto Thor, or generating an `amd64`-only service.
+- Treating an Orin device as a supported Thor.
+- Adding a draft model, or reusing the DGX Spark draft model.
+- Proposing the concurrent-subagent Omni shape as a local Thor deployment.
+- Restarting vLLM during a first-boot kernel compile.

--- a/skills/create-voice-agent/references/platforms/readiness.md
+++ b/skills/create-voice-agent/references/platforms/readiness.md
@@ -35,8 +35,8 @@ This intentionally pulls a small image when it is not cached. Require the contai
 to list the same intended GPU devices seen on the host. A working host `nvidia-smi` alone
 does not pass this check.
 
-If the command fails, stop before NIM, vLLM, or Riva pulls. Point to NVIDIA Container
-Toolkit installation or Docker runtime configuration based on the actual error.
+If the command fails, stop before any NIM, vLLM, or speech container pull. Point to NVIDIA
+Container Toolkit installation or Docker runtime configuration based on the actual error.
 
 ## 3. Storage and Cache Paths
 
@@ -47,8 +47,8 @@ docker info --format '{{.DockerRootDir}}'
 ```
 
 Check free space on that filesystem and every host path that the generated
-`compose.yaml` will mount. These include the locked NIM cache, Hugging Face cache, and
-Jetson Thor Riva `model_repository` when applicable.
+`compose.yaml` will mount. Depending on the routed stack these include the locked NIM
+cache, the Hugging Face cache, the compiled kernel cache, and the speech model tree.
 
 For each host-mounted cache:
 
@@ -67,17 +67,37 @@ Reconfirm the required keys from `preflight.md` without printing them. Use the c
 build.nvidia.com login instructions for NGC. A registry authentication failure is a hard
 stop before model pulls.
 
-## 5. Jetson Thor
+## 5. Speech Model Tree
 
-When the routed platform is Jetson Thor, also require:
+Required when the routed stack is the single-GPU stack in `platforms/single-gpu.md`, which
+covers DGX Spark, Jetson Thor, and a low-concurrency workstation. The speech service loads
+GGUF files from a read-only mount, so it cannot create or repair anything itself.
 
-- the JetPack release supported by the current Riva ARM64 Quick Start
-- NGC CLI authentication
-- `hf auth whoami` access to the locked Nemotron repository
-- a writable parent path with enough space for the external Riva `model_repository`
+Require all of the following before the one-time download:
 
-The repository itself is produced later by the one-time `riva_init.sh` step. Require it to
-exist before starting the generated `riva` service, not before generating the project.
+- `hf auth whoami` succeeds for the locked LLM repository and the speech model
+  repositories
+- a writable parent path outside the generated project, with space for the ASR GGUF, the
+  Magpie GGUF and its extracted tokenizer, the codec GGUF, and the normalization grammars
+- space for the Hugging Face cache and the compiled kernel cache, which are separate from
+  the model tree and much larger
+- on Jetson Thor, the JetPack release the current platform documentation supports
+
+Two ownership rules decide whether the service can read the models.
+
+**Create the model tree before the first `compose up`.** When Compose starts with the bind
+mount missing, Docker creates that host path as root. The download then cannot write to
+it, and the failure reads like a tooling problem rather than a permissions one. If it has
+already happened, reclaim ownership for the user account and retry.
+
+**Do not run the download with `sudo` to work around it.** Elevating changes the PATH, so
+the user's Hugging Face CLI disappears and the files land owned by root again. Fix the
+ownership, then run the download as the account that owns the path.
+
+After the download, require the tree and every file in it to be readable by the container
+user, which is not the host account that downloaded them. Assert the expected files exist
+by name, including the grammar files under each language directory, rather than trusting
+that an archive extracted correctly.
 
 ## Pass Condition
 
@@ -89,6 +109,6 @@ guide only when:
 - all required host-mounted paths are writable
 - Docker storage and model caches have enough free space
 - required registries and model sources can authenticate
-- Jetson Thor prerequisites above pass when applicable
+- the speech model tree checks above pass when the routed stack is single-GPU
 
 Record the commands, expected GPU assignment, and cache paths in the generated README.

--- a/skills/create-voice-agent/references/platforms/single-gpu.md
+++ b/skills/create-voice-agent/references/platforms/single-gpu.md
@@ -1,0 +1,367 @@
+# Single-GPU vLLM and NeMo-Speech.cpp
+
+vLLM serves the Nemotron LLM, and one NeMo-Speech.cpp service holds ASR and TTS on the same
+device. NeMo-Speech.cpp is a native ggml runtime with no Triton and no Python, and its
+container publishes `amd64` and `arm64` from one tag.
+
+Read this file when `preflight.md` §4 routes here:
+
+| Host class | Status |
+| --- | --- |
+| `dgx_spark` | only supported local stack, plus `platforms/dgx-spark.md` |
+| `jetson_thor` | only supported local stack, plus `platforms/jetson-thor.md` |
+| `workstation`, one user or a few concurrent sessions | recommended local stack |
+
+A workstation serving many users uses NIM instead (`platforms/deployment.md`). DGX Spark and
+Jetson Thor have no NIM path, so do not present NIM images, NIM profiles,
+`NIM_MODEL_PROFILE`, `NIM_TAGS_SELECTOR`, Magpie NIM, or speech function ids there.
+
+## Before Proposing
+
+This checklist covers all three host classes. The platform file adds only its own identity
+signals and coverage limits.
+
+1. Plan against memory the probe reports as available, never advertised capacity. On DGX
+   Spark and Jetson Thor the GPU, the operating system, the containers, and page cache all
+   draw on one pool.
+2. Verify every local slot against §Models, subject to any coverage limit the platform file
+   states.
+3. Build the runtime budget through §Memory. The speech reserve is measured, not estimated,
+   and a draft model counts as a second resident model.
+4. Mark provisional co-location until §Start and verify passes.
+5. If a slot does not fit, move that slot to NVIDIA cloud and show the hybrid layout in the
+   proposal. Never substitute a different model silently.
+
+## Source of Truth
+
+Read these before generating. No value here may come from memory.
+
+| Source | Authority over |
+| --- | --- |
+| Locked model page in §Models | vLLM container and version, quantization variants, serve flags, parsers, required environment, request format |
+| [vLLM `serve` CLI reference](https://docs.vllm.ai/en/stable/cli/serve/) | each flag's spelling, meaning, and current default |
+| [`nemo-speech.cpp` on NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-speech.cpp) | image tag, architectures, container command line |
+| [NeMo-Speech.cpp repository](https://github.com/NVIDIA/NeMo-Speech.cpp) | engine keys ([server](https://github.com/NVIDIA/NeMo-Speech.cpp/blob/main/docs/server.md), [ASR](https://github.com/NVIDIA/NeMo-Speech.cpp/blob/main/docs/asr/configuration.md), [TTS](https://github.com/NVIDIA/NeMo-Speech.cpp/blob/main/docs/tts/configuration.md)), model layout, boosting, text normalization, gRPC limits |
+| Hugging Face page per speech model | exact GGUF file names and revisions |
+
+Pass `platforms/readiness.md`, then generate services through `output-contract.md`. This
+skill ships no static Compose file.
+
+## Models
+
+| Pipeline | LLM page | Repository family | Speech |
+| --- | --- | --- | --- |
+| Cascaded | [Nemotron 3.5 Lightning](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b?nim=self-hosted) | `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-<variant>` | streaming ASR plus Magpie TTS in one service |
+| Omni | [Nemotron 3 Omni](https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning) | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-<variant>` | TTS only, because Omni performs ASR |
+
+`<variant>` is resolved by §Precision. Read the page for the exact ids rather than
+assembling one. The Omni display name and its `nano-omni` ids differ by design
+(`models/llm.md` §The Omni name and its ids differ).
+
+Lock locales through `models/language-routing.md`. Resolve speech models through
+`models/asr.md` and `models/tts.md`, which route back here.
+
+### Read from the Page
+
+Open the page for the slot being built, immediately before generating. Take:
+
+- exact container tag and CUDA variant. The two models do not pin the same vLLM version
+- the platform-specific section when one exists, in preference to the generic example
+- extra packages the image lacks (§Omni needs audio extras)
+- available precision variants, for §Precision
+- reasoning and tool-call parser names
+- required environment variables
+- sampling values for thinking mode and instruct mode. Voice uses instruct unless reasoning
+  was approved
+- multimodal limits and media path allowance, which Omni needs before it accepts audio
+- per-architecture backend notes, for example a different MoE backend on some cards
+- supported response languages, against `models/language-routing.md` §LLM
+- published draft model, if any
+
+The page's hardware-compatibility summary is not the authority. Its vLLM section is.
+
+A published launch command is an example, not a budget. These commonly serve a very long
+context and size memory for a device not also running speech. Calculate memory and context
+yourself in §Memory.
+
+Authenticate with `HF_TOKEN` and verify with `hf auth whoami`. vLLM downloads from the Hub
+directly unless the page instructs otherwise.
+
+### Omni Needs Audio Extras
+
+The published vLLM image ships without audio support. Install `vllm[audio]`, pinned to the
+image's vLLM version, before `vllm serve`.
+
+Without it the server starts, `/v1/models` answers, and text requests succeed. Only the
+first spoken turn fails. Prove the audio path in smoke, not at the microphone. Cascaded does
+not need this.
+
+## Precision
+
+Resolve precision per model and GPU. A checkpoint's name and its execution kernel are
+different facts. A NIM profile can also name a different precision, because NIM and raw
+vLLM use different artifacts. NIM selection belongs to `models/llm.md` §Cascaded LLM NIM
+fit or `frameworks/omni.md` §Workstation NIM.
+
+For Cascaded Lightning, use the published NVFP4 checkpoint on the hardware its card
+supports:
+
+| Host | Lightning checkpoint and execution | Speculative decoding |
+| --- | --- | --- |
+| DGX Spark | NVFP4 checkpoint through the published W4A16 Marlin recipe | the DGX Spark draft model |
+| Jetson Thor | NVFP4 checkpoint through the published platform recipe | none |
+| Blackwell workstation | NVFP4 checkpoint with the backend published for that GPU | the workstation draft model published for that architecture |
+| Hopper | NVFP4 checkpoint through W4A16 kernels | only when the card publishes a draft recipe for that workload |
+| Ampere | NVFP4 checkpoint through W4A16 kernels | none |
+| Ada | use only when the current Lightning page publishes an explicit recipe for the exact GPU |
+| Older than Ampere | unsupported. Propose cloud |
+
+Do not replace the Lightning NVFP4 checkpoint with BF16 merely because the GPU executes it
+through W4A16 kernels. That increases the weight footprint and can reject a valid local
+deployment.
+
+For Omni, do not reuse the Lightning table. Its page publishes separate BF16, FP8, and
+NVFP4 repositories. Select the lightest variant with an explicit recipe for the exact GPU,
+and propose cloud when the page provides none.
+
+Confirm the repository, execution backend, draft model, flag names, and token count on the
+locked page and the vLLM reference. Speculative flag spelling changes between releases.
+
+A draft model is a second download and a second resident model, so budget it in §Memory.
+
+When compute capability was derived from the GPU name rather than read from the driver
+(`preflight.md` §Compute capability fallback), confirm it before selecting a variant.
+
+## One-Time Speech Model Setup
+
+Do this before configuring the service, which takes these files as paths. GGUF files load
+from disk. Fetch once per machine, keep the tree outside the generated project, mount
+read-only.
+
+| Asset | Repository |
+| --- | --- |
+| Streaming ASR GGUF, English | `nvidia/nemotron-speech-streaming-en-0.6b` |
+| Streaming ASR GGUF, multilingual | `nvidia/nemotron-3.5-asr-streaming-0.6b` |
+| Magpie TTS GGUF and `.nemo` archive | `nvidia/magpie_tts_multilingual_357m` |
+| NanoCodec decoder GGUF | `nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps` |
+| Text-normalization grammars | NeMo-Speech.cpp GitHub release asset |
+
+Resolve file names and revisions from each page at fetch time. Quantized names carry a
+quantization and version, so a remembered name goes stale.
+
+Four rules decide whether the service starts:
+
+1. **The Magpie tokenizer is in the `.nemo` archive, not the GGUF.** Extract it and pass the
+   directory. TTS enables only with the Magpie model, the codec model, and the tokenizer
+   directory all present.
+2. **The grammars are not on Hugging Face.** They are a release asset pinned to the release
+   matching the container tag. Verify the checksum, extract to a staging path, and replace an
+   installed set only after the expected files are present.
+3. **Assert the grammar layout.** Either a single grammar directory or a parent with
+   language-named children, each holding `tokenize_and_classify.far` and `verbalize.far`.
+4. **Run the download as the account that owns the path, never with `sudo`**
+   (`platforms/readiness.md` §Speech model tree).
+
+Without normalization the service speaks digits, dates, and currency literally. Treat a
+missing grammar directory as a defect to fix before handover, and disclose it if the user
+accepts it. A container built without normalization support logs a warning at startup and
+passes text through unchanged, so read that line rather than assuming the flag took effect.
+
+## Speech Service
+
+One gRPC binary, Riva-compatible. No HTTP listener, no playground, no client tools. Take the
+image tag and run command from the NGC page.
+
+One service covers both directions. Capabilities enable from the model paths passed, so
+cascaded passes ASR and TTS paths and Omni passes TTS paths only. No enabled capability is
+an error.
+
+Precedence is defaults, YAML, environment, then command line. Environment names are the
+dotted key uppercased with `.` and `-` becoming `_`, so `asr.model.path` becomes
+`NEMO_SPEECH_ASR_MODEL_PATH`. **Unknown keys are errors, not warnings**, so a typo is a
+startup failure. Use canonical dotted names, because the short aliases belong to the HTTP
+binary.
+
+### Set Explicitly
+
+| Setting | Key | Note |
+| --- | --- | --- |
+| ASR model | `--asr.model.path` | cascaded only, required for ASR |
+| ASR device | `--asr.backend.gpu` | device index, `-1` is CPU |
+| Mid-stream end of utterance | `--asr.endpointing.enable` | **off by default.** A live agent requires it |
+| End-of-utterance silence | `--asr.endpointing.stop_history_eou_ms` | default 800, usually tuned lower for conversation |
+| Magpie token generator | `--tts.magpie-model` | required for TTS |
+| NanoCodec decoder | `--tts.codec-model` | required for TTS |
+| Tokenizer directory | `--tts.tokenizer-model-dir` | required for TTS, the extracted `.nemo` directory |
+| Normalization grammars | `--tts.tn-model-dir` | required for spoken numbers, dates, currency |
+| Default locale | `--tts.language-code` | defaults to `en-US` |
+| Default voice | `--tts.voice-name` | confirm against the running service |
+| TTS CPU threads | `--tts.threads` | Magpie and codec run on CPU |
+| Listen address | `--bind` | `0.0.0.0:50051` by default |
+
+Endpointing is the trap. At its default the server emits one final result only when the
+client closes the stream, so a live conversation never produces a turn boundary and the
+agent appears deaf to the end of a sentence. Verify a mid-stream final in smoke.
+
+### Readiness Is gRPC Only
+
+No health URL exists, so generate no HTTP health check. Prove readiness with
+`GetRivaSynthesisConfig`, plus `GetRivaSpeechRecognitionConfig` when cascaded. A TCP connect
+shows the port is open, not which model loaded.
+
+### Languages and Voices
+
+Implements `Synthesize`, `SynthesizeOnline`, and `GetRivaSynthesisConfig`. Takes plain text,
+returns 16-bit linear PCM at the codec sample rate.
+
+Some Magpie languages are build-time options that are off by default, so the container can
+serve fewer languages than the model page lists. `GetRivaSynthesisConfig` is the authority
+for this deployment and the page is the upper bound. Disclose it when the requested locale is
+one of the optional ones.
+
+Voice names accept a local name, a zero-based speaker index, or a model-qualified name. Lock
+only a voice the running service returned.
+
+### gRPC Limits
+
+Confirm on current documentation, and disclose when they touch the use case:
+
+- mono 16-bit linear PCM only, so compressed inbound audio needs client-side transcoding
+- one alternative per result, whatever maximum-alternatives the request carries
+- confidence is not comparable to NIM. Interim results report zero, cache-aware RNNT finals
+  report a fixed value
+
+## LLM with vLLM
+
+Use the image and version the locked page requires, serve the exact repository id, and
+translate the page's launch command into the generated `llm` or `omni` service. This is raw
+vLLM, so:
+
+- `HF_TOKEN` supplies model access. `NIM_MODEL_PROFILE` and `list-model-profiles` do not
+  apply
+- the Omni repository name does not enable reasoning by itself
+- reasoning off has two parts: `extra_body.chat_template_kwargs.enable_thinking` false in
+  agent requests, and the page's reasoning parser in the serve command
+  (`models/llm.md` §Reasoning parser)
+- add no flag the page does not list unless a fatal log names it
+  (`models/llm.md` §Serve flags)
+- put the served id from `/v1/models` in the agent, not the repository name
+- client traps are the same as any local endpoint (`frameworks/pipecat.md` §Local LLM wiring
+  or `frameworks/livekit.md` §NVIDIA models)
+
+### First Boot Compiles Kernels
+
+The NVFP4 path can compile kernels on device at first boot, observed at around 45 minutes
+before the server answers. Rising `nvcc` and `cicc` output is progress, not a hang.
+
+Mount a persistent kernel cache beside the Hugging Face cache, with the location resolved
+from the vLLM docs for the pinned version. Without it every container replacement recompiles.
+No serve flag shortens this.
+
+### Host Memory at Startup
+
+vLLM's startup check has been observed to read Linux **free** memory rather than
+**available** memory. Page cache counts against it, so a host with plenty of reclaimable
+memory can fail to start after downloads and engine builds fill the cache.
+
+Read both numbers. When free memory is the blocker, reclaim page cache or restart the host
+rather than lowering the model configuration. This and a real device OOM look alike and
+their fixes are opposite.
+
+## Memory
+
+`--gpu-memory-utilization` and `--max-model-len` are **required Compose entries**, not
+post-OOM tuning, because vLLM and speech share one device. The fraction is per-instance
+against total device memory and does not account for memory another process holds, so vLLM
+will not leave room for speech on its own.
+
+```text
+usable     = available_memory - startup_headroom
+llm_budget = usable - measured_speech_reserve
+```
+
+`available_memory` is the lower of CUDA free memory and host available memory on DGX Spark
+and Jetson Thor, which share one pool. On a workstation it is CUDA free memory alone.
+
+```bash
+nvidia-smi --query-gpu=index,name,memory.total,memory.free --format=csv,noheader
+awk '/MemTotal|MemAvailable/ {print}' /proc/meminfo
+```
+
+**Measure the speech reserve, do not estimate it.** Start speech alone, let warmup finish,
+read both numbers again. The difference is the reserve.
+
+On DGX Spark and Jetson Thor prefer a fixed conservative fraction over one derived at launch,
+because free memory moves between a cold boot and a boot after downloads. On a workstation
+with dedicated VRAM, derive it from measured free VRAM. Either way round down, leave startup
+headroom, and raise it only once the full stack is stable.
+
+Set context to the smallest length the approved use case needs. KV cache grows with context
+and a voice turn is short. The repository config carries its own default, so omitting the
+flag inherits that. Prefer an absolute KV cache size over a fraction when the current
+reference documents one.
+
+Recalculate when context, speech models, thread count, or the draft model changes. If the
+budget cannot hold weights, overhead, and a usable KV cache, lower `--max-model-len` first,
+then the fraction, then move a slot to cloud.
+
+## Start and Verify
+
+Start speech first, because its footprint is fixed by the models it loads while the LLM
+fraction is set against what remains. This is the opposite of the NIM order in
+`platforms/deployment.md`.
+
+Assert each result rather than reading a step as done because the previous one produced
+output.
+
+1. Start speech alone. `GetRivaSynthesisConfig`, and assert the loaded TTS model, the
+   compiled-in languages, and a returned voice.
+2. Cascaded: `GetRivaSpeechRecognitionConfig`, and assert the loaded ASR model and language.
+3. Measure memory again with speech resident. Write the resulting fraction into Compose
+   before starting vLLM.
+4. Start vLLM. Wait for `/v1/models` and confirm the locked served id.
+5. Prove the input path. Cascaded: one streaming chat completion with reasoning off,
+   asserting non-empty `delta.content` and empty or absent `delta.reasoning_content`. Omni:
+   one minimal audio request asserting a non-empty text response.
+6. Cascaded: synthesize one sentence in the approved locale and feed it back through
+   streaming ASR. This is the only check that proves both directions before a microphone,
+   and a mid-stream final is what proves endpointing is on.
+7. `scripts/smoke.sh`.
+8. Start the framework agent.
+9. Complete a spoken exchange (`operations/run.md`).
+
+Only after step 9 may the README status change from `provisional co-location` to
+`self-hosted, co-located`.
+
+Speech loads GGUFs and warms up rather than building a TensorRT engine, so it starts far
+faster than a speech NIM. A long wait there is a symptom to read in the logs. The long first
+boot on this stack belongs to vLLM.
+
+## Resource Sharing
+
+Do not prescribe CPU pinning or compute splits. Start from the defaults the current vLLM,
+container, and platform releases support. Memory is the exception, set explicitly in §Memory.
+
+Magpie and codec work runs on CPU threads, so leave CPU headroom for the configured thread
+count. If measured contention causes audio glitches, lower that count.
+
+## Anti-Patterns
+
+- Following NIM instructions on DGX Spark or Jetson Thor, or using `NIM_MODEL_PROFILE`,
+  `NIM_TAGS_SELECTOR`, or a speech function id on this stack.
+- Generating an HTTP health check for a gRPC-only service.
+- Leaving ASR endpointing at its default, then debugging turn detection in the client.
+- Starting vLLM before the speech reserve is measured.
+- Copying a page's launch command verbatim, which leaves the memory default in place and
+  sizes context for a device not running speech.
+- Deriving the memory fraction from launch-time free memory on a unified-memory pool.
+- Carrying a draft model across architectures, or adding one to Jetson Thor.
+- Serving Omni without the audio extras, installing them unpinned, or calling it working
+  from a text request.
+- Copying the cascaded vLLM version, tag, or flags onto Omni.
+- Assembling a repository id instead of reading it, or dropping `nano` from an id.
+- Passing the Magpie GGUF without the tokenizer directory and codec model.
+- Treating the model page's language list as what the container serves.
+- Shipping without normalization grammars and calling literal digits a model limitation.
+- Hardcoding a voice the service never returned.
+- Treating advertised unified memory as available to vLLM.

--- a/skills/create-voice-agent/references/preflight.md
+++ b/skills/create-voice-agent/references/preflight.md
@@ -1,8 +1,10 @@
 # Preflight
 
-Sections 1-3 are step 0 of `intake.md` and run before the first word to the user. They
-establish host class and base credentials. Section 4 runs during proposal after pipeline,
-framework, and candidate models are known.
+Sections 1-3 are step 0 of `intake.md` and run before the proposal. They establish host
+class and base credentials, and they stay silent unless they find something that changes
+the conversation, which is a missing credential, a detection failure, or memory held by
+another process. Section 4 runs during proposal, after pipeline, framework, and candidate
+models are known.
 
 Per-slot footprints and knobs live in `models/llm.md`, `models/asr.md`, and
 `models/tts.md`. Section 4 combines them into self-hosted, cloud, or hybrid placement.
@@ -18,59 +20,209 @@ Per-slot footprints and knobs live in `models/llm.md`, `models/asr.md`, and
 ## 1. Probe the Host
 
 Collect the operating system, GPU inventory, machine identity, system RAM, and free disk.
-Failures on a machine without a GPU are expected and are not errors.
 
-`nvidia-smi` is the detection method. Ask it for everything in one query, including
-`compute_cap`, because compute capability is what decides the precision:
+Detect the operating system first, for example with `uname -sm`. Self-hosted NVIDIA model
+containers require Linux, so on macOS or Windows the deployment is cloud. The Linux
+identity paths below do not exist on other systems, and their absence there is expected.
+
+Run the GPU probe as the ordered stages below. Do not collapse them into one command. A
+single combined query is the reported cause of a host with a working GPU being classified
+as cloud only, because one unsupported field makes the whole query return nothing.
+
+### Stage 1. Locate `nvidia-smi`
 
 ```bash
-nvidia-smi --query-gpu=index,name,memory.total,memory.free,compute_cap --format=csv,noheader
+command -v nvidia-smi
 ```
 
-A non-zero exit or empty output means no usable NVIDIA GPU.
+When that returns nothing, check the paths a driver install can use before concluding
+anything: `/usr/bin/nvidia-smi`, `/usr/local/nvidia/bin/nvidia-smi`,
+`/opt/nvidia/bin/nvidia-smi`, and `/usr/lib/wsl/lib/nvidia-smi` on WSL. Use the path that
+exists for every later stage.
 
-Report usable VRAM as `memory.free`, not nameplate `memory.total`. Add VRAM across GPUs
-only when the user intends to pin slots to separate devices.
+### Stage 2. Read the Inventory
 
-Detect the operating system first, for example with `uname -s`. Self-hosted NIM models
-require Linux, so on macOS or Windows the deployment is cloud. The identity paths below
-exist only on Linux; their absence on other systems is expected, not an error.
+```bash
+nvidia-smi -L
+```
 
-On Linux, read the machine identity from `/sys/class/dmi/id/product_name` and
-`/proc/device-tree/model`, which is the only reliable way to tell DGX Spark and Jetson Thor
-apart from a generic host.
+`nvidia-smi -L` is the inventory step because it takes no field arguments, so no driver
+version can reject part of it. One line per GPU proves a usable device exists. Treat a
+failure here as a driver or permission problem to be reported, never as proof of no GPU.
 
-Re-probe if the user says they will run on a different machine from the one hosting the
-agent.
+### Stage 3. Read the Fields in Two Queries
+
+Query the long-standing fields first, then compute capability on its own:
+
+```bash
+nvidia-smi --query-gpu=index,name,memory.total,memory.free --format=csv,noheader
+nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+```
+
+`compute_cap` is a newer field than the rest. Asking for it in the same query as the
+memory fields means a driver that does not know it discards the memory and name output
+too. Keeping it separate loses only the field the driver cannot answer.
+
+Treat `[N/A]`, `[Not Supported]`, and `Insufficient Permissions` as unread values rather
+than as zero. A blank or `[N/A]` memory figure on an integrated device is normal, and
+§Unified memory hosts explains what to read instead.
+
+### Stage 4. Confirm Machine Identity
+
+On Linux, read both identity sources, because they are the only reliable way to separate
+DGX Spark and Jetson Thor from a generic host:
+
+```bash
+cat /sys/class/dmi/id/product_name 2>/dev/null
+cat /proc/device-tree/model 2>/dev/null
+```
+
+Either file can be absent on a given machine, and that alone is not an error. Match the
+strings exactly as §2 lists them.
+
+### Stage 5. Look for a GPU Independently
+
+Reach this stage only when Stages 1 to 3 produced no GPU. Before recording `no_gpu`,
+confirm the absence against evidence that does not depend on `nvidia-smi`:
+
+```bash
+cat /proc/driver/nvidia/version 2>/dev/null
+ls /dev/nvidia* /dev/nvgpu 2>/dev/null
+lspci -nn -d 10de: 2>/dev/null
+```
+
+A loaded kernel module, a device node, or an NVIDIA PCI vendor id means the machine has a
+GPU that the probe could not read. That is a detection failure to report, not a cloud-only
+host. On Tegra platforms such as Jetson there is no discrete PCI entry and no
+`/dev/nvidia0`, so the device-tree model from Stage 4 is the signal there.
+
+### Unified Memory Hosts
+
+DGX Spark and Jetson Thor share one memory pool between the CPU and the GPU, so
+`memory.total` describes that pool rather than dedicated VRAM. Read host memory as well
+and plan against the lower of the two figures:
+
+```bash
+awk '/MemTotal|MemAvailable/ {print}' /proc/meminfo
+free -h
+```
+
+### Find Out What Is Holding the Memory
+
+When free memory is well below total, identify what is resident before that number changes
+the deployment. A stale container looks exactly like a small GPU, and the two deserve
+opposite responses.
+
+```bash
+nvidia-smi --query-compute-apps=pid,used_memory,name --format=csv
+docker ps --format '{{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Status}}'
+```
+
+Map a pid to a container with `docker inspect -f '{{.State.Pid}}'` per running id. On Tegra
+platforms per-process memory is often unavailable, so attribute by container and say so.
+
+| What is resident | Action |
+| --- | --- |
+| A slot this project owns that matches the lock | keep it (`platforms/deployment.md` §Per-slot reuse) |
+| A slot this project owns that is stale, wrong, or unhealthy | offer to stop that named container, with the memory it returns |
+| Anything else, including notebooks, training jobs, and desktop sessions | report and name it. Let the user decide |
+
+Report the finding with numbers, for example that stopping a named stale container returns
+about 40 GiB and makes the deployment fully local. Then wait.
+
+Three rules:
+
+1. **Stop only named containers the user approved.** Never `docker system prune`, never
+   `docker kill $(docker ps -q)`, never kill a bare pid.
+2. **Re-measure after reclaiming**, because memory returns when the process exits rather
+   than when the command returns.
+3. **Do not downgrade around reclaimable memory.** Confirm the shortfall is real before
+   proposing a smaller model, a lighter quantization, a shorter context, or a cloud slot. If
+   the user declines or the memory is someone else's, treat what remains as the budget and
+   record in the proposal that the GPU was partially occupied.
+
+### What to Report
+
+Report usable VRAM as `memory.free`, not nameplate `memory.total`, and alongside whatever is
+holding the rest. Add VRAM across GPUs only when the user intends to pin slots to separate
+devices. Name the GPU exactly as `nvidia-smi` reports it, for example
+`NVIDIA RTX 6000 Ada Generation`.
+
+Warn when system RAM is under 32 GiB or free disk is under 50 GiB, because model images
+and weights are large.
+
+Re-probe when the user says the agent will run on a different machine from the one being
+probed.
+
+### Detection Failure Is Not `no_gpu`
+
+`no_gpu` is a finding. A probe that could not answer is a different outcome, and the two
+have opposite next steps. Read the actual output before choosing between them.
+
+| Observation | What it means | Do this |
+| --- | --- | --- |
+| `Field "<name>" is not a valid field to query.` with exit 2 | the driver predates that field, and the entire query returned nothing | rerun without that field, then resolve compute capability through §Compute capability fallback |
+| `NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver` | the driver is not loaded, or this is a container without the container toolkit | detection failure. Report the layer and stop |
+| `Failed to initialize NVML: Driver/library version mismatch` | the loaded module and the user-space library differ | detection failure. The host needs a module reload or reboot |
+| `Failed to initialize NVML: Insufficient Permissions` | the account cannot reach the device nodes | detection failure. Report it rather than adding `sudo` |
+| `nvidia-smi` is absent but `/proc/driver/nvidia/version` exists | the driver is present and the utility is not on this PATH | retry with the Stage 1 paths |
+| `nvidia-smi -L` lists GPUs but the field query is empty | partial field support | keep the Stage 2 inventory and continue |
+| Stages 1 to 3 empty and Stage 5 finds a module, device node, or PCI id | a GPU exists and the probe cannot read it | detection failure. Report it |
+| Stages 1 to 3 empty and Stage 5 finds nothing | genuinely no NVIDIA GPU | record `no_gpu` |
+
+On a detection failure, show the command, its exit code, and its error output, then say
+what you were unable to determine. Ask the user to confirm the hardware or fix the named
+layer. Never present cloud as the only option on the strength of a probe that failed, and
+never claim a machine has no GPU without the Stage 5 evidence.
+
+### Compute Capability Fallback
+
+Compute capability decides LLM precision, so it cannot be guessed silently. When Stage 3
+cannot return it, use the GPU name to identify the architecture, state that the value was
+derived from the name rather than read from the driver, and treat the resulting precision
+as a candidate only. Confirm it against the authoritative source for the locked model,
+which is the support matrix for a NIM path and the model card for a vLLM path, before
+anything is generated.
 
 ## 2. Classify the Host
 
 | Signal | Host class |
 | --- | --- |
-| OS is macOS or Windows | `no_gpu`, cloud only (NIM needs Linux) |
-| `nvidia-smi` fails or names no GPU | `no_gpu`, cloud is the only option |
-| DMI product name contains GB10 or Spark | `dgx_spark`, see `platforms/dgx-spark.md` |
-| Device tree model names Jetson Thor | `jetson_thor`, see `platforms/jetson-thor.md` |
-| x86_64 with an NVIDIA GPU | `workstation` |
-| aarch64 with a GPU that is not Thor | `unsupported_edge`, cloud only |
+| OS is macOS or Windows | `no_gpu`, cloud only, because self-hosted model containers need Linux |
+| Stage 5 confirms no NVIDIA GPU | `no_gpu`, cloud is the only option |
+| GPU name contains `NVIDIA GB10`, or DMI product name contains `DGX_Spark` | `dgx_spark`, see `platforms/dgx-spark.md` |
+| Device-tree model or DMI product name contains both `Jetson` and `Thor` | `jetson_thor`, see `platforms/jetson-thor.md` |
+| x86_64 with an NVIDIA GPU | `workstation`, see `platforms/deployment.md` |
+| Jetson Orin or any other Tegra platform that is not Thor | `unsupported_edge`, cloud only |
+| aarch64 with a GPU that is neither GB10 nor Thor | `unsupported_edge`, cloud only |
 
-Name the GPU to the user exactly as `nvidia-smi` reports it, for example
-`NVIDIA RTX 6000 Ada Generation`. Warn when system RAM is under 32 GiB or free disk is
-under 50 GiB, because NIM images are large.
+Match `DGX_Spark` with the underscore as the file reports it. Check DGX Spark before the
+generic aarch64 row, because GB10 is an aarch64 platform and would otherwise fall through
+to `unsupported_edge`.
+
+Jetson Orin is not a smaller Thor. The models in this skill do not fit it, so it routes to
+cloud rather than to a reduced local stack.
+
+A probe that ended in detection failure has no host class yet. Resolve it with the user
+before continuing.
 
 ## 3. Check the Credentials
 
-`NVIDIA_API_KEY` is required for cloud inference and for pulling NIM images from `nvcr.io`.
-It is not required for a raw-vLLM path that pulls from Hugging Face. Check the credential
-that the selected deployment path requires.
+Each path needs one model credential. Check that one, not every key.
 
-The rest depend on choices intake has not made yet, so check them the moment the table's
-shape is known, and before writing anything.
+| Path | Credential | Authenticates |
+| --- | --- | --- |
+| Cloud inference | `NVIDIA_API_KEY` | the API calls |
+| NIM on a workstation | `NVIDIA_API_KEY` | the `nvcr.io` image pull |
+| vLLM plus NeMo-Speech.cpp, any host | `HF_TOKEN` | the LLM weights and the speech GGUFs |
+| LiveKit, cloud or self-hosted | `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` | the room connection |
 
-| Also required | When |
-| --- | --- |
-| `HF_TOKEN` | local raw vLLM pulls from Hugging Face, including Jetson Thor and any workstation / DGX Omni path whose locked source is Hugging Face |
-| `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` | any LiveKit run, cloud or self-hosted |
+The single-GPU stack needs no `NVIDIA_API_KEY`, because everything it downloads comes from
+Hugging Face and its speech container pulls from `nvcr.io` without NGC authentication.
+Confirm that on the container's current NGC page, and stop on a registry authentication
+failure rather than retrying.
+
+A hybrid layout needs both model keys, one per placement. Ask for them together.
 
 Check the shell environment first, then `.env`. A key exported in the shell counts even
 when there is no `.env` file at all. Parse `.env`, never source it. Count a key as missing
@@ -82,8 +234,8 @@ it is set. Ask for every missing key in one message rather than one at a time.
 
 | Key | Where the user gets it |
 | --- | --- |
-| `NVIDIA_API_KEY` | [NVIDIA API key settings](https://build.nvidia.com/settings/api-keys), starts with `nvapi-`, shown once |
-| `HF_TOKEN` | Hugging Face settings, access tokens, read access is enough |
+| `NVIDIA_API_KEY` | [NVIDIA API key settings](https://build.nvidia.com/settings/api-keys). Ask the user to set it locally and confirm only |
+| `HF_TOKEN` | Hugging Face settings. A read-scoped token is enough |
 | `LIVEKIT_*` | the `lk cloud auth` browser flow, or project settings, API keys, create key |
 
 Fetch the LiveKit steps from the LiveKit documentation MCP before answering, because that
@@ -96,43 +248,81 @@ never put model ids or endpoints in `.env`, which holds secrets only.
 ## 4. Deployment Fit
 
 During proposal, set the intake **Deployment** row from usable VRAM. Model weights are
-planning hints, not service footprints. Authoritative speech VRAM comes from the selected
-matrix profiles. The LLM support matrix supplies the proposal candidate. Post-approval
-`list-model-profiles` confirms the exact profile. Runtime memory also includes KV cache,
+planning hints, not service footprints. Runtime memory also includes KV cache,
 activations, CUDA graphs, and engine overhead.
 
-For `no_gpu` or `unsupported_edge`, set Deployment to cloud and skip local fit.
-Jetson Thor uses `platforms/jetson-thor.md`. DGX Spark uses
-`platforms/dgx-spark.md` and available unified memory. Neither uses a fixed workstation
-VRAM threshold.
+Host class chooses the local stack. On a workstation, expected concurrency chooses between
+two:
 
-For a workstation, build a runtime budget before approving co-location:
+| Host class | Local stack | Fit method |
+| --- | --- | --- |
+| `workstation`, one user or a few concurrent sessions | vLLM plus NeMo-Speech.cpp | `platforms/single-gpu.md` §Memory |
+| `workstation`, many users and higher concurrency | NIM for LLM, ASR, and TTS | §NIM budget below |
+| `dgx_spark` | vLLM plus NeMo-Speech.cpp | `platforms/dgx-spark.md` and `platforms/single-gpu.md` §Memory |
+| `jetson_thor` | vLLM plus NeMo-Speech.cpp | `platforms/jetson-thor.md` and `platforms/single-gpu.md` §Memory |
+| `no_gpu`, `unsupported_edge` | none | cloud, skip local fit |
 
-1. select a candidate Compatible LLM quantization profile from the support matrix.
-   Post-approval `list-model-profiles` pins the exact profile
+NIM is the workstation path for serving many users, because it is built for throughput and
+scale-out. DGX Spark and Jetson Thor have no NIM path and no VRAM threshold, because both
+run one shared unified-memory pool.
+
+Infer concurrency from the use case and state the assumption in the Deployment row, so the
+user amends one row rather than answering another question. A personal assistant, a demo, a
+developer workstation, or an on-device agent is low concurrency. A contact centre, a shared
+service, or a stated user count is high. When the use case does not say, propose the
+single-GPU stack and name the scale at which NIM becomes the better choice.
+
+### NIM Budget
+
+Authoritative speech VRAM comes from the selected Speech matrix profiles. The model service
+uses the LLM NIM matrix for a Cascaded LLM and the VLM NIM matrix for Omni. Its
+post-approval `list-model-profiles` confirms the exact profile. Build the budget before
+approving co-location:
+
+1. select a candidate Compatible model profile from the correct NIM support matrix.
+   Post-approval `list-model-profiles` from that NIM image pins the exact profile
 2. reserve the selected ASR matrix GPU memory
 3. reserve the selected TTS batch profile GPU memory
 4. reserve GPU memory for the framework, CUDA, service startup, and engine build
-5. give only the remainder to the LLM runtime, including weights and KV cache
+5. give only the remainder to the model runtime, including weights and KV cache
 
 That budget is a hard gate, and the arithmetic must pass before anything starts:
 
 ```text
-llm_weights + llm_kv_and_activations + tts_vram + asr_vram + startup_overhead
+model_weights + model_kv_and_activations + tts_vram + asr_vram + startup_overhead
     <= free VRAM measured now
 ```
 
-Omni omits the ASR term, so its stack is Omni + TTS. Hybrid counts only the slots assigned
-to this GPU, because cloud slots consume no local VRAM. If the sum does not fit, change the
-profile, the TTS batch profile, or the placement. Do not start the stack and let the last
-service discover the shortfall as an OOM.
+Omni omits the ASR term, so its stack is Omni plus TTS. Hybrid counts only the slots
+assigned to this GPU, because cloud slots consume no local VRAM. If the sum does not fit,
+change the profile, the TTS batch profile, or the placement. Do not start the stack and
+let the last service discover the shortfall as an OOM.
 
-Recalculate whenever profile, context length, TTS batch size, or slot placement changes.
+Use a Compatible NVFP4 profile when the selected service's matrix offers one. Otherwise,
+use the next compatible precision from that matrix. Do not transfer a precision or memory
+estimate between the LLM NIM and VLM NIM families.
 
-Weight estimates alone can support only `provisional co-location`, never the final
-`self-hosted, co-located` status. Before generating Compose, lock the LLM profile and
-memory controls from `models/llm.md` plus the TTS batch profile from `models/tts.md`.
-Require the Shared-GPU memory gate in `platforms/deployment.md`.
+For every shared workstation NIM GPU, set the controls in `models/llm.md` (profile,
+context, runtime memory cap) and `models/tts.md` (explicit batch profile). Require the
+Shared-GPU memory gate in `platforms/deployment.md`.
+
+Higher concurrency raises the reserve on every slot, because it adds LLM KV cache and
+needs a larger ASR and TTS batch profile. Size those profiles for the concurrency the
+Deployment row assumes, and recalculate the budget when that assumption changes.
+
+### Shared Rules
+
+Recalculate whenever profile, precision, context length, TTS batch size, or slot placement
+changes. Re-read this section whenever a slot moves GPU or to cloud, or the user asks why
+something will not fit.
+
+Estimates alone can support only `provisional co-location`, never the final
+`self-hosted, co-located` status. That status requires the measured gate for the routed
+stack, which is `platforms/deployment.md` §Shared-GPU memory gate on the workstation NIM
+path and `platforms/single-gpu.md` §Start and verify on the single-GPU path.
+
+Before recording anything below `self-hosted`, confirm the shortfall is real rather than
+reclaimable (§Find out what is holding the memory).
 
 | Fit result | Deployment row |
 | --- | --- |
@@ -141,12 +331,6 @@ Require the Shared-GPU memory gate in `platforms/deployment.md`.
 | Only some slots fit | hybrid, name each cloud slot |
 | No local layout fits | cloud |
 
-Use a Compatible NVFP4 profile when available. Otherwise, use the next compatible precision from `models/llm.md`. Do not apply a heavier-precision estimate after selecting NVFP4.
-
-For every shared single-GPU layout, use the controls in `models/llm.md` (profile, context,
-runtime memory cap) and `models/tts.md` (explicit batch profile). Re-read this section
-whenever a slot moves GPU or to cloud, or the user asks why something will not fit.
-
 Host GPU detection is not container readiness. After self-hosting is approved and before
 pulling an image, require Docker, Compose, NVIDIA Container Toolkit, in-container GPU
 visibility, and writable cache paths through `platforms/readiness.md`.
@@ -154,10 +338,24 @@ visibility, and writable cache paths through `platforms/readiness.md`.
 ## Anti-Patterns
 
 - Asking whether to use cloud or self-hosted before probing.
+- Combining `compute_cap` with the memory fields in one query, which discards the whole
+  result on a driver that does not know the field.
+- Recording `no_gpu` from a failed probe without the Stage 5 evidence.
+- Presenting cloud as the only option to hide a detection failure.
+- Reading a derived compute capability as a confirmed one.
 - Offering a deployment choice on a machine with no GPU.
-- Routing unsupported ARM64 edge hardware to workstation NIM images.
-- Reporting nameplate VRAM instead of what is actually free.
+- Routing DGX Spark or Jetson Thor to NIM images, or unsupported edge hardware to any
+  local stack.
+- Proposing NIM for a single-user workstation agent, or the single-GPU stack for a
+  high-concurrency service, without saying which assumption drove it.
+- Reporting nameplate VRAM instead of what is actually free, or treating unified memory as
+  dedicated VRAM.
+- Reporting low free VRAM without saying what is holding the rest.
+- Downgrading the model, the quantization, the context, or the placement to fit around a
+  stale container the user would have stopped.
+- Stopping, killing, or pruning anything the user did not approve by name.
+- Building the budget from the pre-reclaim number after a container was stopped.
 - Approving co-location from model weights without budgeting KV cache and service startup.
-- Leaving the LLM runtime memory cap or TTS batch profile implicit on a shared GPU.
+- Leaving the LLM runtime memory control or TTS batch profile implicit on a shared GPU.
 - Generating files before checking credentials.
 - Treating an `.env.example` placeholder as a real key.


### PR DESCRIPTION
## Summary
- route DGX Spark, Jetson Thor, and low-concurrency workstations through vLLM with NeMo-Speech.cpp
- retain NIM for high-concurrency workstations with distinct LLM, VLM Omni, and Speech NIM source guidance
- strengthen GPU detection, memory reclamation, quantization checks, reasoning controls, and generated-project verification
- keep the root skill lean while consolidating shared single-GPU guidance

## Test plan
- [x] Validate Markdown file and section cross-references
- [x] Check edited skill files for linter diagnostics
- [x] Verify no semicolons or sentence-interrupting dashes remain in skill prose
- [x] Verify current NVIDIA model, API, VLM NIM, and Pipecat documentation links used by the new routing
- [ ] Run reviewer pass against the complete PR diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-GPU voice-agent deployment guidance using vLLM and NeMo-Speech.cpp.
  * Added clearer routing for Cascaded LLM and Omni pipelines across deployment options.
  * Added concurrency-aware sizing, memory planning, readiness checks, and audio verification.
  * Added ARM64 and remote WebRTC guidance for DGX Spark and Jetson Thor.

* **Documentation**
  * Updated speech, language, deployment, startup, troubleshooting, and framework guidance.
  * Clarified supported voices, languages, pronunciation controls, and service readiness.

* **Tests**
  * Added evaluation coverage for routing, hardware, deployment, networking, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->