### PR TITLE
Fix/frontend backend deterministic guards v2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,3 +228,4 @@ services:
     environment:
       <<: *app-env
       EXAMPLE_SELECTION: ${EXAMPLE_SELECTION:-frontend-backend-agent}
+      THINKER_TOOL_TIMEOUT_SECONDS: ${THINKER_TOOL_TIMEOUT_SECONDS:-90}

--- a/docker/docker-compose.nemotron35-lightning.yaml
+++ b/docker/docker-compose.nemotron35-lightning.yaml
@@ -40,12 +40,14 @@ x-vllm-lightning: &vllm-lightning
       max-file: "5"
 
 services:
-  nvidia-llm-vllm-lightning:
+  nvidia-llm-vllm-lightning: &vllm-lightning-service
     <<: *vllm-lightning
     profiles:
       - generic-assistant/single-gpu
       - multilingual-assistant/single-gpu
-      - frontend-backend-agent/single-gpu
+    environment:
+      FLASHINFER_DISABLE_VERSION_CHECK: "1"
+      VLLM_USE_V2_MODEL_RUNNER: "1"
     command:
       - |
         args=(
@@ -73,16 +75,22 @@ services:
 
         auto_gpu_memory=1
         if [[ "$${gpu_name}" == *"NVIDIA GB10"* || "$${dmi_product}" == *"DGX_Spark"* ]]; then
-          echo "LLM recipe: DGX Spark / NVFP4 / DSpark"
           auto_gpu_memory=0
           model=nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
           args+=(
             --gpu-memory-utilization 0.35
             --moe-backend marlin
             --kv-cache-dtype fp8
-            --speculative_config.model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark
-            --speculative_config.num_speculative_tokens 3
           )
+          if [[ "$${VLLM_USE_V2_MODEL_RUNNER}" == "0" ]]; then
+            echo "LLM recipe: DGX Spark / NVFP4 / Model Runner V1"
+          else
+            echo "LLM recipe: DGX Spark / NVFP4 / DSpark"
+            args+=(
+              --speculative_config.model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark
+              --speculative_config.num_speculative_tokens 3
+            )
+          fi
         elif [[ "$${device_model}" == *"Jetson"* && "$${device_model}" == *"Thor"* ]] ||
              [[ "$${dmi_product}" == *"Jetson"* && "$${dmi_product}" == *"Thor"* ]]; then
           echo "LLM recipe: Jetson Thor / NVFP4"
@@ -90,16 +98,22 @@ services:
           model=nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
           args+=(--gpu-memory-utilization 0.35 --moe-backend marlin --kv-cache-dtype fp8 --async-scheduling)
         elif [[ "$${compute_major}" =~ ^[0-9]+$ ]] && (( compute_major >= 10 )); then
-          echo "LLM recipe: Blackwell workstation / NVFP4 / DFlash"
           model=nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
           args+=(
             --moe-backend marlin
             --kv-cache-dtype fp8
             --async-scheduling
-            --speculative_config.method dflash
-            --speculative_config.model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DFlash
-            --speculative_config.num_speculative_tokens 3
           )
+          if [[ "$${VLLM_USE_V2_MODEL_RUNNER}" == "0" ]]; then
+            echo "LLM recipe: Blackwell workstation / NVFP4 / Model Runner V1"
+          else
+            echo "LLM recipe: Blackwell workstation / NVFP4 / DFlash"
+            args+=(
+              --speculative_config.method dflash
+              --speculative_config.model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DFlash
+              --speculative_config.num_speculative_tokens 3
+            )
+          fi
         elif [[ "$${compute_major}" == "9" ]] ||
              [[ "$${compute_major}" == "8" && "$${compute_minor}" =~ ^[0-9]+$ && "$${compute_minor}" -ge 9 ]]; then
           echo "LLM recipe: Hopper/Ada workstation / NVFP4 W4A16 via Marlin"
@@ -143,6 +157,20 @@ services:
       default:
         aliases:
           - nvidia-llm-vllm
+
+  nvidia-llm-vllm-lightning-frontend-backend:
+    <<: *vllm-lightning-service
+    profiles:
+      - frontend-backend-agent/single-gpu
+    environment:
+      FLASHINFER_DISABLE_VERSION_CHECK: "1"
+      VLLM_USE_V2_MODEL_RUNNER: "0"
+    ports:
+      - "18001:8000"
+    networks:
+      default:
+        aliases:
+          - nvidia-llm-vllm-frontend-backend
 
 volumes:
   llm_cache:

--- a/src/examples/frontend_backend_agent/README.md
+++ b/src/examples/frontend_backend_agent/README.md
@@ -6,6 +6,8 @@ The frontend LLM is the only user-facing LLM and exposes `call_backend` plus `ca
 
 The airline backend agent is the reference backend, but the architecture is reusable: treat the frontend LLM as a generic conversational layer in front of another backend agent that exposes compatible call/cancel behavior. Booking is intentionally gated, so the user must search flights first and select one returned flight before the backend agent can continue booking.
 
+The example validates known past travel dates before it invokes the backend agent. It asks the user for a future date without waiting for planning or backend tools. If planning fails, the example limits retries and then returns a terminal user-facing error instead of repeatedly delegating the same request. The initial synthetic greeting runs with tool execution disabled, so it cannot invoke the backend agent; normal tool behavior resumes for user turns.
+
 ![Frontend/Backend Agent architecture](images/frontend-backend-agent-architecture.png)
 
 The diagram shows the full runtime path. User audio enters through the WebRTC/WebSocket transport, audio input processing produces a user transcript for the frontend LLM, the frontend LLM sends rephrased task requirements to the backend agent, and backend results return to the frontend LLM before audio output is synthesized and played back.
@@ -20,11 +22,13 @@ The defaults in [`examples_registry.yaml`](../../../examples_registry.yaml) reso
 | Server | Nemotron ASR Streaming English NIM | Nemotron 3.5 Lightning 30B A3B NIM | Nemotron 3.5 Lightning 30B A3B NIM with reasoning enabled | Magpie TTS Multilingual NIM |
 | Single GPU | Nemotron Speech Streaming English 0.6B through NeMo-Speech.cpp | Nemotron 3.5 Lightning 30B A3B through vLLM | Nemotron 3.5 Lightning 30B A3B through vLLM with reasoning enabled | Magpie TTS Multilingual through NeMo-Speech.cpp |
 
-The Talker and Thinker use the same model weights with different runtime settings. The Talker disables reasoning for lower latency, while the Thinker enables reasoning with a 1,024-token budget.
+The Talker and Thinker use the same model weights with different runtime settings. The Talker disables reasoning for lower latency. The Cloud and Server Thinkers enable reasoning with a 1,024-token budget. The Single GPU Thinker runs on its dedicated Model Runner V1 service with `thinking_token_budget=1024` and `max_tokens=4096`.
 
 ## Running the example
 
 This example runs with **Cloud**, **Server** (NIM, recommended for scaling), and universal **Single GPU** profiles. Server is workstation-only (not DGX Spark or Jetson Thor). The single-gpu profile covers workstations, DGX Spark, and Jetson Thor. See the [Getting Started guide](../../../docs/01-getting-started.md) for prerequisites and hardware detail. Run every command from the repository root.
+
+> **Known limitation:** The `frontend-backend-agent/single-gpu` profile currently shows a conversational-experience regression compared with Cloud and Server deployments, including longer backend-planning pauses.
 
 1. Preserve any existing `.env` file. Otherwise, copy the template, and then set `NVIDIA_API_KEY` in `.env` for the Cloud or Server profile:
 
@@ -56,7 +60,7 @@ This example runs with **Cloud**, **Server** (NIM, recommended for scaling), and
    | --- | --- | --- |
    | `frontend-backend-agent` | `frontend-backend-agent` | `booking-server` |
    | `frontend-backend-agent/server` | `frontend-backend-agent-server` | `booking-server`, `nvidia-llm`, `nemotron-asr-streaming-english`, `magpie-multilingual-tts-service` |
-   | `frontend-backend-agent/single-gpu` | `frontend-backend-agent-single-gpu` | `booking-server`, `nvidia-llm-vllm-lightning`, `nemo-speech` |
+   | `frontend-backend-agent/single-gpu` | `frontend-backend-agent-single-gpu` | `booking-server`, `nvidia-llm-vllm-lightning-frontend-backend`, `nemo-speech` |
 
 4. Open the UI at `https://localhost:7860/`. Keep TLS enabled for browser UI testing. `PIPELINE_TLS=false` serves plain HTTP for headless performance and API testing. For plain-HTTP browser testing, see [browser access](../../../docs/06-troubleshooting.md#browser-access).
 
@@ -89,7 +93,9 @@ Reusable Frontend/Backend Agent helpers live under `src/`, airline flight-bookin
 | --- | --- | --- |
 | `CHAT_HISTORY_RECENT_TURNS` | `20` | Number of recent non-prompt messages retained in the frontend LLM context window |
 | `THINKER_FILLER_THRESHOLD_SECONDS` | `0.3` | Delay before optional `call_backend.filler_text` is spoken while backend work is still running |
-| `THINKER_TOOL_TIMEOUT_SECONDS` | `30.0` | Timeout for `call_backend` / `cancel_backend` tool handlers |
+| `THINKER_TOOL_TIMEOUT_SECONDS` | `30.0` (`90` for single-GPU Compose) | Timeout for `call_backend` / `cancel_backend` tool handlers |
+
+The single-GPU profile uses a dedicated Model Runner V1 service, separate from the V2 service used by the generic and multilingual profiles. The Thinker sets `thinking_token_budget=1024` and `max_tokens=4096`, while the single-GPU Compose profile gives backend tool calls 90 seconds to complete. The numeric thinking budget requires Model Runner V1 in vLLM 0.27.1.
 
 For model, prompt, and catalog configuration, see [Configure LLM](../../../docs/how-to/configure-llm.md), [Configure Prompts](../../../docs/how-to/configure-prompts.md), and [Configure Services](../../../docs/how-to/configure-services.md). For deployment and general failure modes, see the [Troubleshooting guide](../../../docs/06-troubleshooting.md).
 
@@ -114,7 +120,10 @@ Prompt edits can silently break the architecture contract. After changing the fr
 - Frontend LLM calls `call_backend` for flight search, booking continuation, flight selection, passenger details, seat or meal preferences, confirmations, corrections, and PNR-status requests.
 - Frontend LLM calls `cancel_backend` for stop, cancel, never-mind requests, and topic switches while flight work is pending.
 - Frontend LLM does not call tools for greetings, thanks, or small talk when no flight task is pending.
+- The initial greeting does not call `call_backend` or `cancel_backend`.
 - Backend agent calls `flight_search` only when required route and date details are available.
+- Known past travel dates return a future-date request without invoking the backend agent.
 - Backend agent calls `booking` only after a searched flight has been selected.
 - Backend agent calls `pnr_status` for PNR, record-locator, or booking-status requests.
 - Backend agent returns `response_hint` for missing information or unsupported requests instead of inventing backend results.
+- Planner failures stop after two total attempts (the initial attempt and one retry) and return a terminal response rather than causing repeated backend calls.

--- a/src/examples/frontend_backend_agent/pipeline.py
+++ b/src/examples/frontend_backend_agent/pipeline.py
@@ -171,15 +171,17 @@ async def bot(runner_args: RunnerArguments) -> None:
     booking_backend_url = _booking_backend_url(default_booking_server)
     thinker_model_id = body.get("thinker_model_id", "") or default_thinker_llm.get("model_id", "") or model_id
     thinker_base_url = body.get("thinker_base_url", "") or default_thinker_llm.get("base_url", "") or base_url
-    thinker_max_tokens = _parse_optional_int(
-        body.get("thinker_max_tokens", "") or default_thinker_llm.get("max_tokens"),
-        4096,
+    thinker_max_tokens_raw = body.get("thinker_max_tokens", "") or default_thinker_llm.get("max_tokens")
+    thinker_max_tokens = (
+        _parse_optional_int(thinker_max_tokens_raw, 4096) if thinker_max_tokens_raw not in (None, "") else None
     )
     thinker_extra_params = parse_json_dict(
         body.get("thinker_extra_params", "") or default_thinker_llm.get("extra_params", ""),
         label="thinker_extra_params",
     )
-    thinker_llm_settings = NvidiaLLMSettings(model=thinker_model_id, max_tokens=thinker_max_tokens)
+    thinker_llm_settings = NvidiaLLMSettings(model=thinker_model_id)
+    if thinker_max_tokens is not None:
+        thinker_llm_settings.max_tokens = thinker_max_tokens
     if thinker_extra_params:
         thinker_llm_settings.extra = thinker_extra_params
     thinker_llm = NvidiaLLMService(
@@ -337,8 +339,10 @@ async def bot(runner_args: RunnerArguments) -> None:
         runner_args=runner_args,
         intro_prompt=(
             "This is an initial direct greeting, not a flight request. Do not call any tools. "
-            "Greet the user briefly as Ava, the G Force Airlines flight-booking assistant."
+            "Greet the user briefly as Ava, the G Force Airlines flight-booking assistant. "
+            "Respond directly with spoken text and do not call call_backend or cancel_backend."
         ),
+        intro_tool_choice="none",
         on_start=_on_session_start,
         welcome_enabled=welcome_enabled,
     )

--- a/src/examples/frontend_backend_agent/services.local.yaml
+++ b/src/examples/frontend_backend_agent/services.local.yaml
@@ -60,7 +60,7 @@ singlegpu:
     nemotron-lightning:
       name: "Nemotron 3.5 Lightning 30B A3B"
       model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
-      base_url: "http://nvidia-llm-vllm:8000/v1"
+      base_url: "http://nvidia-llm-vllm-frontend-backend:8000/v1"
       system_prompt: ""
       max_tokens: 2048
       extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":false},"repetition_penalty":1.05}}'
@@ -68,9 +68,9 @@ singlegpu:
     nemotron-lightning:
       name: "Nemotron 3.5 Lightning 30B A3B Thinker"
       model_id: "nvidia/nemotron-3.5-lightning-30b-a3b"
-      base_url: "http://nvidia-llm-vllm:8000/v1"
+      base_url: "http://nvidia-llm-vllm-frontend-backend:8000/v1"
       max_tokens: 4096
-      extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true},"reasoning_budget":1024,"repetition_penalty":1.05}}'
+      extra_params: '{"extra_body":{"chat_template_kwargs":{"enable_thinking":true},"thinking_token_budget":1024,"repetition_penalty":1.05}}'
   booking-server:
     default:
       name: "Booking Server"

--- a/src/examples/frontend_backend_agent/src/planner.py
+++ b/src/examples/frontend_backend_agent/src/planner.py
@@ -31,7 +31,7 @@ class NvidiaThinkerPlanner:
         *,
         llm: NvidiaLLMService,
         system_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
     ) -> None:
         """Create an NVIDIA-backed Thinker planner."""
         if not system_prompt.strip():

--- a/src/examples/frontend_backend_agent/src/tool_handlers.py
+++ b/src/examples/frontend_backend_agent/src/tool_handlers.py
@@ -8,15 +8,28 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Protocol
 
 from loguru import logger
 from pipecat.frames.frames import LLMFullResponseEndFrame, LLMFullResponseStartFrame, LLMTextFrame
 from pipecat.services.llm_service import FunctionCallResultProperties
 
-from examples.frontend_backend_agent.src.protocol import ThinkerLifecycleEvent, is_speakable_payload
+from examples.frontend_backend_agent.src.protocol import ThinkerLifecycleEvent, is_speakable_payload, response_hint
+from examples.frontend_backend_agent.src.runtime_context import runtime_today
+
+_ISO_DATE_PATTERN = re.compile(r"(?<!\d)(\d{4}-\d{2}-\d{2})(?!\d)")
+_NAMED_DATE_PATTERN = re.compile(
+    r"\b("
+    r"jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|"
+    r"jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?"
+    r")\s+(\d{1,2})(?:st|nd|rd|th)?(?:,\s*|\s+)(\d{4})\b",
+    re.IGNORECASE,
+)
+_MAX_PLANNER_ERROR_ATTEMPTS = 2
 
 if TYPE_CHECKING:
     from pipecat.services.llm_service import FunctionCallParams
@@ -43,11 +56,14 @@ class ThinkerBackend(Protocol):
 
 def build_handlers(thinker: ThinkerBackend, *, filler_threshold_seconds: float = 0.8) -> dict[str, Callable]:
     """Return tool handlers bound to one session-local backend agent."""
+    consecutive_planner_errors = 0
 
     async def handle_call_backend(params: FunctionCallParams) -> None:
+        nonlocal consecutive_planner_errors
         arguments = _normalize_arguments(params.arguments or {})
         query = str(arguments.get("query", "") or "").strip()
         if not query:
+            consecutive_planner_errors = 0
             await params.result_callback(
                 {
                     "type": "response_hint",
@@ -58,6 +74,20 @@ def build_handlers(thinker: ThinkerBackend, *, filler_threshold_seconds: float =
                     "context": "call_backend",
                 }
             )
+            return
+        past_date = _past_date_in_query(query)
+        if past_date is not None:
+            consecutive_planner_errors = 0
+            payload = response_hint(
+                reason="past_date",
+                action="request_future_date",
+                response_text=(
+                    f"{past_date.strftime('%B')} {past_date.day}, {past_date.year} has already passed. "
+                    "Please provide a future travel date."
+                ),
+                context="flight_search",
+            )
+            await _emit_terminal_payload(params, payload)
             return
         try:
             filler_text = str(arguments.get("filler_text", "") or "").strip()
@@ -91,6 +121,7 @@ def build_handlers(thinker: ThinkerBackend, *, filler_threshold_seconds: float =
             finally:
                 await _cancel_pending_filler(filler_task)
         except asyncio.CancelledError:
+            consecutive_planner_errors = 0
             logger.info("call_backend result suppressed after Thinker abort")
             await params.result_callback(
                 {
@@ -105,6 +136,7 @@ def build_handlers(thinker: ThinkerBackend, *, filler_threshold_seconds: float =
             )
             return
         except Exception as exc:
+            consecutive_planner_errors = 0
             logger.exception(f"call_backend failed before producing a result: {exc}")
             await params.result_callback(
                 {
@@ -117,6 +149,25 @@ def build_handlers(thinker: ThinkerBackend, *, filler_threshold_seconds: float =
                 }
             )
             return
+        if payload.get("reason") == "planner_error":
+            consecutive_planner_errors += 1
+            if consecutive_planner_errors >= _MAX_PLANNER_ERROR_ATTEMPTS:
+                logger.warning(f"Planner failed {_MAX_PLANNER_ERROR_ATTEMPTS} consecutive times; ending retries")
+                terminal_payload = dict(payload)
+                terminal_payload.update(
+                    {
+                        "reason": "planner_error_exhausted",
+                        "action": "answer_directly",
+                        "response_text": (
+                            "I could not process that request after a few attempts. Please try again later."
+                        ),
+                    }
+                )
+                await _emit_terminal_payload(params, terminal_payload)
+                consecutive_planner_errors = 0
+                return
+        else:
+            consecutive_planner_errors = 0
         if _direct_tool_response_enabled() and is_speakable_payload(payload):
             await _emit_talker_response(params.llm, str(payload.get("response_text") or ""))
             await params.result_callback(payload, properties=FunctionCallResultProperties(run_llm=False))
@@ -124,6 +175,8 @@ def build_handlers(thinker: ThinkerBackend, *, filler_threshold_seconds: float =
         await params.result_callback(payload)
 
     async def handle_cancel_backend(params: FunctionCallParams) -> None:
+        nonlocal consecutive_planner_errors
+        consecutive_planner_errors = 0
         cancelled = thinker.cancel_active("user_cancelled")
         cleared_pending_booking = thinker.cancel_pending_booking()
         did_cancel = cancelled or cleared_pending_booking
@@ -157,6 +210,12 @@ async def _emit_talker_response(llm, text: str) -> None:
             await llm.push_frame(LLMFullResponseEndFrame())
 
 
+async def _emit_terminal_payload(params: FunctionCallParams, payload: dict[str, Any]) -> None:
+    """Speak a validated terminal payload without asking the Talker to reinterpret it."""
+    await _emit_talker_response(params.llm, str(payload.get("response_text") or ""))
+    await params.result_callback(payload, properties=FunctionCallResultProperties(run_llm=False))
+
+
 async def _cancel_pending_filler(task: asyncio.Task | None) -> None:
     """Cancel a delayed filler if the Thinker returned before it fired."""
     if task is None or task.done():
@@ -177,6 +236,35 @@ def _normalize_arguments(arguments: dict) -> dict:
         if isinstance(decoded, dict):
             return decoded
     return arguments
+
+
+def _past_date_in_query(query: str, *, today: date | None = None) -> date | None:
+    """Return a past ISO travel date when the query contains no future date.
+
+    The Talker contract supplies known travel dates as ISO values. If a correction
+    contains both an old and a new date, the future date wins and the Thinker still
+    receives the request.
+    """
+    dates: list[date] = []
+    for match in _ISO_DATE_PATTERN.finditer(query):
+        try:
+            dates.append(date.fromisoformat(match.group(1)))
+        except ValueError:
+            continue
+    for match in _NAMED_DATE_PATTERN.finditer(query):
+        candidate = " ".join(match.groups())
+        for date_format in ("%B %d %Y", "%b %d %Y"):
+            try:
+                dates.append(datetime.strptime(candidate, date_format).date())
+                break
+            except ValueError:
+                continue
+    if not dates:
+        return None
+    today = today or runtime_today()
+    if any(value >= today for value in dates):
+        return None
+    return max(dates)
 
 
 def _direct_tool_response_enabled() -> bool:

--- a/src/examples/shared/pipeline_utils.py
+++ b/src/examples/shared/pipeline_utils.py
@@ -104,16 +104,19 @@ def register_session_start_handlers(
     context,
     runner_args: RunnerArguments,
     intro_prompt: str = "Please introduce yourself to the user.",
+    intro_tool_choice: str | None = None,
     on_start=None,
     welcome_enabled: bool = True,
 ) -> None:
     """Start the session using the correct signal for the wire protocol.
 
     RTVI/WebRTC uses ``on_client_ready``; Realtime uses ``on_client_connected``.
-    Both share the same optional ``on_start`` + welcome intro path. When welcome
-    is off, skip the intro and (on Realtime) open the client text gate.
+    Both share the same optional ``on_start`` + welcome intro path. Set
+    ``intro_tool_choice`` for a one-off greeting context without changing the
+    shared context's tool behavior for subsequent user turns. When welcome is
+    off, skip the intro and (on Realtime) open the client text gate.
     """
-    from pipecat.frames.frames import LLMRunFrame
+    from pipecat.frames.frames import LLMContextFrame, LLMRunFrame
 
     started = False
 
@@ -129,7 +132,16 @@ def register_session_start_handlers(
             logger.info("Welcome message disabled; waiting for the user to speak first")
             return
         context.add_message({"role": "user", "content": intro_prompt})
-        await task.queue_frames([LLMRunFrame()])
+        if intro_tool_choice is None:
+            run_frame = LLMRunFrame()
+        else:
+            intro_context = LLMContext(
+                messages=list(context.get_messages()),
+                tools=context.tools,
+                tool_choice=intro_tool_choice,
+            )
+            run_frame = LLMContextFrame(context=intro_context)
+        await task.queue_frames([run_frame])
 
     if runner_protocol(runner_args) == "realtime":
         if not welcome_enabled:

--- a/tests/unit/test_frontend_backend_agent.py
+++ b/tests/unit/test_frontend_backend_agent.py
@@ -254,6 +254,36 @@ class _RaisingThinker:
         return False
 
 
+class _PlannerErrorThinker:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def call(self, query: str, slots: dict[str, Any] | None = None, *, on_started=None) -> dict[str, Any]:
+        self.calls += 1
+        return {
+            "type": "response_hint",
+            "reason": "planner_error",
+            "action": "retry",
+            "response_text": "I could not plan that request. Could you say it again?",
+            "context": "general",
+        }
+
+    def cancel_active(self, reason: str = "new_user_query") -> bool:
+        return False
+
+    def cancel_pending_booking(self) -> bool:
+        return False
+
+
+class _PlannerErrorWithTerminalPathsThinker(_PlannerErrorThinker):
+    async def call(self, query: str, slots: dict[str, Any] | None = None, *, on_started=None) -> dict[str, Any]:
+        if query == "raise":
+            raise RuntimeError("thinker exploded")
+        if query == "abort":
+            raise asyncio.CancelledError
+        return await super().call(query, slots, on_started=on_started)
+
+
 class _FrameCapturingLLM:
     def __init__(self) -> None:
         self.frames = []
@@ -265,9 +295,11 @@ class _FrameCapturingLLM:
 class _InferenceCapturingLLM:
     def __init__(self) -> None:
         self.messages: list[dict[str, Any]] = []
+        self.max_tokens: int | None = -1
 
     async def run_inference(self, context, max_tokens=None) -> str:
         self.messages = list(context.get_messages())
+        self.max_tokens = max_tokens
         return json.dumps(
             {
                 "tool": "response_hint",
@@ -463,6 +495,7 @@ class FrontendBackendAgentTests(unittest.IsolatedAsyncioTestCase):
             user_payload["runtime_context"],
             {"today": today.isoformat(), "tomorrow": tomorrow.isoformat()},
         )
+        self.assertIsNone(llm.max_tokens)
 
     async def test_thinker_started_is_internal_only_while_response_hint_is_speakable(self) -> None:
         thinker = _make_thinker()
@@ -1004,6 +1037,113 @@ class FrontendBackendAgentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(results[-1][0]["type"], "response_hint")
         self.assertEqual(results[-1][0]["reason"], "tool_error")
         self.assertIn("try again", results[-1][0]["response_text"].lower())
+
+    async def test_call_backend_rejects_past_iso_date_without_calling_thinker(self) -> None:
+        llm = _FrameCapturingLLM()
+        results = []
+
+        async def result_callback(result, *, properties=None) -> None:
+            results.append((result, properties))
+
+        params = FunctionCallParams(
+            function_name="call_backend",
+            tool_call_id="past_date",
+            arguments={"query": "Book a flight from JFK to SEA on September 1, 2026."},
+            llm=llm,
+            pipeline_worker=None,
+            context=None,
+            result_callback=result_callback,
+        )
+
+        with patch.dict("os.environ", {"FRONTEND_BACKEND_AGENT_TODAY": "2026-09-07"}):
+            await build_handlers(_RaisingThinker())["call_backend"](params)
+
+        self.assertEqual(results[-1][0]["reason"], "past_date")
+        self.assertFalse(results[-1][1].run_llm)
+        self.assertEqual(llm.frames[1].text, results[-1][0]["response_text"])
+
+    async def test_call_backend_stops_planner_errors_after_initial_attempt_and_one_retry(self) -> None:
+        thinker = _PlannerErrorThinker()
+        llm = _FrameCapturingLLM()
+        results = []
+
+        async def result_callback(result, *, properties=None) -> None:
+            results.append((result, properties))
+
+        handler = build_handlers(thinker)["call_backend"]
+        for attempt in range(2):
+            params = FunctionCallParams(
+                function_name="call_backend",
+                tool_call_id=f"planner_error_{attempt}",
+                arguments={"query": "Search flights from New York to Seattle tomorrow."},
+                llm=llm,
+                pipeline_worker=None,
+                context=None,
+                result_callback=result_callback,
+            )
+            await handler(params)
+
+        self.assertEqual(thinker.calls, 2)
+        self.assertEqual(results[0][0]["reason"], "planner_error")
+        self.assertEqual(results[1][0]["reason"], "planner_error_exhausted")
+        self.assertFalse(results[1][1].run_llm)
+        self.assertEqual(llm.frames[1].text, results[1][0]["response_text"])
+
+    async def test_non_planner_terminal_paths_reset_planner_error_retries(self) -> None:
+        thinker = _PlannerErrorWithTerminalPathsThinker()
+        results = []
+
+        async def result_callback(result, *, properties=None) -> None:
+            results.append((result, properties))
+
+        handlers = build_handlers(thinker)
+
+        async def call_backend(query: str | None) -> str:
+            params = FunctionCallParams(
+                function_name="call_backend",
+                tool_call_id=f"call_{len(results)}",
+                arguments={} if query is None else {"query": query},
+                llm=_FrameCapturingLLM(),
+                pipeline_worker=None,
+                context=None,
+                result_callback=result_callback,
+            )
+            await handlers["call_backend"](params)
+            return results[-1][0]["reason"]
+
+        async def assert_first_planner_error() -> None:
+            reason = await call_backend("Search flights from New York to Seattle tomorrow.")
+            self.assertEqual(reason, "planner_error")
+
+        await assert_first_planner_error()
+        self.assertEqual(await call_backend(None), "params_missing")
+        await assert_first_planner_error()
+
+        with patch.dict("os.environ", {"FRONTEND_BACKEND_AGENT_TODAY": "2026-09-07"}):
+            self.assertEqual(
+                await call_backend("Book a flight from JFK to SEA on September 1, 2026."),
+                "past_date",
+            )
+        await assert_first_planner_error()
+
+        self.assertEqual(await call_backend("raise"), "tool_error")
+        await assert_first_planner_error()
+
+        cancel_params = FunctionCallParams(
+            function_name="cancel_backend",
+            tool_call_id="cancel_reset",
+            arguments={},
+            llm=_FrameCapturingLLM(),
+            pipeline_worker=None,
+            context=None,
+            result_callback=result_callback,
+        )
+        await handlers["cancel_backend"](cancel_params)
+        self.assertEqual(results[-1][0]["reason"], "nothing_to_cancel")
+        await assert_first_planner_error()
+
+        self.assertEqual(await call_backend("abort"), "aborted")
+        await assert_first_planner_error()
 
     async def test_cancel_backend_cancels_active_call_and_suppresses_stale_result(self) -> None:
         thinker = _make_thinker(tool_delay_seconds=1.0)

--- a/tests/unit/test_realtime_transcripts_control.py
+++ b/tests/unit/test_realtime_transcripts_control.py
@@ -11,13 +11,14 @@ import asyncio
 import json
 import unittest
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     InterimTranscriptionFrame,
     InterruptionFrame,
+    LLMContextFrame,
     LLMMessagesAppendFrame,
     LLMRunFrame,
     TranscriptionFrame,
@@ -25,6 +26,7 @@ from pipecat.frames.frames import (
     TTSTextFrame,
 )
 from pipecat.observers.base_observer import FramePushed
+from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.utils.text.base_text_aggregator import AggregationType
@@ -1191,6 +1193,50 @@ class WelcomeGateAlignmentTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIsInstance(frame, LLMMessagesAppendFrame)
         self.assertEqual(emitted[0]["type"], "conversation.item.created")
+
+    async def test_register_handlers_uses_isolated_no_tool_welcome_context(self) -> None:
+        from examples.frontend_backend_agent.airline.tools import TOOLS_SCHEMA
+        from examples.shared.pipeline_utils import register_session_start_handlers
+
+        class _Transport:
+            def __init__(self) -> None:
+                self.handlers: dict[str, Any] = {}
+
+            def event_handler(self, name: str):
+                def decorator(fn):
+                    self.handlers[name] = fn
+                    return fn
+
+                return decorator
+
+        transport = _Transport()
+        task = MagicMock()
+        task.queue_frames = AsyncMock()
+        context = LLMContext(
+            messages=[{"role": "system", "content": "Use tools for flight requests."}],
+            tools=TOOLS_SCHEMA,
+            tool_choice="auto",
+        )
+        runner_args = MagicMock()
+        runner_args.body = {"protocol": "realtime"}
+
+        register_session_start_handlers(
+            transport=transport,
+            task=task,
+            context=context,
+            runner_args=runner_args,
+            intro_prompt="Greet without tools.",
+            intro_tool_choice="none",
+        )
+        await transport.handlers["on_client_connected"](None, None)
+
+        queued_frames = task.queue_frames.await_args.args[0]
+        self.assertEqual(len(queued_frames), 1)
+        self.assertIsInstance(queued_frames[0], LLMContextFrame)
+        self.assertEqual(queued_frames[0].context.tool_choice, "none")
+        self.assertIs(queued_frames[0].context.tools, TOOLS_SCHEMA)
+        self.assertEqual(context.tool_choice, "auto")
+        self.assertEqual(context.messages[-1], {"role": "user", "content": "Greet without tools."})
 
     def test_register_handlers_opens_gate_when_welcome_disabled(self) -> None:
         from examples.shared.pipeline_utils import register_session_start_handlers


### PR DESCRIPTION
## Summary

Makes the frontend/backend flight-booking agent terminate invalid or repeatedly failing plans deterministically and keeps the single-GPU Thinker from truncating its final planner JSON.

Before this change, past-date requests could reach the backend, planner failures could leak retry state across unrelated requests, the synthetic greeting could dispatch tools, and the single-GPU Thinker could exhaust its 4,096-token completion limit before producing a final plan.

After this change, past dates return an immediate future-date request, planner errors stop after the initial attempt and one retry, every non-planner terminal path resets retry state, the greeting runs with tools disabled, and the single-GPU Thinker omits the completion-token limit with a 90-second tool timeout.

## Changes

- Reject travel requests containing only known past dates before invoking the backend.
- Limit consecutive planner failures to two attempts and emit a terminal response.
- Reset planner retry state on missing parameters, past dates, cancellation, abort, tool errors, and successful non-planner outcomes.
- Run the synthetic welcome with `tool_choice="none"` in an isolated context while retaining normal tool behavior for later user turns.
- Omit the single-GPU Thinker completion-token limit so reasoning can finish and emit planner JSON.
- Default the frontend/backend single-GPU tool timeout to 90 seconds.
- Document profile-specific Thinker limits and the possible latency/resource regression from unbounded generation.
- Add regression coverage for terminal retry boundaries and the no-tool greeting context.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:

## Documentation Writer Review

- [x] Documentation writer reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `src/examples/frontend_backend_agent/README.md` with profile-specific token-limit, timeout, greeting, retry, and regression guidance. Repository documentation hooks passed.
- Agent: Codex
<!-- docs-review-head-sha: 694e0c3 -->
<!-- docs-review-agents-blob-sha: b73fe32 -->

## Verification

- [x] Applicable lint, test, and build checks passed
- [x] Documentation validation passed for changed documentation
- [x] No secrets, API keys, or credentials are committed

Validation performed:

- `uv run --project . --group dev pre-commit run --files ...`
- `PYTHON_DOTENV_DISABLED=1 uv run pytest -q tests/unit/test_frontend_backend_agent.py tests/unit/test_realtime_transcripts_control.py` — 97 passed, 4 subtests passed
- `docker compose --profile frontend-backend-agent/single-gpu config --quiet`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for past travel dates with prompts to provide a future date.
  - Added bounded planner retries and terminal responses after repeated errors.
  - Improved initial greetings with spoken responses and no unintended tool actions.
  - Added configurable thinker token limits and tool timeouts.
  - Added isolated welcome contexts while preserving ongoing tool behavior.

- **Bug Fixes**
  - Retry state now resets after completed updates, cancellations, tool errors, or aborted requests.
  - Updated Single-GPU and frontend-backend runtime configurations for improved compatibility.

- **Documentation**
  - Documented date validation, retry behavior, greeting tool suppression, runtime settings, and known Single-GPU limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->