### PR TITLE
fix(omni): keep webcam summaries on the live scene

### DIFF
--- a/client/src/components/WebcamVisionPanel.tsx
+++ b/client/src/components/WebcamVisionPanel.tsx
@@ -43,7 +43,7 @@ const DEFAULT_WEBCAM_CONFIG: Required<WebcamConfig> = {
 };
 const IDLE_UPLOAD_STATE: WebcamUploadState = { mode: "idle", label: "" };
 const HIGHRES_JPEG_QUALITY = 0.92;
-const DEFAULT_CHUNK_SECONDS = 8;
+const DEFAULT_CHUNK_SECONDS = 2;
 
 function normalizeWebcamConfig(config: WebcamConfig): NormalizedWebcamConfig {
   return {
@@ -444,7 +444,7 @@ export function WebcamVisionPanel({ sessionId }: Readonly<{ sessionId: string }>
           <small className="webcam-status-label">{statusLabel}</small>
           {error && <small className="webcam-error">{error}</small>}
         </div>
-        <label className="webcam-chunk-control" title="Recent seconds sent to the model as one continuous video">
+        <label className="webcam-chunk-control" title="How many recent seconds of live video the webcam agent sees. Shorter keeps the summary on what is in frame now.">
           <span>Chunk</span>
           <select
             value={chunkSeconds}

--- a/notebooks/brev_launchable.ipynb
+++ b/notebooks/brev_launchable.ipynb
@@ -147,9 +147,7 @@
     "\n",
     "EXAMPLE_PROFILE = os.environ.get(\"EXAMPLE_PROFILE\", \"generic-assistant/single-gpu\")\n",
     "if EXAMPLE_PROFILE not in SUPPORTED_PROFILES:\n",
-    "    raise ValueError(\n",
-    "        f\"EXAMPLE_PROFILE must be one of: {', '.join(SUPPORTED_PROFILES)}\"\n",
-    "    )\n",
+    "    raise ValueError(f\"EXAMPLE_PROFILE must be one of: {', '.join(SUPPORTED_PROFILES)}\")\n",
     "\n",
     "IS_SERVER_PROFILE = EXAMPLE_PROFILE in SERVER_PROFILES\n",
     "IS_SINGLE_GPU_PROFILE = EXAMPLE_PROFILE in SINGLE_GPU_PROFILES\n",
@@ -175,9 +173,7 @@
     "\n",
     "if IS_SERVER_PROFILE:\n",
     "    if not NVIDIA_API_KEY:\n",
-    "        NVIDIA_API_KEY = getpass.getpass(\n",
-    "            \"🔑 NVIDIA_API_KEY (required for the server profile): \"\n",
-    "        ).strip()\n",
+    "        NVIDIA_API_KEY = getpass.getpass(\"🔑 NVIDIA_API_KEY (required for the server profile): \").strip()\n",
     "    if not NVIDIA_API_KEY:\n",
     "        raise RuntimeError(\n",
     "            \"NVIDIA_API_KEY is required for */server NIM services and the NGC login. \"\n",
@@ -186,16 +182,14 @@
     "\n",
     "if IS_SINGLE_GPU_PROFILE:\n",
     "    if not HF_TOKEN:\n",
-    "        HF_TOKEN = getpass.getpass(\n",
-    "            \"🤗 HF_TOKEN (required for the single-GPU profile): \"\n",
-    "        ).strip()\n",
+    "        HF_TOKEN = getpass.getpass(\"🤗 HF_TOKEN (required for the single-GPU profile): \").strip()\n",
     "    if not HF_TOKEN:\n",
     "        raise RuntimeError(\n",
     "            \"HF_TOKEN is required for */single-gpu model downloads. \"\n",
     "            \"Get a token at https://huggingface.co/settings/tokens\"\n",
     "        )\n",
     "\n",
-    "print(\"Credentials configured.\")\n"
+    "print(\"Credentials configured.\")"
    ]
   },
   {
@@ -422,7 +416,7 @@
     "\n",
     "# Pull and start (--quiet-pull suppresses per-layer download noise).\n",
     "run([*COMPOSE_PROGRESS, \"up\", \"-d\", \"--build\", \"--remove-orphans\", \"--quiet-pull\"], stream=True)\n",
-    "run([*COMPOSE, \"ps\"])\n"
+    "run([*COMPOSE, \"ps\"])"
    ]
   },
   {
@@ -509,7 +503,7 @@
     "        model_ids = [item.get(\"id\", \"<unknown>\") for item in models.get(\"data\", [])]\n",
     "        print(\"Loaded model(s): \" + \", \".join(model_ids or [\"<none reported>\"]))\n",
     "    except Exception as exc:\n",
-    "        print(f\"Model list unavailable (non-fatal): {exc}\")\n"
+    "        print(f\"Model list unavailable (non-fatal): {exc}\")"
    ]
   },
   {

--- a/src/examples/omni_assistant_subagents/prompts.yaml
+++ b/src/examples/omni_assistant_subagents/prompts.yaml
@@ -41,8 +41,10 @@ shared:
     label, but the text is too small to read') so the assistant knows there is something to read and can offer
     a high-resolution snapshot. Describe only non-text visuals (the object's kind, colors, and imagery).
   webcam_no_change_rule: >-
-    If nothing meaningful changed, set observation exactly to "No notable change." and do not repeat your previous
-    sentence; still return the complete JSON object with visual_control.
+    Always describe what is present in the newest frames. Use "No notable change." only when
+    those newest frames still match the last note, including the same objects still in view. An object leaving the
+    frame is a change — describe the new current state and do not keep naming the missing object. Never invent an
+    item (not a phone, bottle, screen, or anything else) just to fill the observation.
 
 omni_subagents_assistant:
   description: "Nemotron Omni voice assistant using one model for ASR and LLM."
@@ -127,7 +129,7 @@ agent_prompts:
         {{webcam_role_intro}}
         Reply with STRICT JSON only — one object, nothing else:
         {"observation": "<one short sentence>", "focus": "<short visible focus from the conversation, or empty>", "visual_control": {"intent": "none|greet|stop|continue|down", "confidence": 0.0, "reason": "<short>"}}
-        observation: in natural, professional language, say what the person is DOING and name the KIND of item they hold up or show (a phone, a screen, a document, an object). {{webcam_appearance_rule}} {{webcam_text_too_small_rule}} Interpret cues as behavior ('speaking', 'thinking', 'smiling'), never raw anatomy ('mouth open'); keep hand gestures OUT of the observation. {{webcam_no_change_rule}}
+        observation: one short sentence of what is happening NOW in the newest frames. Name a held object only if it is clearly visible there; otherwise just say what the person is doing and never mention an object as absent, missing, or not visible. {{webcam_appearance_rule}} {{webcam_text_too_small_rule}} Interpret cues as behavior ('speaking', 'thinking', 'smiling'), never raw anatomy ('mouth open'); keep hand gestures OUT of the observation. {{webcam_no_change_rule}}
         focus: when recent conversation steers attention to a visible subject, name that subject in a few words; otherwise "".
         visual_control.intent: score ONLY a clear, deliberate hand gesture occurring in the final roughly 1.5 seconds of the video. Earlier frames are historical context and MUST NOT produce an intent, even if they contain an unmistakable gesture. The gesture must still be visible or actively finishing in the newest frames; otherwise return 'none'. Judge the HANDS, not the face (a smile never changes the gesture):
         - greet: ONLY a hand that CLEARLY and REPEATEDLY moves side to side across the video (an unmistakable wave). A hand that is merely raised, reaching toward the camera or webcam, adjusting the device, scratching, resting, gesturing while talking, or holding something is NOT a wave — use 'none'.
@@ -139,9 +141,9 @@ agent_prompts:
     gesture_prompt:
       description: "Webcam per-frame user prompt requesting the strict-JSON gesture object."
       content: >-
-        Now — use the older part of this short video only as background, report the person's current state from its
-        newest frames, and score a hand gesture only if it occurs in the final roughly 1.5 seconds. Reply with the
-        strict JSON object only.
+        Now — report only the person's current state from the newest frames (an object that left those frames is
+        gone), and score a hand gesture only if it occurs in the final roughly 1.5 seconds. Reply with the strict
+        JSON object only.
 
   TransportAgent:
     proactive_greet:

--- a/src/examples/omni_assistant_subagents/subagents/transport/agent.py
+++ b/src/examples/omni_assistant_subagents/subagents/transport/agent.py
@@ -466,23 +466,27 @@ class OmniTransportAgent(PipelineWorker):
         return self._webcam_controller.current_visual_status()
 
     def _recent_conversation(self, max_turns: int = 6, max_chars: int = 600) -> str:
-        """Render the last few user/assistant turns as plain text for the webcam analyzer.
+        """Render the last few user turns as plain text for the webcam analyzer.
 
-        Only conversational turns are included, never the pinned board, so the webcam worker
-        learns the current topic without a feedback loop from its own past observations. Capped
-        in turns and characters to keep the continuous sub-second webcam loop fast.
+        Assistant replies are omitted so a spoken visual claim cannot lock the webcam
+        worker onto a stale object after it leaves the frame. Gesture directives are
+        injected as user turns, so they are skipped for the same reason. Capped in
+        turns and characters to keep the continuous webcam loop fast.
         """
+        directives = {text.strip() for text in self._proactive_directives.values() if text.strip()}
         turns: list[str] = []
         for message in self._context.get_messages():
             if not isinstance(message, dict):
                 continue
-            role = str(message.get("role") or "")
+            if str(message.get("role") or "") != "user":
+                continue
             content = message.get("content")
-            if role not in ("user", "assistant") or not isinstance(content, str):
+            if not isinstance(content, str):
                 continue
             text = content.strip()
-            if text:
-                turns.append(f"{'User' if role == 'user' else 'Assistant'}: {text}")
+            if not text or text in directives:
+                continue
+            turns.append(f"User: {text}")
         rendered = "\n".join(turns[-max_turns:]).strip()
         return rendered[-max_chars:] if len(rendered) > max_chars else rendered
 

--- a/src/examples/omni_assistant_subagents/subagents/transport/webcam_controller.py
+++ b/src/examples/omni_assistant_subagents/subagents/transport/webcam_controller.py
@@ -6,10 +6,10 @@
 This is the ``omni-video-stream`` style capability: while the browser webcam is
 on, frames are uploaded continuously and each fresh frame is sent to the
 ``WebcamAgent`` (reasoning-off, rolling visual memory) for a one-sentence
-description. There is no scene-change gate and no speech-conditioned gating: each fresh
-observation is streamed to the client UI and mirrored into the Speaker's pinned
-subagents board (its "live eyes"), updated in one place so the Speaker always
-knows what it currently sees.
+description of the newest moments. There is no speech-conditioned gating: each
+fresh observation is streamed to the client UI and mirrored into the Speaker's
+pinned subagents board (its "live eyes"), with the last note passed back so a
+disappeared object is not kept in the description.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ _CAMERA_OFF_STATE = "the camera is OFF right now — there is nothing visible li
 _CAMERA_ON_STATE = "the camera just turned on; the live view is loading"
 _NOOP_OBSERVATION = "no notable change"
 _STREAM_INTERVAL_MS = 800
-_WINDOW_SECONDS = 8.0
+_WINDOW_SECONDS = 2.0
 
 
 def _is_noop_observation(observation: str) -> bool:
@@ -143,7 +143,7 @@ class WebcamController:
         logger.info(f"Webcam video window set to {self._window_seconds}s")
 
     def _conversation_context(self) -> str:
-        """Recent conversation text for the webcam analyzer, or "" if unavailable."""
+        """Recent user-turn text for the webcam analyzer, or "" if unavailable."""
         if self._conversation_provider is None:
             return ""
         try:
@@ -151,6 +151,13 @@ class WebcamController:
         except Exception as exc:
             logger.debug(f"Webcam conversation context unavailable: {exc}")
             return ""
+
+    def _previous_observation(self) -> str:
+        """Last published scene note, or "" when the camera is off/loading."""
+        state = self._board_state.strip()
+        if not state or state in (_CAMERA_OFF_STATE, _CAMERA_ON_STATE):
+            return ""
+        return state
 
     def current_visual_status(self) -> str:
         """A fresh, per-turn line stating what the assistant can see right now.
@@ -255,6 +262,7 @@ class WebcamController:
                             "frame": frame.metadata(),
                             "window_seconds": self._window_seconds,
                             "conversation_context": self._conversation_context(),
+                            "previous_observation": self._previous_observation(),
                         },
                         timeout=60.0,
                     )

--- a/src/examples/omni_assistant_subagents/subagents/webcam/agent.py
+++ b/src/examples/omni_assistant_subagents/subagents/webcam/agent.py
@@ -48,38 +48,47 @@ SPEAKER_STATE_PREFIXES: tuple[str, ...] = (WEBCAM_CONTEXT_PREFIX, WEBCAM_FIRST_S
 
 _FFMPEG = imageio_ffmpeg.get_ffmpeg_exe()
 _SUMMARY_MAX_TOKENS = 128
-_WINDOW_SECONDS = 8.0
+_WINDOW_SECONDS = 2.0
 _MAX_FRAMES = 32
 _ENCODE_FPS = 2
 _TEMPERATURE = 0.2
 _FFMPEG_TIMEOUT_SECONDS = 15
 
 
-def _steering_preamble(conversation: str) -> str:
+def _steering_preamble(conversation: str, previous_observation: str = "") -> str:
     """Build the self-steering block prepended to the per-frame prompt.
 
-    The worker steers itself: by default it prioritizes the person's current activity —
-    what they are holding, showing, or doing — and, when a recent conversation is given,
-    it emphasizes whichever visible things and details that conversation is about. Both
-    are priorities, not strict filters, and neither changes the output format or the
-    gesture-scoring rules that follow.
+    Newest frames win. Conversation may point at a visible subject, but it cannot
+    keep a previous object in the note after that object has left the live view.
+    ``previous_observation`` is the last published note, treated as stale memory.
     """
     parts: list[str] = []
     if conversation:
         parts.append(
-            f"RECENT CONVERSATION (context only; the person cannot be heard in this silent video):\n{conversation}\n"
+            f"RECENT USER TURNS (context only; the person cannot be heard in this silent video):\n{conversation}\n"
+        )
+    previous = previous_observation.strip()
+    if previous:
+        parts.append(
+            f"LAST NOTE (stale unless still visible in the newest frames): {previous}\n"
+            "That note is memory, not current evidence. If an object, pose, or action from it is not clearly "
+            "visible in the final roughly 1.5 seconds, it is GONE — drop it silently and describe the new "
+            "current state instead. Never announce that it left, and never name it again.\n"
         )
     parts.append(
-        "TEMPORAL PRIORITY: this video is ordered oldest to newest. Treat its earlier portion only as background "
-        "for understanding how the scene reached its current state. The final roughly 1.5 seconds are the source of "
-        "truth for what is happening NOW. Lead with what the person is actively holding, showing, or doing in those "
-        "newest frames, and describe ALL items they are currently presenting or interacting with, not stale items that "
-        "disappeared earlier. Mention an earlier event only when it is necessary to explain the current action. "
-        "When the conversation above is about something visible, emphasize that; otherwise simply prioritize their "
-        "current activity. Report ONLY what is genuinely visible in this video: never state a detail the conversation "
-        "implies but the video does not actually show, and if a relevant detail is not visually clear, say so rather "
-        "than guessing. Still obey the output format, the rule against reading fine printed text, and the gesture "
-        "rules below exactly.\n"
+        "TEMPORAL PRIORITY: this video is ordered oldest to newest. Use the earlier portion only to judge "
+        "motion (gestures). The final roughly 1.5 seconds are the ONLY source of truth for the observation — "
+        "which objects are present, what the person is holding, and what they are doing NOW. Do not name an "
+        "object that left those newest frames. Lead with current activity there. Describe ONLY what is "
+        "present: never report anything as absent, missing, hidden, or not visible, so no 'hands not "
+        "visible', 'no object in view', or 'the bottle is gone'. When the person is simply sitting, talking, "
+        "or looking at the camera, that alone is the whole observation — never invent a phone, bottle, "
+        "screen, or other item to fill the sentence. When the user turns above are about something visible, "
+        "mention it ONLY if it is still visible in those newest frames; otherwise ignore that topic. Report "
+        "ONLY what is genuinely visible: never state a detail the conversation implies but the newest frames "
+        "do not show, and leave out any detail that is not visually clear rather than guessing at it. Still "
+        "obey the output format, the rule against reading fine printed text, and the gesture rules below "
+        "exactly.\n"
     )
     return "".join(parts)
 
@@ -144,6 +153,7 @@ class WebcamAgent(BaseWorker):
         frame_metadata = payload.get("frame") if isinstance(payload.get("frame"), dict) else {}
         session_id = str(payload.get("session_id") or "").strip()
         conversation_context = str(payload.get("conversation_context") or "").strip()
+        previous_observation = str(payload.get("previous_observation") or "").strip()
         try:
             window_seconds = float(payload.get("window_seconds") or self._window_seconds)
         except (TypeError, ValueError):
@@ -160,7 +170,11 @@ class WebcamAgent(BaseWorker):
                 mp4 = await asyncio.to_thread(self._encode_mp4, frames)
                 if mp4:
                     observation, visual_control, focus = await self._describe(
-                        mp4, len(frames), window_seconds, conversation_context
+                        mp4,
+                        len(frames),
+                        window_seconds,
+                        conversation_context,
+                        previous_observation,
                     )
             except Exception as exc:
                 logger.exception(f"Webcam video summary failed: {exc}")
@@ -212,14 +226,20 @@ class WebcamAgent(BaseWorker):
             return out.read_bytes()
 
     async def _describe(
-        self, mp4: bytes, n_frames: int, window_seconds: float, conversation: str = ""
+        self,
+        mp4: bytes,
+        n_frames: int,
+        window_seconds: float,
+        conversation: str = "",
+        previous_observation: str = "",
     ) -> tuple[str, dict[str, Any], str]:
         """Describe the recent-window video and score gestures.
 
-        The recent ``conversation`` is prepended so the worker self-steers onto the
-        details that matter now while defaulting to the person's current activity.
+        Newest frames are the observation source. ``conversation`` may point at a
+        visible subject; ``previous_observation`` is stale unless those frames
+        still show it.
         """
-        steering = _steering_preamble(conversation)
+        steering = _steering_preamble(conversation, previous_observation)
         prompt = f"{steering}\n{self._prompt}" if steering else self._prompt
         content = [video_message_part(mp4), text_message_part(prompt)]
         context = LLMContext(
@@ -231,7 +251,7 @@ class WebcamAgent(BaseWorker):
         logger.debug(
             f"Webcam video Omni request: base_url={self._base_url}, model={self._model_id}, "
             f"mp4_bytes={len(mp4)}, frames={n_frames}, window_s={window_seconds}, "
-            f"conversation_chars={len(conversation)}"
+            f"conversation_chars={len(conversation)}, previous_chars={len(previous_observation)}"
         )
         result = await self._omni.run_multimodal_inference(
             context,

--- a/src/examples_registry.py
+++ b/src/examples_registry.py
@@ -232,9 +232,7 @@ def _load_service_catalogs(example_dir: str) -> tuple[dict[str, dict], dict[str,
     """Load cloud and local service catalogs for one example directory."""
     base = Path(example_dir)
     cloud = (
-        _normalize_service_catalog(_load_yaml_mapping(base / "services.cloud.yaml"))
-        if nvidia_cloud_available()
-        else {}
+        _normalize_service_catalog(_load_yaml_mapping(base / "services.cloud.yaml")) if nvidia_cloud_available() else {}
     )
     local = _load_local_service_catalog(base)
     return cloud, local

--- a/tests/unit/test_service_catalog.py
+++ b/tests/unit/test_service_catalog.py
@@ -363,9 +363,9 @@ llm:
         with (
             patch.dict(os.environ, {"NVIDIA_API_KEY": ""}),
             patch("examples_registry._load_service_catalogs", return_value=({}, {})),
+            self.assertRaisesRegex(RuntimeError, "NVIDIA_API_KEY"),
         ):
-            with self.assertRaisesRegex(RuntimeError, "NVIDIA_API_KEY"):
-                examples_registry._resolve_service_default(example, "asr", "cloud-only")
+            examples_registry._resolve_service_default(example, "asr", "cloud-only")
 
     def test_registry_defaults_use_cloud_multilingual_when_local_only_default_is_unreachable(self) -> None:
         example = examples_registry._lookup_by_key("multilingual-assistant")

--- a/tests/unit/test_webcam_steering.py
+++ b/tests/unit/test_webcam_steering.py
@@ -5,9 +5,11 @@
 
 import asyncio
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 from examples.omni_assistant.nvidia_omni_multimodal_service import NvidiaOmniInferenceResult
+from examples.omni_assistant_subagents.subagents.transport.agent import OmniTransportAgent
 from examples.omni_assistant_subagents.subagents.transport.webcam_controller import WebcamController
 from examples.omni_assistant_subagents.subagents.webcam.agent import WebcamAgent, _steering_preamble
 from webcam_frame_store import clear_session_webcam_frames, recent_webcam_frames, store_webcam_frame
@@ -67,22 +69,71 @@ class WebcamStateTests(unittest.IsolatedAsyncioTestCase):
         controller._start_continuous_uploads.assert_awaited_once()
 
 
-class SteeringPreambleTests(unittest.TestCase):
-    def test_defaults_to_user_activity_priority_without_conversation(self) -> None:
-        block = _steering_preamble("")
-        self.assertNotIn("RECENT CONVERSATION", block)
-        self.assertIn("actively holding, showing, or doing", block)
-        self.assertIn("describe ALL items", block)
-        self.assertIn("ONLY what is genuinely visible", block)
-        self.assertIn("final roughly 1.5 seconds", block)
-        self.assertIn("earlier portion only as background", block)
+class PreviousObservationTests(unittest.TestCase):
+    def test_empty_when_camera_is_off_or_loading(self) -> None:
+        controller = _controller(lambda: "")
+        self.assertEqual(controller._previous_observation(), "")
+        controller._board_state = "the camera just turned on; the live view is loading"
+        self.assertEqual(controller._previous_observation(), "")
 
-    def test_conversation_is_included_and_grounded(self) -> None:
-        block = _steering_preamble("User: what am I holding?\nAssistant: a camera")
-        self.assertIn("RECENT CONVERSATION", block)
+    def test_returns_last_published_scene_note(self) -> None:
+        controller = _controller(lambda: "")
+        controller._board_state = "The person holds up a white bottle with a purple label."
+        self.assertEqual(
+            controller._previous_observation(),
+            "The person holds up a white bottle with a purple label.",
+        )
+
+
+class SteeringPreambleTests(unittest.TestCase):
+    def test_defaults_to_newest_frames_without_conversation(self) -> None:
+        block = _steering_preamble("")
+        self.assertNotIn("RECENT USER TURNS", block)
+        self.assertNotIn("LAST NOTE", block)
+        self.assertIn("ONLY source of truth for the observation", block)
+        self.assertIn("Do not name an object that left those newest frames", block)
+        self.assertIn("never invent a phone, bottle", block)
+        self.assertIn("final roughly 1.5 seconds", block)
+
+    def test_absent_things_are_never_narrated(self) -> None:
+        block = _steering_preamble("")
+        self.assertIn("never report anything as absent, missing, hidden, or not visible", block)
+        self.assertIn("hands not visible", block)
+        self.assertNotIn("Empty hands", block)
+
+    def test_user_turns_are_included_and_grounded(self) -> None:
+        block = _steering_preamble("User: what am I holding?")
+        self.assertIn("RECENT USER TURNS", block)
         self.assertIn("what am I holding", block)
-        self.assertIn("actively holding, showing, or doing", block)
-        self.assertIn("ONLY what is genuinely visible", block)
+        self.assertIn("ONLY if it is still visible", block)
+        self.assertNotIn("RECENT CONVERSATION", block)
+
+    def test_previous_note_is_stale_unless_still_visible(self) -> None:
+        block = _steering_preamble("", "The person holds up a white bottle with a purple label.")
+        self.assertIn("LAST NOTE", block)
+        self.assertIn("white bottle", block)
+        self.assertIn("it is GONE", block)
+        self.assertIn("drop it silently", block)
+        self.assertIn("Never announce that it left", block)
+
+
+class RecentConversationTests(unittest.TestCase):
+    def test_omits_assistant_visual_claims_and_gesture_cues(self) -> None:
+        cue = "(Visual cue, no audio: the user just waved and greeted you on camera.)"
+        agent = object.__new__(OmniTransportAgent)
+        agent._proactive_directives = {"proactive_greet": cue}
+        agent._context = SimpleNamespace(
+            get_messages=lambda: [
+                {"role": "user", "content": "So can you tell me what I am holding right now?"},
+                {"role": "assistant", "content": "You are holding a white bottle with a purple label."},
+                {"role": "user", "content": cue},
+            ]
+        )
+        text = OmniTransportAgent._recent_conversation(agent)
+        self.assertIn("what I am holding", text)
+        self.assertNotIn("bottle", text)
+        self.assertNotIn("Visual cue", text)
+        self.assertNotIn("Assistant:", text)
 
 
 class WebcamOutputValidationTests(unittest.IsolatedAsyncioTestCase):
@@ -116,10 +167,36 @@ class WebcamOutputValidationTests(unittest.IsolatedAsyncioTestCase):
             text='{"observation":"holding a camera","focus":"camera","visual_control":{"intent":"none"}}'
         )
 
-        observation, _, focus = await worker._describe(b"mp4", 2, 8.0)
+        observation, _, focus = await worker._describe(b"mp4", 2, 2.0)
 
         self.assertEqual(observation, "holding a camera")
         self.assertEqual(focus, "camera")
+
+    async def test_previous_observation_is_steered_into_the_prompt(self) -> None:
+        worker = object.__new__(WebcamAgent)
+        worker._base_url = "http://localhost:8002/v1"
+        worker._model_id = "test-model"
+        worker._system_prompt = "Return JSON."
+        worker._prompt = "Describe the video."
+        worker._max_tokens = 128
+        worker._temperature = 0.2
+        worker._omni = AsyncMock()
+        worker._omni.run_multimodal_inference.return_value = NvidiaOmniInferenceResult(
+            text='{"observation":"empty hands","focus":"","visual_control":{"intent":"none"}}'
+        )
+
+        await worker._describe(
+            b"mp4",
+            2,
+            2.0,
+            previous_observation="The person holds up a white bottle with a purple label.",
+        )
+
+        context = worker._omni.run_multimodal_inference.await_args.args[0]
+        user_text = context.messages[1]["content"][1]["text"]
+        self.assertIn("LAST NOTE", user_text)
+        self.assertIn("white bottle", user_text)
+        self.assertIn("it is GONE", user_text)
 
     def test_non_finite_frame_window_does_not_raise(self) -> None:
         store_webcam_frame(


### PR DESCRIPTION
## Problem

The Omni Assistant Subagents webcam note lagged the live scene in three ways, all reported from live sessions:

- An object stayed in the summary long after it left the frame (a purple bottle persisted after being removed).
- The summary claimed the user was holding a smartphone when they were not.
- The assistant's own spoken visual guesses were fed back to the webcam worker as conversation context, so a wrong claim reinforced itself instead of being corrected by the next frame.

## Root cause

Three things compounded:

1. **The window was 8 seconds.** The worker analyzed a rolling 8s video, so an object removed 3 seconds ago was still plainly visible in most of the frames it was shown.
2. **Assistant turns were part of `conversation_context`.** `_recent_conversation` rendered both user and assistant turns. Once the Speaker said "you're holding a bottle", that sentence came back as steering context on every subsequent frame.
3. **The worker had no notion of a stale note.** It could not tell the difference between "this object is still here" and "this object was here a moment ago".

## Changes

- Narrow the analysis window from 8s to 2s, both the server default (`_WINDOW_SECONDS`) and the client default (`DEFAULT_CHUNK_SECONDS`). The UI chunk selector is unchanged, only its default moves.
- Pass the last published note back to the worker as explicitly stale memory (`previous_observation`). It is dropped unless still visible in the newest frames, and the worker is told to drop it silently rather than announcing that it left.
- Feed only user turns to the worker. Assistant replies and gesture directives (injected as user turns) are filtered out, so a spoken visual claim cannot reinforce itself.
- Describe only what is present. An earlier revision of this fix said "empty hands are a valid current state", which made hands a topic and produced a steady stream of "hands not visible" summaries. The rule is now presence-only: never report anything as absent, missing, or not visible, and never invent an item to fill the sentence.

`previous_observation` is sourced from the board state, which only ever holds non-noop observations and excludes the camera off/loading notes. So a `"No notable change."` reply does not wipe the note, and a camera toggle sends an empty note rather than a stale one. The existing epoch guard in `handle_summary_response` still drops jobs that cross a camera toggle.

## Also in this commit

Pre-existing `ruff check` and `ruff format` drift, unrelated to the webcam work but needed for lint to pass on this branch:

- `src/examples_registry.py` and `notebooks/brev_launchable.ipynb` — `ruff format` output.
- `tests/unit/test_service_catalog.py` — SIM117, merged a nested `with` into the existing parenthesized group.

No CHANGELOG entry, this is a behavior tune rather than a user-facing feature.

## Testing

- `uv run pytest tests/unit` — 425 passed, 22 subtests passed.
- `uv run ruff check` and `uv run ruff format --check` — clean.
- New unit coverage: the stale-note block is steered into the prompt, absences are never narrated, and `_recent_conversation` omits assistant visual claims and gesture directives.

Live retest of the original bottle-removal scenario is still worth doing before merge, since the core of this fix is model steering.

Fixes NVBugs 6682177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Webcam analysis now uses a shorter, 2-second video window for more recent visual context.
  - Webcam observations prioritize the newest frames and account for objects that have disappeared or are no longer clearly visible.
  - Previous observations are used to improve continuity between webcam updates.

- **Bug Fixes**
  - Reduced stale visual information and irrelevant conversation context in webcam analysis.
  - Improved handling of absent objects to avoid carrying outdated items into current descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->