### PR TITLE
fix: Remove mean from perf eval

### DIFF
--- a/docs/04-evaluation-and-performance.md
+++ b/docs/04-evaluation-and-performance.md
@@ -23,7 +23,6 @@ The reference performance benchmark measures the Nemotron Voice Agent on a dedic
 | 16 | 0.86 | 0.49 | 0.34 | 0.13 | 0.08 |
 | 32 | 0.9 | 0.48 | 0.37 | 0.13 | 0.09 |
 | 64 | 0.93 | 0.49 | 0.4 | 0.13 | 0.1 |
-| Mean | 0.89 | 0.49 | 0.38 | 0.16 | 0.08 |
 
 *E2E: End-to-End · TTFB: Time to First Byte · TTFT: Time to First Token*
 


### PR DESCRIPTION
Remove mean from perf eval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the aggregate “Mean” row from the latency and scalability reference-results table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->