### PR TITLE
fix: pin nltk to 3.10.3 for CVE-2026-78681

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ override-dependencies = [
     "uuid-utils>=0.16.0",
     "pillow>=12.3.0",
     "nvidia-riva-client>=2.27.0,<3",
+    "nltk>=3.10.3",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -15,6 +15,7 @@ overrides = [
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "idna", specifier = ">=3.15" },
     { name = "langchain-core", specifier = ">=1.4.1" },
+    { name = "nltk", specifier = ">=3.10.3" },
     { name = "nvidia-riva-client", specifier = ">=2.27.0,<3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "protobuf", specifier = ">=6.33.6" },
@@ -1486,7 +1487,7 @@ eval = [{ name = "pipecat-ai", extras = ["evals"], specifier = "==1.7.0" }]
 
 [[package]]
 name = "nltk"
-version = "3.10.0"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1495,9 +1496,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pin the transitive `nltk` dependency to 3.10.3 or later so Inspect/NVD no longer flags CVE-2026-78681 (XML entity-expansion DoS in versions before 3.10.3). `pipecat-ai==1.7.0` allows `nltk>=3.10.0,<4`; `uv.lock` had resolved 3.10.0.

## Changes

- Add `"nltk>=3.10.3"` to `[tool.uv] override-dependencies` in `pyproject.toml`, matching the existing CVE-pin pattern.
- Refresh `uv.lock` (`nltk` 3.10.0 → 3.10.3).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: dependency version pin only; no runtime or test behavior changed.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no user-facing behavior change.

## Documentation Writer Review

- [x] Documentation writer reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: CVE pin in `pyproject.toml` / `uv.lock` only; no user-facing docs.
- Agent: Cursor
<!-- docs-review-head-sha: cbff0eb -->
<!-- docs-review-agents-blob-sha: b73fe32 -->

## Verification

- [ ] Applicable lint, test, and build checks passed
- [ ] Documentation validation passed for changed documentation
- [x] No secrets, API keys, or credentials are committed

## Test plan

- [ ] Confirm `uv.lock` records `nltk` 3.10.3.
- [ ] Confirm `pyproject.toml` override-dependencies includes `nltk>=3.10.3`.
- [ ] Confirm Inspect/NVD no longer reports CVE-2026-78681 after rescan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to use NLTK version 3.10.3 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->